### PR TITLE
feat(#20): Browser observation

### DIFF
--- a/deploy/docker/Dockerfile.playwright-sidecar
+++ b/deploy/docker/Dockerfile.playwright-sidecar
@@ -1,6 +1,7 @@
 # ==============================================================================
 # Playwright CDP Sidecar
 # Runs headless Chromium with Chrome DevTools Protocol on port 9222.
+# Optionally exposes a VNC stream via Xvfb + x11vnc + websockify (noVNC).
 # Used as a sidecar container in agent pods for browser automation.
 # ==============================================================================
 FROM mcr.microsoft.com/playwright:v1.52.0-noble
@@ -10,6 +11,14 @@ USER root
 # Remove unnecessary browsers — only Chromium is needed for CDP
 RUN rm -rf /ms-playwright/firefox-* /ms-playwright/webkit-*
 
+# Install VNC dependencies: Xvfb (virtual framebuffer), x11vnc, websockify (noVNC WS bridge)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      xvfb \
+      x11vnc \
+      python3-websockify \
+    && rm -rf /var/lib/apt/lists/*
+
 # Create non-root user matching pod security context (uid 1000)
 RUN groupadd -g 2000 playwright && \
     useradd -u 1000 -g 2000 -m -s /bin/sh playwright
@@ -17,12 +26,13 @@ RUN groupadd -g 2000 playwright && \
 # Workspace directory shared with core-agent via PVC
 RUN mkdir -p /workspace && chown 1000:2000 /workspace
 
-# Install a tiny entrypoint that launches Chromium with CDP
+# Install entrypoint that launches Xvfb + Chromium + VNC
 COPY deploy/docker/playwright-entrypoint.mjs /opt/entrypoint.mjs
 
 USER 1000
 
-EXPOSE 9222
+# 9222 = CDP, 5900 = VNC (raw), 6080 = websockify (noVNC WebSocket)
+EXPOSE 9222 5900 6080
 
 HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:9222/json/version').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"

--- a/deploy/docker/playwright-entrypoint.mjs
+++ b/deploy/docker/playwright-entrypoint.mjs
@@ -1,36 +1,143 @@
 /**
  * Playwright CDP Sidecar Entrypoint
  *
- * Launches headless Chromium via Playwright and exposes Chrome DevTools Protocol
- * on 0.0.0.0:9222. Handles SIGTERM for graceful pod shutdown.
+ * Launches Xvfb (virtual framebuffer) → Chromium (displayed on Xvfb) →
+ * x11vnc (VNC server) → websockify (WebSocket bridge for noVNC).
+ *
+ * Ports:
+ *   9222 — Chrome DevTools Protocol
+ *   5900 — Raw VNC (x11vnc)
+ *   6080 — WebSocket VNC via websockify (consumed by noVNC in the dashboard)
+ *
+ * Environment variables:
+ *   CDP_PORT          — CDP listen port (default 9222)
+ *   VNC_PORT          — Raw VNC port (default 5900)
+ *   WEBSOCKIFY_PORT   — websockify WS port (default 6080)
+ *   VNC_ENABLED       — Set to "false" to skip VNC entirely (default "true")
+ *   DISPLAY           — X11 display (default ":99")
+ *   SCREEN_WIDTH      — Virtual screen width (default 1280)
+ *   SCREEN_HEIGHT     — Virtual screen height (default 720)
+ *   SCREEN_DEPTH      — Virtual screen color depth (default 24)
  */
 import { chromium } from "playwright-core";
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
 
-const PORT = Number(process.env.CDP_PORT ?? 9222);
+const execFileAsync = promisify(execFile);
 
+const CDP_PORT = Number(process.env.CDP_PORT ?? 9222);
+const VNC_PORT = Number(process.env.VNC_PORT ?? 5900);
+const WEBSOCKIFY_PORT = Number(process.env.WEBSOCKIFY_PORT ?? 6080);
+const VNC_ENABLED = (process.env.VNC_ENABLED ?? "true") !== "false";
+const DISPLAY = process.env.DISPLAY || ":99";
+const SCREEN_WIDTH = Number(process.env.SCREEN_WIDTH ?? 1280);
+const SCREEN_HEIGHT = Number(process.env.SCREEN_HEIGHT ?? 720);
+const SCREEN_DEPTH = Number(process.env.SCREEN_DEPTH ?? 24);
+
+const children = [];
+
+function spawnTracked(cmd, args, opts = {}) {
+  const child = spawn(cmd, args, { stdio: "pipe", ...opts });
+  children.push(child);
+  child.stdout?.on("data", (d) => process.stdout.write(`[${cmd}] ${d}`));
+  child.stderr?.on("data", (d) => process.stderr.write(`[${cmd}] ${d}`));
+  child.on("error", (err) => console.error(`[${cmd}] spawn error:`, err.message));
+  return child;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Start Xvfb (virtual X11 display) if VNC is enabled
+// ---------------------------------------------------------------------------
+if (VNC_ENABLED) {
+  const screenSpec = `${SCREEN_WIDTH}x${SCREEN_HEIGHT}x${SCREEN_DEPTH}`;
+  const xvfb = spawnTracked("Xvfb", [DISPLAY, "-screen", "0", screenSpec, "-ac", "-nolisten", "tcp"]);
+
+  // Wait for Xvfb to be ready
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Xvfb did not start within 5s")), 5000);
+    const check = setInterval(async () => {
+      try {
+        await execFileAsync("xdpyinfo", ["-display", DISPLAY]);
+        clearInterval(check);
+        clearTimeout(timeout);
+        resolve();
+      } catch {
+        // not ready yet
+      }
+    }, 100);
+    xvfb.on("exit", (code) => {
+      clearInterval(check);
+      clearTimeout(timeout);
+      reject(new Error(`Xvfb exited with code ${code}`));
+    });
+  });
+
+  console.log(`Xvfb running on display ${DISPLAY} (${screenSpec})`);
+  process.env.DISPLAY = DISPLAY;
+}
+
+// ---------------------------------------------------------------------------
+// 2. Launch Chromium with CDP
+// ---------------------------------------------------------------------------
+const launchArgs = [
+  "--no-sandbox",
+  "--disable-setuid-sandbox",
+  "--disable-dev-shm-usage",
+  "--disable-gpu",
+  "--disable-extensions",
+  "--disable-background-networking",
+  "--disable-default-apps",
+  "--disable-sync",
+  "--disable-translate",
+  "--metrics-recording-only",
+  "--no-first-run",
+];
+
+// When VNC is enabled, run headed (non-headless) so the GUI renders to Xvfb
 const browser = await chromium.launchServer({
-  headless: true,
-  port: PORT,
+  headless: !VNC_ENABLED,
+  port: CDP_PORT,
   host: "0.0.0.0",
-  args: [
-    "--no-sandbox",
-    "--disable-setuid-sandbox",
-    "--disable-dev-shm-usage",
-    "--disable-gpu",
-    "--disable-extensions",
-    "--disable-background-networking",
-    "--disable-default-apps",
-    "--disable-sync",
-    "--disable-translate",
-    "--metrics-recording-only",
-    "--no-first-run",
-  ],
+  args: VNC_ENABLED
+    ? [...launchArgs, `--display=${DISPLAY}`, `--window-size=${SCREEN_WIDTH},${SCREEN_HEIGHT}`]
+    : launchArgs,
 });
 
 console.log(`CDP sidecar listening: ${browser.wsEndpoint()}`);
 
+// ---------------------------------------------------------------------------
+// 3. Start x11vnc + websockify if VNC is enabled
+// ---------------------------------------------------------------------------
+if (VNC_ENABLED) {
+  // x11vnc: capture the Xvfb framebuffer on VNC_PORT
+  spawnTracked("x11vnc", [
+    "-display", DISPLAY,
+    "-rfbport", String(VNC_PORT),
+    "-shared",
+    "-forever",
+    "-nopw",
+    "-noxdamage",
+    "-wait", "5",
+    "-defer", "5",
+  ]);
+
+  // websockify: bridge VNC_PORT → WebSocket on WEBSOCKIFY_PORT (for noVNC)
+  spawnTracked("websockify", [
+    String(WEBSOCKIFY_PORT),
+    `localhost:${VNC_PORT}`,
+  ]);
+
+  console.log(`VNC server on :${VNC_PORT}, websockify on :${WEBSOCKIFY_PORT}`);
+}
+
+// ---------------------------------------------------------------------------
+// Graceful shutdown
+// ---------------------------------------------------------------------------
 const shutdown = async () => {
   console.log("Shutting down CDP sidecar...");
+  for (const child of children) {
+    child.kill("SIGTERM");
+  }
   await browser.close();
   process.exit(0);
 };

--- a/deploy/k8s/agent/base/pod-template.yaml
+++ b/deploy/k8s/agent/base/pod-template.yaml
@@ -113,7 +113,16 @@ template:
           - name: cdp
             containerPort: 9222
             protocol: TCP
+          - name: vnc
+            containerPort: 5900
+            protocol: TCP
+          - name: websockify
+            containerPort: 6080
+            protocol: TCP
         command: ["node", "/opt/entrypoint.mjs"]
+        env:
+          - name: VNC_ENABLED
+            value: "true"
         resources:
           requests:
             cpu: 500m

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -29,11 +29,13 @@
     "graphile-worker": "^0.16.0",
     "kysely": "^0.27.0",
     "pg": "^8.13.0",
-    "pino": "^9.6.0"
+    "pino": "^9.6.0",
+    "ws": "^8.19.0"
   },
   "devDependencies": {
     "@cortex/config": "workspace:*",
     "@types/pg": "^8.11.0",
+    "@types/ws": "^8.18.1",
     "embedded-postgres": "18.2.0-beta.16",
     "pino-pretty": "^13.0.0",
     "tsx": "^4.19.0",

--- a/packages/control-plane/src/__tests__/observation-routes.test.ts
+++ b/packages/control-plane/src/__tests__/observation-routes.test.ts
@@ -1,0 +1,712 @@
+import Fastify from "fastify"
+import fastifyWebSocket from "@fastify/websocket"
+import type { Runner } from "graphile-worker"
+import type { Kysely } from "kysely"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { Database } from "../db/types.js"
+import type { AgentLifecycleManager } from "../lifecycle/manager.js"
+import type { AgentLifecycleState } from "../lifecycle/state-machine.js"
+import { BrowserObservationService } from "../observation/service.js"
+import { observationRoutes } from "../routes/observation.js"
+import { healthRoutes } from "../routes/health.js"
+import { SSEConnectionManager } from "../streaming/manager.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockDb(sessionRow?: Record<string, unknown> | null) {
+  const executeTakeFirst = vi.fn().mockResolvedValue(sessionRow ?? null)
+  const whereSecond = vi.fn().mockReturnValue({ executeTakeFirst })
+  const whereFirst = vi.fn().mockReturnValue({ where: whereSecond })
+  const selectFn = vi.fn().mockReturnValue({ where: whereFirst })
+  const selectFromFn = vi.fn().mockImplementation((table: string) => {
+    if (table === "session") {
+      return { select: selectFn }
+    }
+    return {
+      select: vi.fn().mockReturnValue({
+        limit: vi.fn().mockReturnValue({
+          execute: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    }
+  })
+
+  return { selectFrom: selectFromFn } as unknown as Kysely<Database>
+}
+
+function mockLifecycleManager(
+  overrides: {
+    getAgentState?: (agentId: string) => AgentLifecycleState | undefined
+    steer?: (msg: unknown) => void
+  } = {},
+): AgentLifecycleManager {
+  return {
+    getAgentState: overrides.getAgentState ?? (() => "EXECUTING"),
+    getAgentContext: vi.fn(),
+    steer: overrides.steer ?? vi.fn(),
+  } as unknown as AgentLifecycleManager
+}
+
+function mockObservationService(
+  overrides: Partial<Record<keyof BrowserObservationService, unknown>> = {},
+): BrowserObservationService {
+  return {
+    getStreamStatus: vi.fn().mockResolvedValue({
+      agentId: "agent-1",
+      quality: "degraded",
+      fps: 0,
+      lastFrameAt: null,
+      vncEndpoint: null,
+    }),
+    getVncEndpoint: vi.fn().mockResolvedValue(null),
+    proxyVncWebSocket: vi.fn(),
+    captureScreenshot: vi.fn().mockResolvedValue({
+      agentId: "agent-1",
+      data: "base64data",
+      format: "jpeg",
+      width: 1280,
+      height: 720,
+      timestamp: "2026-01-01T00:00:00.000Z",
+      url: "https://example.com",
+      title: "Example Page",
+    }),
+    listTabs: vi.fn().mockResolvedValue({
+      agentId: "agent-1",
+      tabs: [
+        { index: 0, url: "https://example.com", title: "Example", active: true },
+        { index: 1, url: "https://other.com", title: "Other", active: false },
+      ],
+      timestamp: "2026-01-01T00:00:00.000Z",
+    }),
+    getTraceState: vi.fn().mockReturnValue({
+      agentId: "agent-1",
+      status: "idle",
+      startedAt: null,
+      options: null,
+    }),
+    startTrace: vi.fn().mockResolvedValue({
+      agentId: "agent-1",
+      status: "recording",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      options: { snapshots: true, screenshots: true, network: true, console: true },
+    }),
+    stopTrace: vi.fn().mockResolvedValue({
+      agentId: "agent-1",
+      filePath: "/workspace/traces/trace-agent-1-123.json",
+      sizeBytes: 4096,
+      durationMs: 5000,
+      timestamp: "2026-01-01T00:00:05.000Z",
+    }),
+    forwardAnnotation: vi.fn().mockResolvedValue({
+      agentId: "agent-1",
+      annotationId: "annot-123",
+      forwarded: true,
+      timestamp: "2026-01-01T00:00:00.000Z",
+    }),
+    onAnnotation: vi.fn().mockReturnValue(() => {}),
+    cleanup: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as BrowserObservationService
+}
+
+const VALID_SESSION = {
+  id: "session-123",
+  agent_id: "agent-1",
+  user_account_id: "user-1",
+  status: "active",
+}
+
+const AUTH_HEADER = { authorization: "Bearer session-123" }
+
+const AUTH_HEADERS = {
+  ...AUTH_HEADER,
+  "content-type": "application/json",
+}
+
+async function buildTestApp(options: {
+  session?: Record<string, unknown> | null
+  lifecycleManager?: AgentLifecycleManager
+  observationService?: BrowserObservationService
+}) {
+  const app = Fastify({ logger: false })
+  const db = mockDb("session" in options ? options.session : VALID_SESSION)
+  const sseManager = new SSEConnectionManager({ heartbeatIntervalMs: 60_000 })
+  const lifecycle = options.lifecycleManager ?? mockLifecycleManager()
+  const observation = options.observationService ?? mockObservationService()
+
+  app.decorate("worker", {} as Runner)
+  app.decorate("db", db)
+
+  await app.register(fastifyWebSocket)
+  await app.register(healthRoutes)
+  await app.register(
+    observationRoutes({
+      sseManager,
+      lifecycleManager: lifecycle,
+      observationService: observation,
+    }),
+  )
+
+  return { app, sseManager, lifecycle, observation, db }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Authentication (shared across all observation endpoints)
+// ---------------------------------------------------------------------------
+
+describe("observation route authentication", () => {
+  it("returns 401 without Authorization header", async () => {
+    const { app } = await buildTestApp({})
+    const res = await app.inject({
+      method: "GET",
+      url: "/agents/agent-1/observe/stream-status",
+    })
+    expect(res.statusCode).toBe(401)
+    expect(res.json().error).toBe("unauthorized")
+  })
+
+  it("returns 401 with invalid session", async () => {
+    const { app } = await buildTestApp({ session: null })
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/screenshot",
+      headers: AUTH_HEADERS,
+      payload: {},
+    })
+    expect(res.statusCode).toBe(401)
+  })
+
+  it("returns 403 when session agent_id does not match", async () => {
+    const { app } = await buildTestApp({
+      session: { ...VALID_SESSION, agent_id: "different-agent" },
+    })
+    const res = await app.inject({
+      method: "GET",
+      url: "/agents/agent-1/observe/tabs",
+      headers: AUTH_HEADERS,
+    })
+    expect(res.statusCode).toBe(403)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: GET /agents/:agentId/observe/stream-status
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/:agentId/observe/stream-status", () => {
+  it("returns stream status for a live agent", async () => {
+    const { app } = await buildTestApp({})
+    const res = await app.inject({
+      method: "GET",
+      url: "/agents/agent-1/observe/stream-status",
+      headers: AUTH_HEADERS,
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.agentId).toBe("agent-1")
+    expect(body.quality).toBeDefined()
+  })
+
+  it("returns 404 when agent is not found", async () => {
+    const lifecycle = mockLifecycleManager({ getAgentState: () => undefined })
+    const { app } = await buildTestApp({ lifecycleManager: lifecycle })
+    const res = await app.inject({
+      method: "GET",
+      url: "/agents/agent-1/observe/stream-status",
+      headers: AUTH_HEADERS,
+    })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it("returns 410 when agent is terminated", async () => {
+    const lifecycle = mockLifecycleManager({ getAgentState: () => "TERMINATED" })
+    const { app } = await buildTestApp({ lifecycleManager: lifecycle })
+    const res = await app.inject({
+      method: "GET",
+      url: "/agents/agent-1/observe/stream-status",
+      headers: AUTH_HEADERS,
+    })
+    expect(res.statusCode).toBe(410)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/observe/screenshot
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/observe/screenshot", () => {
+  it("returns screenshot result on success", async () => {
+    const { app, observation } = await buildTestApp({})
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/screenshot",
+      headers: AUTH_HEADERS,
+      payload: { format: "jpeg", quality: 80 },
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.agentId).toBe("agent-1")
+    expect(body.data).toBe("base64data")
+    expect(body.format).toBe("jpeg")
+    expect(observation.captureScreenshot).toHaveBeenCalledWith("agent-1", {
+      format: "jpeg",
+      quality: 80,
+    })
+  })
+
+  it("returns 502 when screenshot capture fails", async () => {
+    const observation = mockObservationService({
+      captureScreenshot: vi.fn().mockRejectedValue(new Error("CDP connection refused")),
+    })
+    const { app } = await buildTestApp({ observationService: observation })
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/screenshot",
+      headers: AUTH_HEADERS,
+      payload: {},
+    })
+    expect(res.statusCode).toBe(502)
+    expect(res.json().error).toBe("upstream_error")
+  })
+
+  it("returns 404 when agent is not found", async () => {
+    const lifecycle = mockLifecycleManager({ getAgentState: () => undefined })
+    const { app } = await buildTestApp({ lifecycleManager: lifecycle })
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/screenshot",
+      headers: AUTH_HEADERS,
+      payload: {},
+    })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it("broadcasts browser:screenshot event via SSE", async () => {
+    const { app, sseManager } = await buildTestApp({})
+    const broadcastSpy = vi.spyOn(sseManager, "broadcast")
+
+    await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/screenshot",
+      headers: AUTH_HEADERS,
+      payload: {},
+    })
+
+    expect(broadcastSpy).toHaveBeenCalledWith(
+      "agent-1",
+      "browser:screenshot",
+      expect.objectContaining({ agentId: "agent-1" }),
+    )
+    broadcastSpy.mockRestore()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: GET /agents/:agentId/observe/tabs
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/:agentId/observe/tabs", () => {
+  it("returns tab list on success", async () => {
+    const { app } = await buildTestApp({})
+    const res = await app.inject({
+      method: "GET",
+      url: "/agents/agent-1/observe/tabs",
+      headers: AUTH_HEADERS,
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.agentId).toBe("agent-1")
+    expect(body.tabs).toHaveLength(2)
+    expect(body.tabs[0].active).toBe(true)
+    expect(body.tabs[1].url).toBe("https://other.com")
+  })
+
+  it("returns 502 when tab listing fails", async () => {
+    const observation = mockObservationService({
+      listTabs: vi.fn().mockRejectedValue(new Error("No browser page found")),
+    })
+    const { app } = await buildTestApp({ observationService: observation })
+    const res = await app.inject({
+      method: "GET",
+      url: "/agents/agent-1/observe/tabs",
+      headers: AUTH_HEADERS,
+    })
+    expect(res.statusCode).toBe(502)
+  })
+
+  it("returns 404 when agent is not found", async () => {
+    const lifecycle = mockLifecycleManager({ getAgentState: () => undefined })
+    const { app } = await buildTestApp({ lifecycleManager: lifecycle })
+    const res = await app.inject({
+      method: "GET",
+      url: "/agents/agent-1/observe/tabs",
+      headers: AUTH_HEADERS,
+    })
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: GET /agents/:agentId/observe/trace
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/:agentId/observe/trace", () => {
+  it("returns trace state", async () => {
+    const { app } = await buildTestApp({})
+    const res = await app.inject({
+      method: "GET",
+      url: "/agents/agent-1/observe/trace",
+      headers: AUTH_HEADERS,
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.agentId).toBe("agent-1")
+    expect(body.status).toBe("idle")
+  })
+
+  it("returns 404 when agent is not found", async () => {
+    const lifecycle = mockLifecycleManager({ getAgentState: () => undefined })
+    const { app } = await buildTestApp({ lifecycleManager: lifecycle })
+    const res = await app.inject({
+      method: "GET",
+      url: "/agents/agent-1/observe/trace",
+      headers: AUTH_HEADERS,
+    })
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/observe/trace/start
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/observe/trace/start", () => {
+  it("starts trace recording and returns 202", async () => {
+    const { app, observation } = await buildTestApp({})
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/trace/start",
+      headers: AUTH_HEADERS,
+      payload: { snapshots: true, network: true },
+    })
+    expect(res.statusCode).toBe(202)
+    const body = res.json()
+    expect(body.status).toBe("recording")
+    expect(observation.startTrace).toHaveBeenCalledWith("agent-1", {
+      snapshots: true,
+      network: true,
+    })
+  })
+
+  it("returns 409 when trace is already recording", async () => {
+    const observation = mockObservationService({
+      startTrace: vi.fn().mockRejectedValue(new Error("Trace recording already in progress for agent agent-1")),
+    })
+    const { app } = await buildTestApp({ observationService: observation })
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/trace/start",
+      headers: AUTH_HEADERS,
+      payload: {},
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.json().error).toBe("conflict")
+  })
+
+  it("broadcasts browser:trace:state event via SSE", async () => {
+    const { app, sseManager } = await buildTestApp({})
+    const broadcastSpy = vi.spyOn(sseManager, "broadcast")
+
+    await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/trace/start",
+      headers: AUTH_HEADERS,
+      payload: {},
+    })
+
+    expect(broadcastSpy).toHaveBeenCalledWith(
+      "agent-1",
+      "browser:trace:state",
+      expect.objectContaining({ agentId: "agent-1", status: "recording" }),
+    )
+    broadcastSpy.mockRestore()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/observe/trace/stop
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/observe/trace/stop", () => {
+  it("stops trace recording and returns download info", async () => {
+    const { app, observation } = await buildTestApp({})
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/trace/stop",
+      headers: AUTH_HEADER,
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.agentId).toBe("agent-1")
+    expect(body.filePath).toContain("trace-agent-1")
+    expect(body.sizeBytes).toBe(4096)
+    expect(observation.stopTrace).toHaveBeenCalledWith("agent-1")
+  })
+
+  it("returns 409 when no active trace recording", async () => {
+    const observation = mockObservationService({
+      stopTrace: vi.fn().mockRejectedValue(new Error("No active trace recording for agent agent-1")),
+    })
+    const { app } = await buildTestApp({ observationService: observation })
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/trace/stop",
+      headers: AUTH_HEADER,
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.json().error).toBe("conflict")
+  })
+
+  it("broadcasts browser:trace:state idle event via SSE", async () => {
+    const { app, sseManager } = await buildTestApp({})
+    const broadcastSpy = vi.spyOn(sseManager, "broadcast")
+
+    await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/trace/stop",
+      headers: AUTH_HEADER,
+    })
+
+    expect(broadcastSpy).toHaveBeenCalledWith(
+      "agent-1",
+      "browser:trace:state",
+      expect.objectContaining({ agentId: "agent-1", status: "idle" }),
+    )
+    broadcastSpy.mockRestore()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/observe/annotate
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/observe/annotate", () => {
+  it("forwards annotation and returns 202", async () => {
+    const steerFn = vi.fn()
+    const lifecycle = mockLifecycleManager({
+      getAgentState: () => "EXECUTING",
+      steer: steerFn,
+    })
+    const { app, observation } = await buildTestApp({ lifecycleManager: lifecycle })
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/annotate",
+      headers: AUTH_HEADERS,
+      payload: { type: "click", x: 100, y: 200 },
+    })
+    expect(res.statusCode).toBe(202)
+    const body = res.json()
+    expect(body.agentId).toBe("agent-1")
+    expect(body.annotationId).toBeDefined()
+    expect(body.forwarded).toBe(true)
+
+    expect(observation.forwardAnnotation).toHaveBeenCalledWith(
+      "agent-1",
+      expect.objectContaining({ type: "click", x: 100, y: 200 }),
+    )
+  })
+
+  it("generates coordinate-based prompt when no prompt provided", async () => {
+    const steerFn = vi.fn()
+    const lifecycle = mockLifecycleManager({
+      getAgentState: () => "EXECUTING",
+      steer: steerFn,
+    })
+    const { app } = await buildTestApp({ lifecycleManager: lifecycle })
+
+    await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/annotate",
+      headers: AUTH_HEADERS,
+      payload: { type: "click", x: 100, y: 200, selector: "#btn" },
+    })
+
+    expect(steerFn).toHaveBeenCalledTimes(1)
+    const msg = steerFn.mock.calls[0]![0]
+    expect(msg.message).toContain("[ANNOTATION]")
+    expect(msg.message).toContain("(100, 200)")
+    expect(msg.message).toContain("#btn")
+  })
+
+  it("uses custom prompt when provided", async () => {
+    const steerFn = vi.fn()
+    const lifecycle = mockLifecycleManager({
+      getAgentState: () => "EXECUTING",
+      steer: steerFn,
+    })
+    const { app } = await buildTestApp({ lifecycleManager: lifecycle })
+
+    await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/annotate",
+      headers: AUTH_HEADERS,
+      payload: { type: "click", x: 100, y: 200, prompt: "Click the submit button" },
+    })
+
+    const msg = steerFn.mock.calls[0]![0]
+    expect(msg.message).toContain("[ANNOTATION] Click the submit button")
+  })
+
+  it("returns 409 when agent is not EXECUTING", async () => {
+    const lifecycle = mockLifecycleManager({ getAgentState: () => "READY" })
+    const { app } = await buildTestApp({ lifecycleManager: lifecycle })
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/annotate",
+      headers: AUTH_HEADERS,
+      payload: { type: "click", x: 100, y: 200 },
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.json().error).toBe("conflict")
+  })
+
+  it("validates required fields", async () => {
+    const { app } = await buildTestApp({})
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/annotate",
+      headers: AUTH_HEADERS,
+      payload: { type: "click" }, // missing x, y
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it("broadcasts browser:annotation:ack event via SSE", async () => {
+    const steerFn = vi.fn()
+    const lifecycle = mockLifecycleManager({
+      getAgentState: () => "EXECUTING",
+      steer: steerFn,
+    })
+    const { app, sseManager } = await buildTestApp({ lifecycleManager: lifecycle })
+    const broadcastSpy = vi.spyOn(sseManager, "broadcast")
+
+    await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/observe/annotate",
+      headers: AUTH_HEADERS,
+      payload: { type: "click", x: 100, y: 200 },
+    })
+
+    expect(broadcastSpy).toHaveBeenCalledWith(
+      "agent-1",
+      "browser:annotation:ack",
+      expect.objectContaining({
+        agentId: "agent-1",
+        annotationId: "annot-123",
+      }),
+    )
+    broadcastSpy.mockRestore()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: BrowserObservationService unit tests
+// ---------------------------------------------------------------------------
+
+describe("BrowserObservationService", () => {
+  let service: BrowserObservationService
+
+  beforeEach(() => {
+    service = new BrowserObservationService({
+      cdpHost: "127.0.0.1",
+      cdpPort: 9222,
+      websockifyPort: 6080,
+      vncPort: 5900,
+    })
+  })
+
+  afterEach(async () => {
+    await service.shutdown()
+  })
+
+  describe("getTraceState", () => {
+    it("returns idle state for new agent", () => {
+      const state = service.getTraceState("agent-new")
+      expect(state.agentId).toBe("agent-new")
+      expect(state.status).toBe("idle")
+      expect(state.startedAt).toBeNull()
+      expect(state.options).toBeNull()
+    })
+  })
+
+  describe("forwardAnnotation", () => {
+    it("returns result with no listeners", async () => {
+      const result = await service.forwardAnnotation("agent-1", {
+        type: "click",
+        x: 100,
+        y: 200,
+      })
+      expect(result.agentId).toBe("agent-1")
+      expect(result.annotationId).toBeDefined()
+      expect(result.forwarded).toBe(false)
+    })
+
+    it("notifies registered listeners", async () => {
+      const listener = vi.fn()
+      service.onAnnotation("agent-1", listener)
+
+      await service.forwardAnnotation("agent-1", {
+        type: "click",
+        x: 100,
+        y: 200,
+        prompt: "test",
+      })
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "click", x: 100, y: 200, prompt: "test" }),
+      )
+    })
+
+    it("returns forwarded=true when listeners exist", async () => {
+      service.onAnnotation("agent-1", vi.fn())
+
+      const result = await service.forwardAnnotation("agent-1", {
+        type: "click",
+        x: 10,
+        y: 20,
+      })
+      expect(result.forwarded).toBe(true)
+    })
+
+    it("unsubscribes listener on dispose", async () => {
+      const listener = vi.fn()
+      const dispose = service.onAnnotation("agent-1", listener)
+      dispose()
+
+      const result = await service.forwardAnnotation("agent-1", {
+        type: "click",
+        x: 10,
+        y: 20,
+      })
+      expect(listener).not.toHaveBeenCalled()
+      expect(result.forwarded).toBe(false)
+    })
+  })
+
+  describe("cleanup", () => {
+    it("removes agent state", async () => {
+      // Create some state
+      service.getTraceState("agent-cleanup")
+      await service.cleanup("agent-cleanup")
+
+      // State should be fresh now (re-created on access)
+      const state = service.getTraceState("agent-cleanup")
+      expect(state.status).toBe("idle")
+    })
+  })
+})

--- a/packages/control-plane/src/k8s/agent-deployer.ts
+++ b/packages/control-plane/src/k8s/agent-deployer.ts
@@ -79,7 +79,12 @@ function buildPod(config: AgentDeploymentConfig): k8s.V1Pod {
       name: "playwright",
       image: "noncelogic/cortex-playwright-sidecar:latest",
       command: ["node", "/opt/entrypoint.mjs"],
-      ports: [{ containerPort: 9222, name: "cdp", protocol: "TCP" }],
+      ports: [
+        { containerPort: 9222, name: "cdp", protocol: "TCP" },
+        { containerPort: 5900, name: "vnc", protocol: "TCP" },
+        { containerPort: 6080, name: "websockify", protocol: "TCP" },
+      ],
+      env: [{ name: "VNC_ENABLED", value: "true" }],
       resources: {
         requests: { cpu: "500m", memory: "512Mi" },
         limits: { cpu: "2000m", memory: "2Gi" },

--- a/packages/control-plane/src/observation/index.ts
+++ b/packages/control-plane/src/observation/index.ts
@@ -1,0 +1,18 @@
+export { BrowserObservationService } from "./service.js"
+export type {
+  AnnotationEvent,
+  AnnotationResult,
+  BrowserObservationEventType,
+  ObservationServiceConfig,
+  ScreenshotRequest,
+  ScreenshotResult,
+  StreamQuality,
+  StreamStatus,
+  TabInfo,
+  TabListResult,
+  TraceDownloadResult,
+  TraceRecordingOptions,
+  TraceState,
+  TraceStatus,
+  VncEndpointInfo,
+} from "./types.js"

--- a/packages/control-plane/src/observation/service.ts
+++ b/packages/control-plane/src/observation/service.ts
@@ -1,0 +1,624 @@
+/**
+ * Browser Observation Service
+ *
+ * Manages live VNC streaming, screenshot capture (degraded mode),
+ * Playwright trace recording, multi-tab queries, and annotation
+ * forwarding for a given agent's Playwright sidecar.
+ *
+ * The control plane proxies or wraps the sidecar's capabilities;
+ * it does not run Playwright directly — it talks to the sidecar
+ * via CDP (Chrome DevTools Protocol) and VNC endpoints.
+ */
+
+import { randomUUID } from "node:crypto"
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
+import { WebSocket } from "ws"
+
+import type {
+  AnnotationEvent,
+  AnnotationResult,
+  ObservationServiceConfig,
+  ScreenshotRequest,
+  ScreenshotResult,
+  StreamQuality,
+  StreamStatus,
+  TabInfo,
+  TabListResult,
+  TraceDownloadResult,
+  TraceRecordingOptions,
+  TraceState,
+  TraceStatus,
+  VncEndpointInfo,
+} from "./types.js"
+
+const DEFAULT_CDP_HOST = "127.0.0.1"
+const DEFAULT_CDP_PORT = 9222
+const DEFAULT_WEBSOCKIFY_PORT = 6080
+const DEFAULT_VNC_PORT = 5900
+const DEFAULT_TRACE_DIR = "/workspace/traces"
+const DEFAULT_ASSET_DIR = "/workspace/browser"
+
+// ---------------------------------------------------------------------------
+// Per-agent observation state
+// ---------------------------------------------------------------------------
+
+interface AgentObservationState {
+  traceStatus: TraceStatus
+  traceStartedAt: string | null
+  traceOptions: TraceRecordingOptions | null
+  /** WebSocket connection to CDP for this agent. */
+  cdpWs: WebSocket | null
+  /** Pending annotation callbacks. */
+  annotationListeners: Map<string, (event: AnnotationEvent) => void>
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class BrowserObservationService {
+  private readonly cdpHost: string
+  private readonly cdpPort: number
+  private readonly websockifyPort: number
+  private readonly vncPort: number
+  private readonly traceDir: string
+  private readonly assetDir: string
+
+  /** agentId → per-agent observation state */
+  private readonly agents = new Map<string, AgentObservationState>()
+
+  constructor(config: ObservationServiceConfig = {}) {
+    this.cdpHost = config.cdpHost ?? DEFAULT_CDP_HOST
+    this.cdpPort = config.cdpPort ?? DEFAULT_CDP_PORT
+    this.websockifyPort = config.websockifyPort ?? DEFAULT_WEBSOCKIFY_PORT
+    this.vncPort = config.vncPort ?? DEFAULT_VNC_PORT
+    this.traceDir = config.traceDir ?? DEFAULT_TRACE_DIR
+    this.assetDir = config.assetDir ?? DEFAULT_ASSET_DIR
+  }
+
+  // -------------------------------------------------------------------------
+  // VNC / Stream Status
+  // -------------------------------------------------------------------------
+
+  /**
+   * Check VNC availability and return connection info.
+   */
+  async getStreamStatus(agentId: string): Promise<StreamStatus> {
+    const vncEndpoint = await this.getVncEndpoint(agentId)
+    const quality: StreamQuality = vncEndpoint?.available ? "live" : "degraded"
+
+    return {
+      agentId,
+      quality,
+      fps: quality === "live" ? 30 : 0,
+      lastFrameAt: null,
+      vncEndpoint,
+    }
+  }
+
+  /**
+   * Get the VNC endpoint info for the agent's sidecar.
+   */
+  async getVncEndpoint(_agentId: string): Promise<VncEndpointInfo | null> {
+    const available = await this.isVncAvailable()
+    if (!available) return null
+
+    return {
+      websocketUrl: `ws://${this.cdpHost}:${this.websockifyPort}`,
+      vncAddress: `${this.cdpHost}:${this.vncPort}`,
+      available: true,
+    }
+  }
+
+  /**
+   * Proxy a WebSocket connection to the sidecar's websockify endpoint.
+   * Accepts the client-side WebSocket from @fastify/websocket and bridges
+   * it to the upstream websockify instance in the sidecar.
+   */
+  proxyVncWebSocket(clientWs: WebSocket): WebSocket {
+    const target = `ws://${this.cdpHost}:${this.websockifyPort}`
+    const upstream = new WebSocket(target, ["binary"], {
+      perMessageDeflate: false,
+    })
+
+    upstream.on("message", (data) => {
+      if (clientWs.readyState === WebSocket.OPEN) {
+        clientWs.send(data)
+      }
+    })
+
+    clientWs.on("message", (data) => {
+      if (upstream.readyState === WebSocket.OPEN) {
+        upstream.send(data)
+      }
+    })
+
+    clientWs.on("close", () => upstream.close())
+    clientWs.on("error", () => upstream.close())
+    upstream.on("close", () => clientWs.close())
+    upstream.on("error", () => clientWs.close())
+
+    return upstream
+  }
+
+  // -------------------------------------------------------------------------
+  // Screenshot (degraded mode)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Capture a screenshot of the current page via CDP.
+   */
+  async captureScreenshot(agentId: string, request: ScreenshotRequest = {}): Promise<ScreenshotResult> {
+    const format = request.format ?? "jpeg"
+    const quality = format === "jpeg" ? (request.quality ?? 70) : undefined
+    const fullPage = request.fullPage ?? false
+
+    const wsEndpoint = await this.discoverCdpWsEndpoint()
+    const ws = new WebSocket(wsEndpoint)
+
+    try {
+      await this.waitForWsOpen(ws)
+
+      // Get the list of targets to find the first page
+      const targets = await this.cdpSend<{ targetInfos: Array<{ type: string; targetId: string; url: string; title: string }> }>(
+        ws,
+        "Target.getTargets",
+        {},
+      )
+
+      const pageTarget = targets.targetInfos.find((t) => t.type === "page")
+      if (!pageTarget) {
+        throw new Error("No browser page found")
+      }
+
+      // Attach to the target
+      const { sessionId } = await this.cdpSend<{ sessionId: string }>(
+        ws,
+        "Target.attachToTarget",
+        { targetId: pageTarget.targetId, flatten: true },
+      )
+
+      // If fullPage, get the full document dimensions first
+      let clip: { x: number; y: number; width: number; height: number; scale: number } | undefined
+      if (fullPage) {
+        const layout = await this.cdpSendSession<{
+          contentSize: { width: number; height: number }
+        }>(ws, sessionId, "Page.getLayoutMetrics", {})
+        clip = {
+          x: 0,
+          y: 0,
+          width: layout.contentSize.width,
+          height: layout.contentSize.height,
+          scale: 1,
+        }
+      }
+
+      // Capture screenshot
+      const result = await this.cdpSendSession<{ data: string; metadata?: { width?: number; height?: number } }>(
+        ws,
+        sessionId,
+        "Page.captureScreenshot",
+        {
+          format,
+          quality,
+          clip,
+          fromSurface: true,
+        },
+      )
+
+      return {
+        agentId,
+        data: result.data,
+        format,
+        width: result.metadata?.width ?? 1280,
+        height: result.metadata?.height ?? 720,
+        timestamp: new Date().toISOString(),
+        url: pageTarget.url,
+        title: pageTarget.title,
+      }
+    } finally {
+      ws.close()
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Multi-tab awareness
+  // -------------------------------------------------------------------------
+
+  /**
+   * Query all open tabs in the browser context.
+   */
+  async listTabs(agentId: string): Promise<TabListResult> {
+    const wsEndpoint = await this.discoverCdpWsEndpoint()
+    const ws = new WebSocket(wsEndpoint)
+
+    try {
+      await this.waitForWsOpen(ws)
+
+      const result = await this.cdpSend<{
+        targetInfos: Array<{
+          type: string
+          targetId: string
+          url: string
+          title: string
+          attached: boolean
+        }>
+      }>(ws, "Target.getTargets", {})
+
+      const pages = result.targetInfos.filter((t) => t.type === "page")
+
+      const tabs: TabInfo[] = pages.map((page, index) => ({
+        index,
+        url: page.url,
+        title: page.title,
+        active: index === 0, // First page is typically active
+      }))
+
+      return {
+        agentId,
+        tabs,
+        timestamp: new Date().toISOString(),
+      }
+    } finally {
+      ws.close()
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Trace Recording (Playwright Trace Viewer)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Get the current trace recording state.
+   */
+  getTraceState(agentId: string): TraceState {
+    const state = this.getAgentState(agentId)
+    return {
+      agentId,
+      status: state.traceStatus,
+      startedAt: state.traceStartedAt,
+      options: state.traceOptions,
+    }
+  }
+
+  /**
+   * Start trace recording via CDP.
+   */
+  async startTrace(agentId: string, options: TraceRecordingOptions = {}): Promise<TraceState> {
+    const state = this.getAgentState(agentId)
+
+    if (state.traceStatus === "recording") {
+      throw new Error(`Trace recording already in progress for agent ${agentId}`)
+    }
+
+    const traceOptions: TraceRecordingOptions = {
+      snapshots: options.snapshots ?? true,
+      screenshots: options.screenshots ?? true,
+      network: options.network ?? true,
+      console: options.console ?? true,
+    }
+
+    await fs.mkdir(this.traceDir, { recursive: true })
+
+    // Use CDP to enable tracing domains
+    const wsEndpoint = await this.discoverCdpWsEndpoint()
+    const ws = new WebSocket(wsEndpoint)
+
+    try {
+      await this.waitForWsOpen(ws)
+
+      const targets = await this.cdpSend<{ targetInfos: Array<{ type: string; targetId: string }> }>(
+        ws,
+        "Target.getTargets",
+        {},
+      )
+      const pageTarget = targets.targetInfos.find((t) => t.type === "page")
+      if (!pageTarget) throw new Error("No browser page found for tracing")
+
+      const { sessionId } = await this.cdpSend<{ sessionId: string }>(
+        ws,
+        "Target.attachToTarget",
+        { targetId: pageTarget.targetId, flatten: true },
+      )
+
+      // Enable tracing categories
+      const categories: string[] = []
+      if (traceOptions.network) categories.push("-*", "devtools.timeline", "v8.execute")
+      if (traceOptions.snapshots) categories.push("disabled-by-default-devtools.timeline.frame")
+
+      await this.cdpSendSession(ws, sessionId, "Tracing.start", {
+        categories: categories.join(","),
+        options: "sampling-frequency=10000",
+      })
+
+      if (traceOptions.network) {
+        await this.cdpSendSession(ws, sessionId, "Network.enable", {})
+      }
+      if (traceOptions.console) {
+        await this.cdpSendSession(ws, sessionId, "Runtime.enable", {})
+      }
+    } finally {
+      ws.close()
+    }
+
+    state.traceStatus = "recording"
+    state.traceStartedAt = new Date().toISOString()
+    state.traceOptions = traceOptions
+
+    return this.getTraceState(agentId)
+  }
+
+  /**
+   * Stop trace recording and save to file.
+   */
+  async stopTrace(agentId: string): Promise<TraceDownloadResult> {
+    const state = this.getAgentState(agentId)
+
+    if (state.traceStatus !== "recording") {
+      throw new Error(`No active trace recording for agent ${agentId}`)
+    }
+
+    state.traceStatus = "stopping"
+    const startedAt = state.traceStartedAt!
+
+    const wsEndpoint = await this.discoverCdpWsEndpoint()
+    const ws = new WebSocket(wsEndpoint)
+
+    try {
+      await this.waitForWsOpen(ws)
+
+      const targets = await this.cdpSend<{ targetInfos: Array<{ type: string; targetId: string }> }>(
+        ws,
+        "Target.getTargets",
+        {},
+      )
+      const pageTarget = targets.targetInfos.find((t) => t.type === "page")
+      if (!pageTarget) throw new Error("No browser page found for tracing")
+
+      const { sessionId } = await this.cdpSend<{ sessionId: string }>(
+        ws,
+        "Target.attachToTarget",
+        { targetId: pageTarget.targetId, flatten: true },
+      )
+
+      // Stop tracing and collect data
+      await this.cdpSendSession(ws, sessionId, "Tracing.end", {})
+
+      // Wait for tracingComplete event
+      const traceData = await new Promise<string>((resolve, reject) => {
+        const chunks: string[] = []
+        const timeout = setTimeout(() => reject(new Error("Trace collection timed out")), 30_000)
+
+        const handler = (rawMsg: Buffer | string) => {
+          const msg = JSON.parse(rawMsg.toString()) as {
+            method?: string
+            params?: { value?: string[]; dataCollected?: boolean }
+          }
+
+          if (msg.method === "Tracing.dataCollected" && msg.params?.value) {
+            chunks.push(...msg.params.value.map((v) => JSON.stringify(v)))
+          }
+
+          if (msg.method === "Tracing.tracingComplete") {
+            clearTimeout(timeout)
+            ws.off("message", handler)
+            resolve(`[${chunks.join(",")}]`)
+          }
+        }
+
+        ws.on("message", handler)
+      })
+
+      // Save trace data
+      await fs.mkdir(this.traceDir, { recursive: true })
+      const filename = `trace-${agentId}-${Date.now()}.json`
+      const filePath = path.join(this.traceDir, filename)
+      await fs.writeFile(filePath, traceData, "utf-8")
+
+      const stats = await fs.stat(filePath)
+      const durationMs = Date.now() - new Date(startedAt).getTime()
+
+      state.traceStatus = "idle"
+      state.traceStartedAt = null
+      state.traceOptions = null
+
+      return {
+        agentId,
+        filePath,
+        sizeBytes: stats.size,
+        durationMs,
+        timestamp: new Date().toISOString(),
+      }
+    } catch (err) {
+      state.traceStatus = "idle"
+      state.traceStartedAt = null
+      throw err
+    } finally {
+      ws.close()
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Annotation / Event Forwarding
+  // -------------------------------------------------------------------------
+
+  /**
+   * Register a listener for annotation events forwarded to a specific agent.
+   */
+  onAnnotation(agentId: string, listener: (event: AnnotationEvent) => void): () => void {
+    const state = this.getAgentState(agentId)
+    const id = randomUUID()
+    state.annotationListeners.set(id, listener)
+    return () => {
+      state.annotationListeners.delete(id)
+    }
+  }
+
+  /**
+   * Forward a user annotation (click, hover, etc.) to the agent.
+   * Generates a coordinate-based prompt for the agent's next action.
+   */
+  async forwardAnnotation(agentId: string, event: AnnotationEvent): Promise<AnnotationResult> {
+    const annotationId = randomUUID()
+    const state = this.getAgentState(agentId)
+
+    // Notify all registered listeners
+    for (const listener of state.annotationListeners.values()) {
+      try {
+        listener(event)
+      } catch {
+        // swallow listener errors
+      }
+    }
+
+    return {
+      agentId,
+      annotationId,
+      forwarded: state.annotationListeners.size > 0,
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Cleanup
+  // -------------------------------------------------------------------------
+
+  /**
+   * Clean up all state for an agent.
+   */
+  async cleanup(agentId: string): Promise<void> {
+    const state = this.agents.get(agentId)
+    if (!state) return
+
+    if (state.cdpWs) {
+      state.cdpWs.close()
+    }
+    state.annotationListeners.clear()
+    this.agents.delete(agentId)
+  }
+
+  /**
+   * Shut down the service and clean up all agents.
+   */
+  async shutdown(): Promise<void> {
+    for (const agentId of this.agents.keys()) {
+      await this.cleanup(agentId)
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Private: CDP Communication
+  // -------------------------------------------------------------------------
+
+  private async discoverCdpWsEndpoint(): Promise<string> {
+    const res = await fetch(`http://${this.cdpHost}:${this.cdpPort}/json/version`)
+    if (!res.ok) {
+      throw new Error(`CDP version endpoint returned ${res.status}`)
+    }
+    const data = (await res.json()) as { webSocketDebuggerUrl?: string }
+    if (!data.webSocketDebuggerUrl) {
+      throw new Error("No webSocketDebuggerUrl in CDP /json/version response")
+    }
+    return data.webSocketDebuggerUrl
+  }
+
+  private async isVncAvailable(): Promise<boolean> {
+    try {
+      // Probe the websockify port with a quick TCP-level check
+      const res = await fetch(`http://${this.cdpHost}:${this.websockifyPort}`, {
+        signal: AbortSignal.timeout(2_000),
+      })
+      // websockify returns 200 or 400 depending on path — any response means it's up
+      return res.status < 500
+    } catch {
+      return false
+    }
+  }
+
+  private waitForWsOpen(ws: WebSocket): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("WebSocket connection timeout")), 5_000)
+      ws.on("open", () => {
+        clearTimeout(timeout)
+        resolve()
+      })
+      ws.on("error", (err) => {
+        clearTimeout(timeout)
+        reject(err)
+      })
+    })
+  }
+
+  private cdpSend<T>(ws: WebSocket, method: string, params: Record<string, unknown>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const id = Math.floor(Math.random() * 1_000_000)
+      const timeout = setTimeout(() => reject(new Error(`CDP ${method} timed out`)), 10_000)
+
+      const handler = (rawMsg: Buffer | string) => {
+        const msg = JSON.parse(rawMsg.toString()) as { id?: number; result?: T; error?: { message: string } }
+        if (msg.id !== id) return
+
+        clearTimeout(timeout)
+        ws.off("message", handler)
+
+        if (msg.error) {
+          reject(new Error(`CDP error: ${msg.error.message}`))
+        } else {
+          resolve(msg.result as T)
+        }
+      }
+
+      ws.on("message", handler)
+      ws.send(JSON.stringify({ id, method, params }))
+    })
+  }
+
+  private cdpSendSession<T>(
+    ws: WebSocket,
+    sessionId: string,
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const id = Math.floor(Math.random() * 1_000_000)
+      const timeout = setTimeout(() => reject(new Error(`CDP ${method} timed out`)), 10_000)
+
+      const handler = (rawMsg: Buffer | string) => {
+        const msg = JSON.parse(rawMsg.toString()) as { id?: number; result?: T; error?: { message: string } }
+        if (msg.id !== id) return
+
+        clearTimeout(timeout)
+        ws.off("message", handler)
+
+        if (msg.error) {
+          reject(new Error(`CDP error: ${msg.error.message}`))
+        } else {
+          resolve(msg.result as T)
+        }
+      }
+
+      ws.on("message", handler)
+      ws.send(JSON.stringify({ id, method, params, sessionId }))
+    })
+  }
+
+  // -------------------------------------------------------------------------
+  // Private: Per-agent state
+  // -------------------------------------------------------------------------
+
+  private getAgentState(agentId: string): AgentObservationState {
+    let state = this.agents.get(agentId)
+    if (!state) {
+      state = {
+        traceStatus: "idle",
+        traceStartedAt: null,
+        traceOptions: null,
+        cdpWs: null,
+        annotationListeners: new Map(),
+      }
+      this.agents.set(agentId, state)
+    }
+    return state
+  }
+}

--- a/packages/control-plane/src/observation/types.ts
+++ b/packages/control-plane/src/observation/types.ts
@@ -1,0 +1,168 @@
+/**
+ * Browser observation types.
+ *
+ * Defines interfaces for live VNC streaming, screenshot capture,
+ * trace recording, multi-tab awareness, and annotation forwarding.
+ */
+
+// ---------------------------------------------------------------------------
+// VNC / Stream Configuration
+// ---------------------------------------------------------------------------
+
+export interface VncEndpointInfo {
+  /** WebSocket URL for noVNC connection (via websockify). */
+  websocketUrl: string
+  /** Raw VNC host:port (for direct VNC clients). */
+  vncAddress: string
+  /** Whether VNC is currently available. */
+  available: boolean
+}
+
+export type StreamQuality = "live" | "degraded"
+
+export interface StreamStatus {
+  agentId: string
+  quality: StreamQuality
+  fps: number
+  /** Timestamp of last received frame or screenshot. */
+  lastFrameAt: string | null
+  vncEndpoint: VncEndpointInfo | null
+}
+
+// ---------------------------------------------------------------------------
+// Screenshot (degraded mode)
+// ---------------------------------------------------------------------------
+
+export interface ScreenshotRequest {
+  /** Image format. Default "jpeg". */
+  format?: "jpeg" | "png"
+  /** JPEG quality (1–100). Default 70. */
+  quality?: number
+  /** Capture full page or just viewport. Default false. */
+  fullPage?: boolean
+}
+
+export interface ScreenshotResult {
+  agentId: string
+  /** base64-encoded image data. */
+  data: string
+  format: "jpeg" | "png"
+  width: number
+  height: number
+  timestamp: string
+  /** Page URL at capture time. */
+  url: string
+  title: string
+}
+
+// ---------------------------------------------------------------------------
+// Multi-tab awareness
+// ---------------------------------------------------------------------------
+
+export interface TabInfo {
+  /** Page index within the browser context. */
+  index: number
+  url: string
+  title: string
+  /** Whether this is the currently active (focused) page. */
+  active: boolean
+}
+
+export interface TabListResult {
+  agentId: string
+  tabs: TabInfo[]
+  timestamp: string
+}
+
+// ---------------------------------------------------------------------------
+// Trace recording (Playwright Trace Viewer)
+// ---------------------------------------------------------------------------
+
+export type TraceStatus = "idle" | "recording" | "stopping"
+
+export interface TraceState {
+  agentId: string
+  status: TraceStatus
+  /** When recording started (ISO 8601), null if idle. */
+  startedAt: string | null
+  /** Options used for current/last recording. */
+  options: TraceRecordingOptions | null
+}
+
+export interface TraceRecordingOptions {
+  /** Capture DOM snapshots. Default true. */
+  snapshots?: boolean
+  /** Capture screenshots. Default true. */
+  screenshots?: boolean
+  /** Capture network activity. Default true. */
+  network?: boolean
+  /** Capture console messages. Default true. */
+  console?: boolean
+}
+
+export interface TraceDownloadResult {
+  agentId: string
+  /** Absolute path to the .zip trace file. */
+  filePath: string
+  /** Size in bytes. */
+  sizeBytes: number
+  /** Duration of the recording in milliseconds. */
+  durationMs: number
+  timestamp: string
+}
+
+// ---------------------------------------------------------------------------
+// Annotation / Interaction forwarding
+// ---------------------------------------------------------------------------
+
+export interface AnnotationEvent {
+  /** Coordinate-based click from the dashboard overlay. */
+  type: "click" | "hover" | "scroll" | "highlight"
+  /** X coordinate relative to viewport. */
+  x: number
+  /** Y coordinate relative to viewport. */
+  y: number
+  /** Optional element selector hint (if dashboard can resolve it). */
+  selector?: string
+  /** Free-form instruction text attached to the annotation. */
+  prompt?: string
+  /** Scroll delta for scroll events. */
+  scrollDelta?: number
+}
+
+export interface AnnotationResult {
+  agentId: string
+  annotationId: string
+  /** Whether the event was forwarded to the agent. */
+  forwarded: boolean
+  timestamp: string
+}
+
+// ---------------------------------------------------------------------------
+// SSE event types for browser observation
+// ---------------------------------------------------------------------------
+
+export type BrowserObservationEventType =
+  | "browser:screenshot"
+  | "browser:tabs"
+  | "browser:trace:state"
+  | "browser:annotation:ack"
+
+// ---------------------------------------------------------------------------
+// Observation service configuration
+// ---------------------------------------------------------------------------
+
+export interface ObservationServiceConfig {
+  /** CDP sidecar host. Default "127.0.0.1". */
+  cdpHost?: string
+  /** CDP sidecar port. Default 9222. */
+  cdpPort?: number
+  /** Websockify port on the sidecar. Default 6080. */
+  websockifyPort?: number
+  /** Raw VNC port on the sidecar. Default 5900. */
+  vncPort?: number
+  /** Directory for storing trace files. Default "/workspace/traces". */
+  traceDir?: string
+  /** Directory for storing screenshots. Default "/workspace/browser". */
+  assetDir?: string
+}

--- a/packages/control-plane/src/routes/observation.ts
+++ b/packages/control-plane/src/routes/observation.ts
@@ -1,0 +1,418 @@
+/**
+ * Browser Observation Routes
+ *
+ * Endpoints for live VNC streaming, screenshot capture,
+ * trace recording, multi-tab queries, and annotation forwarding.
+ *
+ * GET    /agents/:agentId/observe/stream-status  — VNC availability + quality
+ * GET    /agents/:agentId/observe/vnc            — WebSocket VNC proxy
+ * POST   /agents/:agentId/observe/screenshot     — Capture screenshot (degraded mode)
+ * GET    /agents/:agentId/observe/tabs           — List open browser tabs
+ * GET    /agents/:agentId/observe/trace          — Get trace recording state
+ * POST   /agents/:agentId/observe/trace/start    — Start trace recording
+ * POST   /agents/:agentId/observe/trace/stop     — Stop trace recording + download
+ * POST   /agents/:agentId/observe/annotate       — Forward annotation to agent
+ *
+ * All endpoints require per-session Bearer token authentication.
+ */
+
+import { randomUUID } from "node:crypto"
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify"
+
+import type { AgentLifecycleManager } from "../lifecycle/manager.js"
+import type { BrowserObservationService } from "../observation/service.js"
+import type { AnnotationEvent, ScreenshotRequest, TraceRecordingOptions } from "../observation/types.js"
+import {
+  SSEConnectionManager,
+  createStreamAuth,
+  type AuthenticatedRequest,
+} from "../streaming/index.js"
+
+// ---------------------------------------------------------------------------
+// Route parameter / body types
+// ---------------------------------------------------------------------------
+
+interface AgentParams {
+  agentId: string
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+export interface ObservationRouteDeps {
+  sseManager: SSEConnectionManager
+  lifecycleManager: AgentLifecycleManager
+  observationService: BrowserObservationService
+}
+
+export function observationRoutes(deps: ObservationRouteDeps) {
+  const { sseManager, lifecycleManager, observationService } = deps
+
+  return function register(app: FastifyInstance): void {
+    const authHook = createStreamAuth(app.db)
+
+    // Helper: verify agent exists and is alive
+    function getAgentOrFail(
+      agentId: string,
+      reply: FastifyReply,
+    ): boolean {
+      const state = lifecycleManager.getAgentState(agentId)
+      if (!state) {
+        reply.status(404).send({
+          error: "not_found",
+          message: `Agent ${agentId} is not managed by this control plane`,
+        })
+        return false
+      }
+      if (state === "TERMINATED") {
+        reply.status(410).send({
+          error: "gone",
+          message: `Agent ${agentId} has terminated`,
+        })
+        return false
+      }
+      return true
+    }
+
+    // -----------------------------------------------------------------
+    // GET /agents/:agentId/observe/stream-status
+    // -----------------------------------------------------------------
+
+    app.get<{ Params: AgentParams }>(
+      "/agents/:agentId/observe/stream-status",
+      {
+        preHandler: authHook,
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: AgentParams }>, reply: FastifyReply) => {
+        const { agentId } = request.params
+        if (!getAgentOrFail(agentId, reply)) return
+
+        const status = await observationService.getStreamStatus(agentId)
+        return reply.send(status)
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // GET /agents/:agentId/observe/vnc — WebSocket VNC proxy
+    // -----------------------------------------------------------------
+
+    app.get<{ Params: AgentParams }>(
+      "/agents/:agentId/observe/vnc",
+      {
+        preHandler: authHook,
+        websocket: true,
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+        },
+      },
+      async (socket, request) => {
+        const { agentId } = request.params
+        const state = lifecycleManager.getAgentState(agentId)
+
+        if (!state || state === "TERMINATED") {
+          socket.close(1008, "Agent not available")
+          return
+        }
+
+        request.log.info({ agentId }, "VNC WebSocket proxy established")
+
+        // Proxy to sidecar websockify
+        observationService.proxyVncWebSocket(socket)
+
+        socket.on("close", () => {
+          request.log.info({ agentId }, "VNC WebSocket proxy closed")
+        })
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // POST /agents/:agentId/observe/screenshot
+    // -----------------------------------------------------------------
+
+    app.post<{ Params: AgentParams; Body: ScreenshotRequest }>(
+      "/agents/:agentId/observe/screenshot",
+      {
+        preHandler: authHook,
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              format: { type: "string", enum: ["jpeg", "png"] },
+              quality: { type: "integer", minimum: 1, maximum: 100 },
+              fullPage: { type: "boolean" },
+            },
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: AgentParams; Body: ScreenshotRequest }>, reply: FastifyReply) => {
+        const { agentId } = request.params
+        if (!getAgentOrFail(agentId, reply)) return
+
+        try {
+          const result = await observationService.captureScreenshot(agentId, request.body ?? {})
+
+          // Also broadcast via SSE for any connected dashboard clients
+          sseManager.broadcast(agentId, "browser:screenshot", {
+            agentId,
+            timestamp: result.timestamp,
+            url: result.url,
+            title: result.title,
+          })
+
+          return reply.send(result)
+        } catch (err) {
+          request.log.error(err, "Screenshot capture failed")
+          return reply.status(502).send({
+            error: "upstream_error",
+            message: err instanceof Error ? err.message : "Screenshot capture failed",
+          })
+        }
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // GET /agents/:agentId/observe/tabs
+    // -----------------------------------------------------------------
+
+    app.get<{ Params: AgentParams }>(
+      "/agents/:agentId/observe/tabs",
+      {
+        preHandler: authHook,
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: AgentParams }>, reply: FastifyReply) => {
+        const { agentId } = request.params
+        if (!getAgentOrFail(agentId, reply)) return
+
+        try {
+          const tabs = await observationService.listTabs(agentId)
+          return reply.send(tabs)
+        } catch (err) {
+          request.log.error(err, "Tab listing failed")
+          return reply.status(502).send({
+            error: "upstream_error",
+            message: err instanceof Error ? err.message : "Failed to list tabs",
+          })
+        }
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // GET /agents/:agentId/observe/trace — current trace state
+    // -----------------------------------------------------------------
+
+    app.get<{ Params: AgentParams }>(
+      "/agents/:agentId/observe/trace",
+      {
+        preHandler: authHook,
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: AgentParams }>, reply: FastifyReply) => {
+        const { agentId } = request.params
+        if (!getAgentOrFail(agentId, reply)) return
+
+        const state = observationService.getTraceState(agentId)
+        return reply.send(state)
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // POST /agents/:agentId/observe/trace/start
+    // -----------------------------------------------------------------
+
+    app.post<{ Params: AgentParams; Body: TraceRecordingOptions }>(
+      "/agents/:agentId/observe/trace/start",
+      {
+        preHandler: authHook,
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              snapshots: { type: "boolean" },
+              screenshots: { type: "boolean" },
+              network: { type: "boolean" },
+              console: { type: "boolean" },
+            },
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: AgentParams; Body: TraceRecordingOptions }>, reply: FastifyReply) => {
+        const { agentId } = request.params
+        if (!getAgentOrFail(agentId, reply)) return
+
+        try {
+          const state = await observationService.startTrace(agentId, request.body ?? {})
+
+          sseManager.broadcast(agentId, "browser:trace:state", {
+            agentId,
+            status: state.status,
+            startedAt: state.startedAt,
+            timestamp: new Date().toISOString(),
+          })
+
+          return reply.status(202).send(state)
+        } catch (err) {
+          request.log.error(err, "Trace start failed")
+          const message = err instanceof Error ? err.message : "Failed to start trace"
+          const status = message.includes("already in progress") ? 409 : 502
+          return reply.status(status).send({
+            error: status === 409 ? "conflict" : "upstream_error",
+            message,
+          })
+        }
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // POST /agents/:agentId/observe/trace/stop
+    // -----------------------------------------------------------------
+
+    app.post<{ Params: AgentParams }>(
+      "/agents/:agentId/observe/trace/stop",
+      {
+        preHandler: authHook,
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: AgentParams }>, reply: FastifyReply) => {
+        const { agentId } = request.params
+        if (!getAgentOrFail(agentId, reply)) return
+
+        try {
+          const result = await observationService.stopTrace(agentId)
+
+          sseManager.broadcast(agentId, "browser:trace:state", {
+            agentId,
+            status: "idle",
+            timestamp: new Date().toISOString(),
+          })
+
+          return reply.send(result)
+        } catch (err) {
+          request.log.error(err, "Trace stop failed")
+          const message = err instanceof Error ? err.message : "Failed to stop trace"
+          const status = message.includes("No active trace") ? 409 : 502
+          return reply.status(status).send({
+            error: status === 409 ? "conflict" : "upstream_error",
+            message,
+          })
+        }
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // POST /agents/:agentId/observe/annotate
+    // -----------------------------------------------------------------
+
+    app.post<{ Params: AgentParams; Body: AnnotationEvent }>(
+      "/agents/:agentId/observe/annotate",
+      {
+        preHandler: authHook,
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["click", "hover", "scroll", "highlight"] },
+              x: { type: "number" },
+              y: { type: "number" },
+              selector: { type: "string" },
+              prompt: { type: "string", maxLength: 10_000 },
+              scrollDelta: { type: "number" },
+            },
+            required: ["type", "x", "y"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: AgentParams; Body: AnnotationEvent }>, reply: FastifyReply) => {
+        const { agentId } = request.params
+        if (!getAgentOrFail(agentId, reply)) return
+
+        const agentState = lifecycleManager.getAgentState(agentId)
+        if (agentState !== "EXECUTING") {
+          return reply.status(409).send({
+            error: "conflict",
+            message: `Cannot forward annotation: agent is in ${agentState} state, must be EXECUTING`,
+          })
+        }
+
+        const event = request.body
+
+        // Generate a coordinate-based prompt for the agent
+        const prompt = event.prompt
+          ?? `User clicked at coordinates (${event.x}, ${event.y})${event.selector ? ` on element "${event.selector}"` : ""}. Investigate this element.`
+
+        // Forward annotation to the observation service
+        const result = await observationService.forwardAnnotation(agentId, event)
+
+        // Inject as a steering message via lifecycle manager
+        const steerMessageId = randomUUID()
+        try {
+          lifecycleManager.steer({
+            id: steerMessageId,
+            agentId,
+            message: `[ANNOTATION] ${prompt}`,
+            priority: "normal",
+            timestamp: new Date(),
+          })
+        } catch {
+          // Agent state may have changed
+        }
+
+        // Broadcast annotation acknowledgment via SSE
+        sseManager.broadcast(agentId, "browser:annotation:ack", {
+          agentId,
+          annotationId: result.annotationId,
+          event,
+          prompt,
+          timestamp: result.timestamp,
+        })
+
+        return reply.status(202).send(result)
+      },
+    )
+  }
+}

--- a/packages/control-plane/src/streaming/types.ts
+++ b/packages/control-plane/src/streaming/types.ts
@@ -22,6 +22,10 @@ export type SSEEventType =
   | "approval:created"
   | "approval:decided"
   | "approval:expired"
+  | "browser:screenshot"
+  | "browser:tabs"
+  | "browser:trace:state"
+  | "browser:annotation:ack"
 
 /** A serialized SSE event with an ID for replay support. */
 export interface SSEEvent {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       pino:
         specifier: ^9.6.0
         version: 9.14.0
+      ws:
+        specifier: ^8.19.0
+        version: 8.19.0
     devDependencies:
       '@cortex/config':
         specifier: workspace:*
@@ -134,6 +137,9 @@ importers:
       '@types/pg':
         specifier: ^8.11.0
         version: 8.16.0
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       embedded-postgres:
         specifier: 18.2.0-beta.16
         version: 18.2.0-beta.16


### PR DESCRIPTION
## Summary

Browser observation infrastructure for real-time agent browser monitoring.

### VNC Infrastructure

- Xvfb + x11vnc + websockify in Playwright sidecar
- WebSocket proxy on :6080 for noVNC
- VNC server on :5900

### Endpoints

| Endpoint | Description |
|----------|-------------|
| /agents/:id/observe/stream-status | VNC availability |
| /agents/:id/observe/vnc | WebSocket VNC proxy |
| /agents/:id/observe/screenshot | Screenshot capture |
| /agents/:id/observe/tabs | List browser tabs |
| /agents/:id/observe/trace/start | Start trace recording |
| /agents/:id/observe/trace/stop | Stop + download trace |
| /agents/:id/observe/annotate | Forward annotation to agent |

### Features

- Multi-tab awareness via CDP
- Trace recording (DOM, network, console)
- Screenshot fallback for degraded connections
- Annotation layer for user → agent interaction

### Tests

- 33 new tests
- 342 total tests pass

---

Closes #20