### PR TITLE
fix(shared): add channels subpath export

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./channels": {
+      "import": "./dist/channels/index.js",
+      "types": "./dist/channels/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
Adds missing ./channels subpath export to fix adapter-telegram imports.