### PR TITLE
feat(shared,control-plane): Multi-provider routing with circuit breaker failover (#98)

### DIFF
--- a/packages/control-plane/src/__tests__/echo-backend.test.ts
+++ b/packages/control-plane/src/__tests__/echo-backend.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from "vitest"
+
+import type { ExecutionTask, OutputEvent } from "@cortex/shared"
+
+import { EchoBackend } from "../backends/echo-backend.js"
+
+// ──────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────
+
+function makeTask(overrides?: Partial<ExecutionTask>): ExecutionTask {
+  return {
+    id: "task-echo-001",
+    jobId: "job-echo-001",
+    agentId: "agent-echo-001",
+    instruction: {
+      prompt: "Hello from echo test",
+      goalType: "code_edit",
+    },
+    context: {
+      workspacePath: "/workspace",
+      systemPrompt: "",
+      memories: [],
+      relevantFiles: {},
+      environment: {},
+    },
+    constraints: {
+      timeoutMs: 60_000,
+      maxTokens: 200_000,
+      model: "echo",
+      allowedTools: [],
+      deniedTools: [],
+      maxTurns: 1,
+      networkAccess: false,
+      shellAccess: false,
+    },
+    ...overrides,
+  }
+}
+
+async function collectEvents(handle: { events(): AsyncIterable<OutputEvent> }): Promise<OutputEvent[]> {
+  const events: OutputEvent[] = []
+  for await (const event of handle.events()) {
+    events.push(event)
+  }
+  return events
+}
+
+// ──────────────────────────────────────────────────
+// Lifecycle
+// ──────────────────────────────────────────────────
+
+describe("EchoBackend — lifecycle", () => {
+  it("has backendId 'echo'", () => {
+    const backend = new EchoBackend()
+    expect(backend.backendId).toBe("echo")
+  })
+
+  it("starts successfully", async () => {
+    const backend = new EchoBackend()
+    await backend.start({})
+    // Should not throw
+  })
+
+  it("stops successfully", async () => {
+    const backend = new EchoBackend()
+    await backend.start({})
+    await backend.stop()
+    // Should not throw
+  })
+
+  it("reads latencyMs from config", async () => {
+    const backend = new EchoBackend()
+    await backend.start({ latencyMs: 100 })
+
+    const health = await backend.healthCheck()
+    expect(health.details).toHaveProperty("latencyMs", 100)
+  })
+
+  it("reads failureRate from config", async () => {
+    const backend = new EchoBackend()
+    await backend.start({ failureRate: 0.5 })
+
+    const health = await backend.healthCheck()
+    expect(health.details).toHaveProperty("failureRate", 0.5)
+  })
+
+  it("clamps failureRate to [0, 1]", async () => {
+    const backend = new EchoBackend()
+    await backend.start({ failureRate: 2.0 })
+
+    const health = await backend.healthCheck()
+    expect(health.details).toHaveProperty("failureRate", 1.0)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Health Check
+// ──────────────────────────────────────────────────
+
+describe("EchoBackend — healthCheck()", () => {
+  it("returns healthy when started", async () => {
+    const backend = new EchoBackend()
+    await backend.start({})
+
+    const report = await backend.healthCheck()
+    expect(report.status).toBe("healthy")
+    expect(report.backendId).toBe("echo")
+  })
+
+  it("returns unhealthy when not started", async () => {
+    const backend = new EchoBackend()
+
+    const report = await backend.healthCheck()
+    expect(report.status).toBe("unhealthy")
+  })
+
+  it("returns unhealthy after stop", async () => {
+    const backend = new EchoBackend()
+    await backend.start({})
+    await backend.stop()
+
+    const report = await backend.healthCheck()
+    expect(report.status).toBe("unhealthy")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Capabilities
+// ──────────────────────────────────────────────────
+
+describe("EchoBackend — getCapabilities()", () => {
+  it("returns echo capabilities", () => {
+    const backend = new EchoBackend()
+    const caps = backend.getCapabilities()
+
+    expect(caps.supportsStreaming).toBe(false)
+    expect(caps.supportsFileEdit).toBe(false)
+    expect(caps.supportsCancellation).toBe(true)
+    expect(caps.supportedGoalTypes).toContain("code_edit")
+    expect(caps.supportedGoalTypes).toContain("research")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Execution — Success Path
+// ──────────────────────────────────────────────────
+
+describe("EchoBackend — execution (success)", () => {
+  it("echoes the prompt as text event", async () => {
+    const backend = new EchoBackend()
+    await backend.start({ failureRate: 0 })
+
+    const task = makeTask({ instruction: { prompt: "Say hello", goalType: "code_edit" } })
+    const handle = await backend.executeTask(task)
+    const events = await collectEvents(handle)
+
+    const textEvents = events.filter((e) => e.type === "text")
+    expect(textEvents).toHaveLength(1)
+    expect(textEvents[0]!.type === "text" && textEvents[0]!.content).toBe("Say hello")
+  })
+
+  it("emits complete event with success result", async () => {
+    const backend = new EchoBackend()
+    await backend.start({ failureRate: 0 })
+
+    const handle = await backend.executeTask(makeTask())
+    const events = await collectEvents(handle)
+
+    const completeEvents = events.filter((e) => e.type === "complete")
+    expect(completeEvents).toHaveLength(1)
+
+    const result = await handle.result()
+    expect(result.status).toBe("completed")
+    expect(result.exitCode).toBe(0)
+    expect(result.summary).toBe("Hello from echo test")
+  })
+
+  it("returns prompt as stdout", async () => {
+    const backend = new EchoBackend()
+    await backend.start({ failureRate: 0 })
+
+    const handle = await backend.executeTask(makeTask())
+    await collectEvents(handle)
+
+    const result = await handle.result()
+    expect(result.stdout).toBe("Hello from echo test")
+  })
+
+  it("reports zero token usage", async () => {
+    const backend = new EchoBackend()
+    await backend.start({ failureRate: 0 })
+
+    const handle = await backend.executeTask(makeTask())
+    await collectEvents(handle)
+
+    const result = await handle.result()
+    expect(result.tokenUsage.inputTokens).toBe(0)
+    expect(result.tokenUsage.outputTokens).toBe(0)
+  })
+
+  it("returns empty file changes", async () => {
+    const backend = new EchoBackend()
+    await backend.start({ failureRate: 0 })
+
+    const handle = await backend.executeTask(makeTask())
+    await collectEvents(handle)
+
+    const result = await handle.result()
+    expect(result.fileChanges).toEqual([])
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Execution — Failure Path
+// ──────────────────────────────────────────────────
+
+describe("EchoBackend — execution (failure)", () => {
+  it("fails with configured classification", async () => {
+    const backend = new EchoBackend()
+    await backend.start({ failureRate: 1.0, failureClassification: "transient" })
+
+    const handle = await backend.executeTask(makeTask())
+    await collectEvents(handle)
+
+    const result = await handle.result()
+    expect(result.status).toBe("failed")
+    expect(result.error).toBeDefined()
+    expect(result.error!.classification).toBe("transient")
+    expect(result.error!.message).toContain("simulated failure")
+  })
+
+  it("emits complete event on failure", async () => {
+    const backend = new EchoBackend()
+    await backend.start({ failureRate: 1.0 })
+
+    const handle = await backend.executeTask(makeTask())
+    const events = await collectEvents(handle)
+
+    const completeEvents = events.filter((e) => e.type === "complete")
+    expect(completeEvents).toHaveLength(1)
+  })
+
+  it("uses permanent classification when configured", async () => {
+    const backend = new EchoBackend()
+    await backend.start({ failureRate: 1.0, failureClassification: "permanent" })
+
+    const handle = await backend.executeTask(makeTask())
+    await collectEvents(handle)
+
+    const result = await handle.result()
+    expect(result.error!.classification).toBe("permanent")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Cancellation
+// ──────────────────────────────────────────────────
+
+describe("EchoBackend — cancellation", () => {
+  it("cancels and returns cancelled result", async () => {
+    const backend = new EchoBackend()
+    await backend.start({ latencyMs: 10_000 })
+
+    const handle = await backend.executeTask(makeTask())
+
+    // Cancel immediately before events can complete
+    await handle.cancel("Test cancellation")
+
+    const result = await handle.result()
+    expect(result.status).toBe("cancelled")
+    expect(result.summary).toContain("Test cancellation")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// configure()
+// ──────────────────────────────────────────────────
+
+describe("EchoBackend — configure()", () => {
+  it("updates failure rate at runtime", async () => {
+    const backend = new EchoBackend()
+    await backend.start({ failureRate: 0 })
+
+    backend.configure({ failureRate: 1.0 })
+
+    const handle = await backend.executeTask(makeTask())
+    await collectEvents(handle)
+
+    const result = await handle.result()
+    expect(result.status).toBe("failed")
+  })
+
+  it("updates latency at runtime", async () => {
+    const backend = new EchoBackend()
+    await backend.start({})
+
+    backend.configure({ latencyMs: 50 })
+
+    const start = Date.now()
+    const handle = await backend.executeTask(makeTask())
+    await collectEvents(handle)
+    const elapsed = Date.now() - start
+
+    expect(elapsed).toBeGreaterThanOrEqual(40)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Error on not started
+// ──────────────────────────────────────────────────
+
+describe("EchoBackend — not started", () => {
+  it("throws when executeTask called without start", async () => {
+    const backend = new EchoBackend()
+    await expect(backend.executeTask(makeTask())).rejects.toThrow("not started")
+  })
+})

--- a/packages/control-plane/src/__tests__/health.test.ts
+++ b/packages/control-plane/src/__tests__/health.test.ts
@@ -3,10 +3,45 @@ import type { Runner } from "graphile-worker"
 import type { Kysely } from "kysely"
 import { describe, expect, it, vi } from "vitest"
 
+import {
+  BackendRegistry,
+  type BackendCapabilities,
+  type BackendHealthReport,
+  type ExecutionBackend,
+} from "@cortex/shared/backends"
 import type { Database } from "../db/types.js"
 import { healthRoutes } from "../routes/health.js"
 
-function buildTestApp(overrides?: { worker?: unknown; db?: unknown }) {
+function createMockBackend(id: string, healthy = true): ExecutionBackend {
+  return {
+    backendId: id,
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({
+      backendId: id,
+      status: healthy ? "healthy" : "unhealthy",
+      checkedAt: new Date().toISOString(),
+      latencyMs: 50,
+      details: {},
+    } satisfies BackendHealthReport),
+    executeTask: vi.fn().mockRejectedValue(new Error("Not implemented")),
+    getCapabilities: vi.fn().mockReturnValue({
+      supportsStreaming: true,
+      supportsFileEdit: true,
+      supportsShellExecution: true,
+      reportsTokenUsage: true,
+      supportsCancellation: true,
+      supportedGoalTypes: ["code_edit"],
+      maxContextTokens: 200_000,
+    } satisfies BackendCapabilities),
+  }
+}
+
+function buildTestApp(overrides?: {
+  worker?: unknown
+  db?: unknown
+  backendRegistry?: BackendRegistry
+}) {
   const app = Fastify()
 
   const mockDb =
@@ -26,6 +61,9 @@ function buildTestApp(overrides?: { worker?: unknown; db?: unknown }) {
 
   app.decorate("worker", worker as Runner)
   app.decorate("db", mockDb as Kysely<Database>)
+  if (overrides?.backendRegistry) {
+    app.decorate("backendRegistry", overrides.backendRegistry)
+  }
   return app
 }
 
@@ -82,5 +120,92 @@ describe("health routes", () => {
       status: "not_ready",
       checks: { worker: true, db: false },
     })
+  })
+})
+
+describe("health routes — /health/backends", () => {
+  it("returns 503 when backendRegistry is not configured", async () => {
+    const app = buildTestApp()
+    await app.register(healthRoutes)
+
+    const response = await app.inject({ method: "GET", url: "/health/backends" })
+    expect(response.statusCode).toBe(503)
+    expect(response.json()).toEqual({
+      status: "unavailable",
+      reason: "Backend registry not configured",
+    })
+  })
+
+  it("returns backend health and circuit breaker state", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("claude-code"))
+    await registry.register(createMockBackend("echo"))
+
+    const app = buildTestApp({ backendRegistry: registry })
+    await app.register(healthRoutes)
+
+    const response = await app.inject({ method: "GET", url: "/health/backends" })
+    expect(response.statusCode).toBe(200)
+
+    const body = response.json() as {
+      status: string
+      backends: Array<{
+        backendId: string
+        health: { status: string } | null
+        circuitBreaker: { state: string } | null
+      }>
+    }
+    expect(body.status).toBe("ok")
+    expect(body.backends).toHaveLength(2)
+
+    const ccBackend = body.backends.find((b) => b.backendId === "claude-code")
+    expect(ccBackend).toBeDefined()
+    expect(ccBackend!.health).toBeDefined()
+    expect(ccBackend!.health!.status).toBe("healthy")
+    expect(ccBackend!.circuitBreaker).toBeDefined()
+    expect(ccBackend!.circuitBreaker!.state).toBe("CLOSED")
+
+    const echoBackend = body.backends.find((b) => b.backendId === "echo")
+    expect(echoBackend).toBeDefined()
+    expect(echoBackend!.circuitBreaker!.state).toBe("CLOSED")
+  })
+
+  it("shows OPEN circuit when failures recorded", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(
+      createMockBackend("claude-code"),
+      {},
+      1,
+      { failureThreshold: 1 },
+    )
+
+    // Trip the breaker
+    registry.recordOutcome("claude-code", false, "transient")
+
+    const app = buildTestApp({ backendRegistry: registry })
+    await app.register(healthRoutes)
+
+    const response = await app.inject({ method: "GET", url: "/health/backends" })
+    const body = response.json() as {
+      backends: Array<{
+        backendId: string
+        circuitBreaker: { state: string; windowFailureCount: number } | null
+      }>
+    }
+
+    const cc = body.backends.find((b) => b.backendId === "claude-code")
+    expect(cc!.circuitBreaker!.state).toBe("OPEN")
+    expect(cc!.circuitBreaker!.windowFailureCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it("returns empty backends list when none registered", async () => {
+    const registry = new BackendRegistry()
+
+    const app = buildTestApp({ backendRegistry: registry })
+    await app.register(healthRoutes)
+
+    const response = await app.inject({ method: "GET", url: "/health/backends" })
+    const body = response.json() as { backends: unknown[] }
+    expect(body.backends).toHaveLength(0)
   })
 })

--- a/packages/control-plane/src/backends/echo-backend.ts
+++ b/packages/control-plane/src/backends/echo-backend.ts
@@ -1,0 +1,231 @@
+/**
+ * Echo Backend
+ *
+ * Lightweight stub backend for testing failover and circuit breaker
+ * behavior without making real API calls. Returns the task prompt
+ * as the result with configurable latency and failure rate.
+ */
+
+import type {
+  BackendCapabilities,
+  BackendHealthReport,
+  ExecutionBackend,
+  ExecutionHandle,
+  ExecutionResult,
+  ExecutionTask,
+  OutputCompleteEvent,
+  OutputEvent,
+  OutputTextEvent,
+  TokenUsage,
+} from "@cortex/shared"
+
+const ZERO_TOKEN_USAGE: TokenUsage = {
+  inputTokens: 0,
+  outputTokens: 0,
+  costUsd: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+}
+
+export interface EchoBackendConfig {
+  /** Artificial latency in ms before returning result. Default: 0. */
+  latencyMs?: number
+  /** Failure rate from 0.0 to 1.0. Default: 0.0 (never fails). */
+  failureRate?: number
+  /** Error classification when failing. Default: "transient". */
+  failureClassification?: "transient" | "permanent" | "timeout" | "resource"
+}
+
+export class EchoBackend implements ExecutionBackend {
+  readonly backendId = "echo"
+
+  private latencyMs = 0
+  private failureRate = 0
+  private failureClassification: "transient" | "permanent" | "timeout" | "resource" = "transient"
+  private started = false
+
+  async start(config: Record<string, unknown>): Promise<void> {
+    if (typeof config.latencyMs === "number") {
+      this.latencyMs = config.latencyMs
+    }
+    if (typeof config.failureRate === "number") {
+      this.failureRate = Math.max(0, Math.min(1, config.failureRate))
+    }
+    if (typeof config.failureClassification === "string") {
+      this.failureClassification = config.failureClassification as typeof this.failureClassification
+    }
+    this.started = true
+  }
+
+  async stop(): Promise<void> {
+    this.started = false
+  }
+
+  async healthCheck(): Promise<BackendHealthReport> {
+    return {
+      backendId: this.backendId,
+      status: this.started ? "healthy" : "unhealthy",
+      reason: this.started ? undefined : "Backend not started",
+      checkedAt: new Date().toISOString(),
+      latencyMs: 0,
+      details: { latencyMs: this.latencyMs, failureRate: this.failureRate },
+    }
+  }
+
+  async executeTask(task: ExecutionTask): Promise<ExecutionHandle> {
+    if (!this.started) {
+      throw new Error("EchoBackend not started")
+    }
+
+    const shouldFail = Math.random() < this.failureRate
+    const startTime = Date.now()
+
+    return new EchoHandle(
+      task,
+      this.latencyMs,
+      shouldFail,
+      this.failureClassification,
+      startTime,
+    )
+  }
+
+  getCapabilities(): BackendCapabilities {
+    return {
+      supportsStreaming: false,
+      supportsFileEdit: false,
+      supportsShellExecution: false,
+      reportsTokenUsage: false,
+      supportsCancellation: true,
+      supportedGoalTypes: ["code_edit", "code_generate", "code_review", "shell_command", "research"],
+      maxContextTokens: 100_000,
+    }
+  }
+
+  /** Configure failure behavior at runtime (useful in tests). */
+  configure(config: EchoBackendConfig): void {
+    if (config.latencyMs !== undefined) this.latencyMs = config.latencyMs
+    if (config.failureRate !== undefined) this.failureRate = config.failureRate
+    if (config.failureClassification !== undefined) this.failureClassification = config.failureClassification
+  }
+}
+
+// ──────────────────────────────────────────────────
+// Echo Handle
+// ──────────────────────────────────────────────────
+
+class EchoHandle implements ExecutionHandle {
+  readonly taskId: string
+
+  private cancelled = false
+  private resultPromise: Promise<ExecutionResult>
+  private resolveResult!: (result: ExecutionResult) => void
+  private resultResolved = false
+
+  constructor(
+    private readonly task: ExecutionTask,
+    private readonly latencyMs: number,
+    private readonly shouldFail: boolean,
+    private readonly failureClassification: "transient" | "permanent" | "timeout" | "resource",
+    private readonly startTime: number,
+  ) {
+    this.taskId = task.id
+
+    this.resultPromise = new Promise<ExecutionResult>((resolve) => {
+      this.resolveResult = resolve
+    })
+  }
+
+  async *events(): AsyncIterable<OutputEvent> {
+    if (this.latencyMs > 0) {
+      await new Promise((r) => setTimeout(r, this.latencyMs))
+    }
+
+    if (this.cancelled) return
+
+    if (this.shouldFail) {
+      const result: ExecutionResult = {
+        taskId: this.taskId,
+        status: "failed",
+        exitCode: 1,
+        summary: "Echo backend simulated failure",
+        fileChanges: [],
+        stdout: "",
+        stderr: "Simulated failure",
+        tokenUsage: { ...ZERO_TOKEN_USAGE },
+        artifacts: [],
+        durationMs: Date.now() - this.startTime,
+        error: {
+          message: "Echo backend simulated failure",
+          classification: this.failureClassification,
+          partialExecution: false,
+        },
+      }
+      this.settleResult(result)
+
+      const completeEvent: OutputCompleteEvent = {
+        type: "complete",
+        timestamp: new Date().toISOString(),
+        result,
+      }
+      yield completeEvent
+      return
+    }
+
+    // Echo the prompt back as a text event
+    const textEvent: OutputTextEvent = {
+      type: "text",
+      timestamp: new Date().toISOString(),
+      content: this.task.instruction.prompt,
+    }
+    yield textEvent
+
+    // Build success result
+    const result: ExecutionResult = {
+      taskId: this.taskId,
+      status: "completed",
+      exitCode: 0,
+      summary: this.task.instruction.prompt,
+      fileChanges: [],
+      stdout: this.task.instruction.prompt,
+      stderr: "",
+      tokenUsage: { ...ZERO_TOKEN_USAGE },
+      artifacts: [],
+      durationMs: Date.now() - this.startTime,
+    }
+    this.settleResult(result)
+
+    const completeEvent: OutputCompleteEvent = {
+      type: "complete",
+      timestamp: new Date().toISOString(),
+      result,
+    }
+    yield completeEvent
+  }
+
+  async result(): Promise<ExecutionResult> {
+    return this.resultPromise
+  }
+
+  async cancel(reason: string): Promise<void> {
+    this.cancelled = true
+    this.settleResult({
+      taskId: this.taskId,
+      status: "cancelled",
+      exitCode: null,
+      summary: `Cancelled: ${reason}`,
+      fileChanges: [],
+      stdout: "",
+      stderr: "",
+      tokenUsage: { ...ZERO_TOKEN_USAGE },
+      artifacts: [],
+      durationMs: Date.now() - this.startTime,
+    })
+  }
+
+  private settleResult(result: ExecutionResult): void {
+    if (!this.resultResolved) {
+      this.resultResolved = true
+      this.resolveResult(result)
+    }
+  }
+}

--- a/packages/control-plane/src/backends/index.ts
+++ b/packages/control-plane/src/backends/index.ts
@@ -8,14 +8,17 @@
 import type { ExecutionBackend } from "@cortex/shared"
 
 import { ClaudeCodeBackend } from "./claude-code.js"
+import { EchoBackend } from "./echo-backend.js"
 
 export { ClaudeCodeBackend } from "./claude-code.js"
+export { EchoBackend } from "./echo-backend.js"
 
 /** Default concurrency limits per backend type. */
 export const DEFAULT_CONCURRENCY: Record<string, number> = {
   "claude-code": 1,
   codex: 5,
   aider: 1,
+  echo: 10,
 }
 
 /** Create a backend instance by ID. */
@@ -23,6 +26,8 @@ export function createBackend(backendId: string): ExecutionBackend {
   switch (backendId) {
     case "claude-code":
       return new ClaudeCodeBackend()
+    case "echo":
+      return new EchoBackend()
     default:
       throw new Error(`Unknown backend: '${backendId}'`)
   }

--- a/packages/shared/src/__tests__/circuit-breaker.test.ts
+++ b/packages/shared/src/__tests__/circuit-breaker.test.ts
@@ -1,0 +1,571 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  CircuitBreaker,
+  DEFAULT_CIRCUIT_BREAKER_CONFIG,
+  type CircuitBreakerConfig,
+} from "../backends/circuit-breaker.js"
+
+// ──────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────
+
+function createBreaker(
+  config?: Partial<CircuitBreakerConfig>,
+  now?: () => number,
+): CircuitBreaker {
+  return new CircuitBreaker(config, now)
+}
+
+// ──────────────────────────────────────────────────
+// Default Config
+// ──────────────────────────────────────────────────
+
+describe("DEFAULT_CIRCUIT_BREAKER_CONFIG", () => {
+  it("has expected default values", () => {
+    expect(DEFAULT_CIRCUIT_BREAKER_CONFIG.failureThreshold).toBe(5)
+    expect(DEFAULT_CIRCUIT_BREAKER_CONFIG.windowMs).toBe(60_000)
+    expect(DEFAULT_CIRCUIT_BREAKER_CONFIG.openDurationMs).toBe(30_000)
+    expect(DEFAULT_CIRCUIT_BREAKER_CONFIG.halfOpenMaxAttempts).toBe(1)
+    expect(DEFAULT_CIRCUIT_BREAKER_CONFIG.successThresholdToClose).toBe(3)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Initial State
+// ──────────────────────────────────────────────────
+
+describe("CircuitBreaker — initial state", () => {
+  it("starts in CLOSED state", () => {
+    const breaker = createBreaker()
+    expect(breaker.getState()).toBe("CLOSED")
+  })
+
+  it("allows execution when CLOSED", () => {
+    const breaker = createBreaker()
+    expect(breaker.canExecute()).toBe(true)
+  })
+
+  it("initial stats are zeroed", () => {
+    const breaker = createBreaker()
+    const stats = breaker.getStats()
+    expect(stats.state).toBe("CLOSED")
+    expect(stats.windowFailureCount).toBe(0)
+    expect(stats.consecutiveHalfOpenSuccesses).toBe(0)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// CLOSED → OPEN transition
+// ──────────────────────────────────────────────────
+
+describe("CircuitBreaker — CLOSED → OPEN", () => {
+  it("trips after reaching failure threshold with transient errors", () => {
+    const breaker = createBreaker({ failureThreshold: 3 })
+
+    breaker.recordFailure("transient")
+    breaker.recordFailure("transient")
+    expect(breaker.getState()).toBe("CLOSED")
+
+    breaker.recordFailure("transient")
+    expect(breaker.getState()).toBe("OPEN")
+  })
+
+  it("trips after reaching failure threshold with resource errors", () => {
+    const breaker = createBreaker({ failureThreshold: 2 })
+
+    breaker.recordFailure("resource")
+    breaker.recordFailure("resource")
+    expect(breaker.getState()).toBe("OPEN")
+  })
+
+  it("does NOT count permanent errors toward threshold", () => {
+    const breaker = createBreaker({ failureThreshold: 2 })
+
+    breaker.recordFailure("permanent")
+    breaker.recordFailure("permanent")
+    breaker.recordFailure("permanent")
+    expect(breaker.getState()).toBe("CLOSED")
+  })
+
+  it("does NOT count timeout errors toward threshold", () => {
+    const breaker = createBreaker({ failureThreshold: 2 })
+
+    breaker.recordFailure("timeout")
+    breaker.recordFailure("timeout")
+    expect(breaker.getState()).toBe("CLOSED")
+  })
+
+  it("blocks execution when OPEN", () => {
+    const breaker = createBreaker({ failureThreshold: 1 })
+    breaker.recordFailure("transient")
+
+    expect(breaker.getState()).toBe("OPEN")
+    expect(breaker.canExecute()).toBe(false)
+  })
+
+  it("records failures with mixed classifications correctly", () => {
+    const breaker = createBreaker({ failureThreshold: 3 })
+
+    breaker.recordFailure("transient")   // counts
+    breaker.recordFailure("permanent")   // ignored
+    breaker.recordFailure("resource")    // counts
+    breaker.recordFailure("timeout")     // ignored
+    expect(breaker.getState()).toBe("CLOSED")
+
+    breaker.recordFailure("transient")   // counts → trip
+    expect(breaker.getState()).toBe("OPEN")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Sliding Window
+// ──────────────────────────────────────────────────
+
+describe("CircuitBreaker — sliding window", () => {
+  it("prunes failures outside the window", () => {
+    let time = 1000
+    const breaker = createBreaker(
+      { failureThreshold: 3, windowMs: 5000 },
+      () => time,
+    )
+
+    // Record 2 failures at t=1000
+    breaker.recordFailure("transient")
+    breaker.recordFailure("transient")
+
+    // Advance past window
+    time = 7000
+
+    // These old failures should be pruned
+    breaker.recordFailure("transient")
+    expect(breaker.getState()).toBe("CLOSED") // Only 1 failure in window
+
+    breaker.recordFailure("transient")
+    expect(breaker.getState()).toBe("CLOSED") // 2 failures in window
+
+    breaker.recordFailure("transient")
+    expect(breaker.getState()).toBe("OPEN") // 3 failures in window → trip
+  })
+
+  it("stats reflect current window only", () => {
+    let time = 0
+    const breaker = createBreaker(
+      { failureThreshold: 10, windowMs: 5000 },
+      () => time,
+    )
+
+    breaker.recordFailure("transient")
+    breaker.recordFailure("transient")
+
+    time = 6000
+
+    const stats = breaker.getStats()
+    expect(stats.windowFailureCount).toBe(0) // Pruned
+  })
+
+  it("successes in window count toward total calls", () => {
+    let time = 0
+    const breaker = createBreaker(
+      { failureThreshold: 10, windowMs: 5000 },
+      () => time,
+    )
+
+    breaker.recordSuccess()
+    breaker.recordSuccess()
+    breaker.recordFailure("transient")
+
+    const stats = breaker.getStats()
+    expect(stats.windowTotalCalls).toBe(3)
+    expect(stats.windowFailureCount).toBe(1)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// OPEN → HALF_OPEN transition
+// ──────────────────────────────────────────────────
+
+describe("CircuitBreaker — OPEN → HALF_OPEN", () => {
+  it("transitions to HALF_OPEN after openDurationMs", () => {
+    let time = 0
+    const breaker = createBreaker(
+      { failureThreshold: 1, openDurationMs: 5000 },
+      () => time,
+    )
+
+    breaker.recordFailure("transient")
+    expect(breaker.getState()).toBe("OPEN")
+
+    // Not yet
+    time = 4999
+    expect(breaker.getState()).toBe("OPEN")
+
+    // Now
+    time = 5000
+    expect(breaker.getState()).toBe("HALF_OPEN")
+  })
+
+  it("allows limited execution in HALF_OPEN", () => {
+    let time = 0
+    const breaker = createBreaker(
+      { failureThreshold: 1, openDurationMs: 1000, halfOpenMaxAttempts: 1 },
+      () => time,
+    )
+
+    breaker.recordFailure("transient")
+    time = 1000
+
+    expect(breaker.getState()).toBe("HALF_OPEN")
+    expect(breaker.canExecute()).toBe(true)
+  })
+
+  it("limits concurrent requests in HALF_OPEN", () => {
+    let time = 0
+    const breaker = createBreaker(
+      { failureThreshold: 1, openDurationMs: 1000, halfOpenMaxAttempts: 1 },
+      () => time,
+    )
+
+    breaker.recordFailure("transient")
+    time = 1000
+
+    expect(breaker.canExecute()).toBe(true)
+    breaker.acquireHalfOpenSlot()
+
+    // Slot is occupied
+    expect(breaker.canExecute()).toBe(false)
+  })
+
+  it("allows multiple concurrent requests when halfOpenMaxAttempts > 1", () => {
+    let time = 0
+    const breaker = createBreaker(
+      { failureThreshold: 1, openDurationMs: 1000, halfOpenMaxAttempts: 3 },
+      () => time,
+    )
+
+    breaker.recordFailure("transient")
+    time = 1000
+
+    expect(breaker.canExecute()).toBe(true)
+    breaker.acquireHalfOpenSlot()
+    expect(breaker.canExecute()).toBe(true)
+    breaker.acquireHalfOpenSlot()
+    expect(breaker.canExecute()).toBe(true)
+    breaker.acquireHalfOpenSlot()
+    expect(breaker.canExecute()).toBe(false)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// HALF_OPEN → CLOSED transition
+// ──────────────────────────────────────────────────
+
+describe("CircuitBreaker — HALF_OPEN → CLOSED", () => {
+  it("closes after consecutive successes reach threshold", () => {
+    let time = 0
+    const breaker = createBreaker(
+      {
+        failureThreshold: 1,
+        openDurationMs: 1000,
+        halfOpenMaxAttempts: 5,
+        successThresholdToClose: 3,
+      },
+      () => time,
+    )
+
+    breaker.recordFailure("transient")
+    time = 1000
+
+    expect(breaker.getState()).toBe("HALF_OPEN")
+
+    breaker.acquireHalfOpenSlot()
+    breaker.recordSuccess()
+    expect(breaker.getState()).toBe("HALF_OPEN")
+
+    breaker.acquireHalfOpenSlot()
+    breaker.recordSuccess()
+    expect(breaker.getState()).toBe("HALF_OPEN")
+
+    breaker.acquireHalfOpenSlot()
+    breaker.recordSuccess()
+    expect(breaker.getState()).toBe("CLOSED")
+  })
+
+  it("resets failure count after closing", () => {
+    let time = 0
+    const breaker = createBreaker(
+      {
+        failureThreshold: 1,
+        openDurationMs: 1000,
+        successThresholdToClose: 1,
+      },
+      () => time,
+    )
+
+    breaker.recordFailure("transient")
+    time = 1000
+
+    breaker.acquireHalfOpenSlot()
+    breaker.recordSuccess()
+    expect(breaker.getState()).toBe("CLOSED")
+
+    const stats = breaker.getStats()
+    expect(stats.windowFailureCount).toBe(0)
+    expect(stats.consecutiveHalfOpenSuccesses).toBe(0)
+  })
+
+  it("allows execution again after closing", () => {
+    let time = 0
+    const breaker = createBreaker(
+      {
+        failureThreshold: 1,
+        openDurationMs: 1000,
+        successThresholdToClose: 1,
+      },
+      () => time,
+    )
+
+    breaker.recordFailure("transient")
+    time = 1000
+
+    breaker.acquireHalfOpenSlot()
+    breaker.recordSuccess()
+    expect(breaker.canExecute()).toBe(true)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// HALF_OPEN → OPEN transition (failure during probe)
+// ──────────────────────────────────────────────────
+
+describe("CircuitBreaker — HALF_OPEN → OPEN", () => {
+  it("re-opens on failure during HALF_OPEN", () => {
+    let time = 0
+    const breaker = createBreaker(
+      { failureThreshold: 1, openDurationMs: 1000, successThresholdToClose: 3 },
+      () => time,
+    )
+
+    breaker.recordFailure("transient")
+    time = 1000
+    expect(breaker.getState()).toBe("HALF_OPEN")
+
+    breaker.acquireHalfOpenSlot()
+    breaker.recordFailure("transient")
+    expect(breaker.getState()).toBe("OPEN")
+  })
+
+  it("resets consecutive success count on failure", () => {
+    let time = 0
+    const breaker = createBreaker(
+      {
+        failureThreshold: 1,
+        openDurationMs: 1000,
+        halfOpenMaxAttempts: 5,
+        successThresholdToClose: 3,
+      },
+      () => time,
+    )
+
+    breaker.recordFailure("transient")
+    time = 1000
+
+    // 2 successes, then failure
+    breaker.acquireHalfOpenSlot()
+    breaker.recordSuccess()
+    breaker.acquireHalfOpenSlot()
+    breaker.recordSuccess()
+    breaker.acquireHalfOpenSlot()
+    breaker.recordFailure("transient")
+    expect(breaker.getState()).toBe("OPEN")
+
+    // Wait again to go half-open
+    time = 2000
+    expect(breaker.getState()).toBe("HALF_OPEN")
+
+    // Consecutive successes should be reset
+    const stats = breaker.getStats()
+    expect(stats.consecutiveHalfOpenSuccesses).toBe(0)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Full Lifecycle
+// ──────────────────────────────────────────────────
+
+describe("CircuitBreaker — full lifecycle", () => {
+  it("CLOSED → OPEN → HALF_OPEN → CLOSED", () => {
+    let time = 0
+    const breaker = createBreaker(
+      {
+        failureThreshold: 2,
+        openDurationMs: 5000,
+        successThresholdToClose: 2,
+      },
+      () => time,
+    )
+
+    // CLOSED
+    expect(breaker.getState()).toBe("CLOSED")
+    expect(breaker.canExecute()).toBe(true)
+
+    // Trip to OPEN
+    breaker.recordFailure("transient")
+    breaker.recordFailure("transient")
+    expect(breaker.getState()).toBe("OPEN")
+    expect(breaker.canExecute()).toBe(false)
+
+    // Transition to HALF_OPEN
+    time = 5000
+    expect(breaker.getState()).toBe("HALF_OPEN")
+    expect(breaker.canExecute()).toBe(true)
+
+    // Recover to CLOSED
+    breaker.acquireHalfOpenSlot()
+    breaker.recordSuccess()
+    breaker.acquireHalfOpenSlot()
+    breaker.recordSuccess()
+    expect(breaker.getState()).toBe("CLOSED")
+    expect(breaker.canExecute()).toBe(true)
+  })
+
+  it("CLOSED → OPEN → HALF_OPEN → OPEN → HALF_OPEN → CLOSED", () => {
+    let time = 0
+    const breaker = createBreaker(
+      {
+        failureThreshold: 1,
+        openDurationMs: 1000,
+        successThresholdToClose: 1,
+      },
+      () => time,
+    )
+
+    // CLOSED → OPEN
+    breaker.recordFailure("transient")
+    expect(breaker.getState()).toBe("OPEN")
+
+    // OPEN → HALF_OPEN
+    time = 1000
+    expect(breaker.getState()).toBe("HALF_OPEN")
+
+    // HALF_OPEN → OPEN (failure)
+    breaker.acquireHalfOpenSlot()
+    breaker.recordFailure("resource")
+    expect(breaker.getState()).toBe("OPEN")
+
+    // OPEN → HALF_OPEN again
+    time = 2000
+    expect(breaker.getState()).toBe("HALF_OPEN")
+
+    // HALF_OPEN → CLOSED (success)
+    breaker.acquireHalfOpenSlot()
+    breaker.recordSuccess()
+    expect(breaker.getState()).toBe("CLOSED")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// getStats
+// ──────────────────────────────────────────────────
+
+describe("CircuitBreaker — getStats()", () => {
+  it("reports correct stats after various operations", () => {
+    let time = 1000
+    const breaker = createBreaker(
+      { failureThreshold: 10, windowMs: 60_000 },
+      () => time,
+    )
+
+    breaker.recordSuccess()
+    breaker.recordSuccess()
+    breaker.recordFailure("transient")
+
+    const stats = breaker.getStats()
+    expect(stats.state).toBe("CLOSED")
+    expect(stats.windowFailureCount).toBe(1)
+    expect(stats.windowTotalCalls).toBe(3)
+    expect(stats.lastStateChange).toBeDefined()
+  })
+
+  it("lastStateChange updates on transitions", () => {
+    let time = 0
+    const breaker = createBreaker(
+      { failureThreshold: 1, openDurationMs: 1000 },
+      () => time,
+    )
+
+    const initialStats = breaker.getStats()
+    const initialChange = initialStats.lastStateChange
+
+    time = 500
+    breaker.recordFailure("transient")
+
+    const openStats = breaker.getStats()
+    expect(openStats.lastStateChange).not.toBe(initialChange)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Success in CLOSED state
+// ──────────────────────────────────────────────────
+
+describe("CircuitBreaker — recordSuccess() in CLOSED", () => {
+  it("does not change state", () => {
+    const breaker = createBreaker()
+    breaker.recordSuccess()
+    breaker.recordSuccess()
+    expect(breaker.getState()).toBe("CLOSED")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Edge cases
+// ──────────────────────────────────────────────────
+
+describe("CircuitBreaker — edge cases", () => {
+  it("handles zero failure threshold (immediate trip)", () => {
+    // With threshold=0, we need at least 0 failures to trip,
+    // but the >= check means any failure >= 0 should trip
+    // However, recordFailure prunes then checks, and failures starts at 1.
+    // With threshold 1, one failure trips immediately
+    const breaker = createBreaker({ failureThreshold: 1 })
+    breaker.recordFailure("transient")
+    expect(breaker.getState()).toBe("OPEN")
+  })
+
+  it("handles rapid success/failure alternation", () => {
+    const breaker = createBreaker({ failureThreshold: 3 })
+
+    breaker.recordSuccess()
+    breaker.recordFailure("transient")
+    breaker.recordSuccess()
+    breaker.recordFailure("transient")
+    breaker.recordSuccess()
+    breaker.recordFailure("transient")
+    expect(breaker.getState()).toBe("OPEN")
+  })
+
+  it("custom config overrides defaults", () => {
+    const breaker = createBreaker({
+      failureThreshold: 10,
+      windowMs: 120_000,
+      openDurationMs: 60_000,
+    })
+
+    // Should take 10 failures to trip
+    for (let i = 0; i < 9; i++) {
+      breaker.recordFailure("transient")
+    }
+    expect(breaker.getState()).toBe("CLOSED")
+
+    breaker.recordFailure("transient")
+    expect(breaker.getState()).toBe("OPEN")
+  })
+
+  it("acquireHalfOpenSlot is a no-op in CLOSED state", () => {
+    const breaker = createBreaker()
+    // Should not throw
+    breaker.acquireHalfOpenSlot()
+    expect(breaker.canExecute()).toBe(true)
+  })
+})

--- a/packages/shared/src/__tests__/provider-router.test.ts
+++ b/packages/shared/src/__tests__/provider-router.test.ts
@@ -1,0 +1,425 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { CircuitBreakerConfig } from "../backends/circuit-breaker.js"
+import { ProviderRouter, type ProviderEntry, type RoutingEvent } from "../backends/provider-router.js"
+import type {
+  BackendCapabilities,
+  BackendHealthReport,
+  ExecutionBackend,
+  ExecutionTask,
+} from "../backends/types.js"
+
+// ──────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────
+
+function createMockBackend(id: string): ExecutionBackend {
+  return {
+    backendId: id,
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({
+      backendId: id,
+      status: "healthy",
+      checkedAt: new Date().toISOString(),
+      latencyMs: 50,
+      details: {},
+    } satisfies BackendHealthReport),
+    executeTask: vi.fn().mockRejectedValue(new Error("Not implemented in mock")),
+    getCapabilities: vi.fn().mockReturnValue({
+      supportsStreaming: true,
+      supportsFileEdit: true,
+      supportsShellExecution: true,
+      reportsTokenUsage: true,
+      supportsCancellation: true,
+      supportedGoalTypes: ["code_edit"],
+      maxContextTokens: 200_000,
+    } satisfies BackendCapabilities),
+  }
+}
+
+function makeTask(): ExecutionTask {
+  return {
+    id: "task-001",
+    jobId: "job-001",
+    agentId: "agent-001",
+    instruction: {
+      prompt: "Do something",
+      goalType: "code_edit",
+    },
+    context: {
+      workspacePath: "/workspace",
+      systemPrompt: "",
+      memories: [],
+      relevantFiles: {},
+      environment: {},
+    },
+    constraints: {
+      timeoutMs: 60_000,
+      maxTokens: 200_000,
+      model: "claude-sonnet-4-5-20250929",
+      allowedTools: [],
+      deniedTools: [],
+      maxTurns: 10,
+      networkAccess: false,
+      shellAccess: true,
+    },
+  }
+}
+
+function createRouter(now?: () => number): ProviderRouter {
+  return new ProviderRouter(now)
+}
+
+function addProvider(
+  router: ProviderRouter,
+  id: string,
+  priority: number,
+  config?: Partial<CircuitBreakerConfig>,
+): ExecutionBackend {
+  const backend = createMockBackend(id)
+  router.addProvider({ providerId: id, backend, priority, circuitBreakerConfig: config })
+  return backend
+}
+
+// ──────────────────────────────────────────────────
+// Primary Selection
+// ──────────────────────────────────────────────────
+
+describe("ProviderRouter — primary selection", () => {
+  it("routes to highest priority provider (lowest number)", () => {
+    const router = createRouter()
+    const backendA = addProvider(router, "provider-a", 1)
+    addProvider(router, "provider-b", 2)
+
+    const result = router.route(makeTask())
+    expect(result.providerId).toBe("provider-a")
+    expect(result.backend).toBe(backendA)
+  })
+
+  it("routes to sole provider", () => {
+    const router = createRouter()
+    const backend = addProvider(router, "only-one", 0)
+
+    const result = router.route(makeTask())
+    expect(result.providerId).toBe("only-one")
+    expect(result.backend).toBe(backend)
+  })
+
+  it("sorts providers by priority regardless of add order", () => {
+    const router = createRouter()
+    addProvider(router, "low-priority", 10)
+    const highPrio = addProvider(router, "high-priority", 1)
+    addProvider(router, "mid-priority", 5)
+
+    const result = router.route(makeTask())
+    expect(result.providerId).toBe("high-priority")
+    expect(result.backend).toBe(highPrio)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Failover on circuit-open
+// ──────────────────────────────────────────────────
+
+describe("ProviderRouter — failover on circuit-open", () => {
+  it("skips provider with OPEN circuit and routes to next", () => {
+    let time = 0
+    const router = createRouter(() => time)
+    addProvider(router, "primary", 1, { failureThreshold: 1, openDurationMs: 30_000 })
+    const fallback = addProvider(router, "fallback", 2)
+
+    // Trip primary
+    router.recordOutcome("primary", false, "transient")
+
+    const result = router.route(makeTask())
+    expect(result.providerId).toBe("fallback")
+    expect(result.backend).toBe(fallback)
+  })
+
+  it("emits route_skipped event when skipping OPEN circuit", () => {
+    let time = 0
+    const router = createRouter(() => time)
+    addProvider(router, "primary", 1, { failureThreshold: 1, openDurationMs: 30_000 })
+    addProvider(router, "fallback", 2)
+
+    router.recordOutcome("primary", false, "transient")
+
+    const events: RoutingEvent[] = []
+    router.onRoutingEvent((e) => events.push(e))
+
+    router.route(makeTask())
+
+    const skipped = events.find((e) => e.type === "route_skipped")
+    expect(skipped).toBeDefined()
+    expect(skipped!.providerId).toBe("primary")
+    expect(skipped!.reason).toBe("circuit_open")
+  })
+
+  it("returns to primary after circuit recovers", () => {
+    let time = 0
+    const router = createRouter(() => time)
+    const primary = addProvider(router, "primary", 1, {
+      failureThreshold: 1,
+      openDurationMs: 1000,
+      successThresholdToClose: 1,
+    })
+    addProvider(router, "fallback", 2)
+
+    // Trip primary
+    router.recordOutcome("primary", false, "transient")
+
+    // Wait for half-open
+    time = 1000
+    const halfOpenResult = router.route(makeTask())
+    expect(halfOpenResult.providerId).toBe("primary")
+
+    // Record success → close
+    router.recordOutcome("primary", true)
+
+    const closedResult = router.route(makeTask())
+    expect(closedResult.providerId).toBe("primary")
+    expect(closedResult.backend).toBe(primary)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// All circuits open
+// ──────────────────────────────────────────────────
+
+describe("ProviderRouter — all circuits open", () => {
+  it("throws when all circuits are open", () => {
+    let time = 0
+    const router = createRouter(() => time)
+    addProvider(router, "a", 1, { failureThreshold: 1, openDurationMs: 30_000 })
+    addProvider(router, "b", 2, { failureThreshold: 1, openDurationMs: 30_000 })
+
+    router.recordOutcome("a", false, "transient")
+    router.recordOutcome("b", false, "transient")
+
+    expect(() => router.route(makeTask())).toThrow(
+      "All provider circuits are open",
+    )
+  })
+
+  it("emits route_exhausted event when all circuits open", () => {
+    let time = 0
+    const router = createRouter(() => time)
+    addProvider(router, "a", 1, { failureThreshold: 1, openDurationMs: 30_000 })
+
+    router.recordOutcome("a", false, "transient")
+
+    const events: RoutingEvent[] = []
+    router.onRoutingEvent((e) => events.push(e))
+
+    try {
+      router.route(makeTask())
+    } catch {
+      // expected
+    }
+
+    const exhausted = events.find((e) => e.type === "route_exhausted")
+    expect(exhausted).toBeDefined()
+    expect(exhausted!.reason).toBe("all_circuits_open")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Half-open behavior
+// ──────────────────────────────────────────────────
+
+describe("ProviderRouter — half-open behavior", () => {
+  it("skips half-open provider at capacity", () => {
+    let time = 0
+    const router = createRouter(() => time)
+    addProvider(router, "primary", 1, {
+      failureThreshold: 1,
+      openDurationMs: 1000,
+      halfOpenMaxAttempts: 1,
+    })
+    const fallback = addProvider(router, "fallback", 2)
+
+    // Trip primary
+    router.recordOutcome("primary", false, "transient")
+
+    // Go half-open
+    time = 1000
+
+    // First request takes the half-open slot
+    const first = router.route(makeTask())
+    expect(first.providerId).toBe("primary")
+
+    // Second request should failover — slot is occupied
+    const second = router.route(makeTask())
+    expect(second.providerId).toBe("fallback")
+    expect(second.backend).toBe(fallback)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// routeWithFailover
+// ──────────────────────────────────────────────────
+
+describe("ProviderRouter — routeWithFailover", () => {
+  it("selects primary when healthy", () => {
+    const router = createRouter()
+    const primary = addProvider(router, "primary", 1)
+    addProvider(router, "secondary", 2)
+
+    const result = router.routeWithFailover(makeTask())
+    expect(result.providerId).toBe("primary")
+    expect(result.backend).toBe(primary)
+  })
+
+  it("emits failover event when falling back", () => {
+    let time = 0
+    const router = createRouter(() => time)
+    addProvider(router, "primary", 1, { failureThreshold: 1, openDurationMs: 30_000 })
+    addProvider(router, "secondary", 2)
+
+    router.recordOutcome("primary", false, "transient")
+
+    const events: RoutingEvent[] = []
+    router.onRoutingEvent((e) => events.push(e))
+
+    router.routeWithFailover(makeTask())
+
+    const failover = events.find((e) => e.type === "route_failover")
+    expect(failover).toBeDefined()
+    expect(failover!.providerId).toBe("secondary")
+    expect(failover!.reason).toContain("primary")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// recordOutcome
+// ──────────────────────────────────────────────────
+
+describe("ProviderRouter — recordOutcome", () => {
+  it("records success on circuit breaker", () => {
+    const router = createRouter()
+    addProvider(router, "provider", 1)
+
+    router.recordOutcome("provider", true)
+
+    const states = router.getCircuitStates()
+    expect(states.get("provider")).toBe("CLOSED")
+  })
+
+  it("records failure on circuit breaker", () => {
+    const router = createRouter()
+    addProvider(router, "provider", 1, { failureThreshold: 1 })
+
+    router.recordOutcome("provider", false, "transient")
+
+    const states = router.getCircuitStates()
+    expect(states.get("provider")).toBe("OPEN")
+  })
+
+  it("ignores outcome for unknown provider", () => {
+    const router = createRouter()
+    // Should not throw
+    router.recordOutcome("unknown", true)
+    router.recordOutcome("unknown", false, "transient")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// getCircuitStates
+// ──────────────────────────────────────────────────
+
+describe("ProviderRouter — getCircuitStates", () => {
+  it("returns state for all providers", () => {
+    const router = createRouter()
+    addProvider(router, "a", 1, { failureThreshold: 1 })
+    addProvider(router, "b", 2)
+
+    router.recordOutcome("a", false, "transient")
+
+    const states = router.getCircuitStates()
+    expect(states.size).toBe(2)
+    expect(states.get("a")).toBe("OPEN")
+    expect(states.get("b")).toBe("CLOSED")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// getCircuitBreaker
+// ──────────────────────────────────────────────────
+
+describe("ProviderRouter — getCircuitBreaker", () => {
+  it("returns the breaker for a known provider", () => {
+    const router = createRouter()
+    addProvider(router, "a", 1)
+
+    const breaker = router.getCircuitBreaker("a")
+    expect(breaker).toBeDefined()
+    expect(breaker!.getState()).toBe("CLOSED")
+  })
+
+  it("returns undefined for unknown provider", () => {
+    const router = createRouter()
+    expect(router.getCircuitBreaker("unknown")).toBeUndefined()
+  })
+})
+
+// ──────────────────────────────────────────────────
+// getProviderIds
+// ──────────────────────────────────────────────────
+
+describe("ProviderRouter — getProviderIds", () => {
+  it("returns all provider IDs in priority order", () => {
+    const router = createRouter()
+    addProvider(router, "c", 3)
+    addProvider(router, "a", 1)
+    addProvider(router, "b", 2)
+
+    expect(router.getProviderIds()).toEqual(["a", "b", "c"])
+  })
+})
+
+// ──────────────────────────────────────────────────
+// Event listeners
+// ──────────────────────────────────────────────────
+
+describe("ProviderRouter — event listeners", () => {
+  it("emits route_selected on successful routing", () => {
+    const router = createRouter()
+    addProvider(router, "provider", 1)
+
+    const events: RoutingEvent[] = []
+    router.onRoutingEvent((e) => events.push(e))
+
+    router.route(makeTask())
+
+    expect(events).toHaveLength(1)
+    expect(events[0]!.type).toBe("route_selected")
+    expect(events[0]!.providerId).toBe("provider")
+  })
+
+  it("supports multiple listeners", () => {
+    const router = createRouter()
+    addProvider(router, "provider", 1)
+
+    const events1: RoutingEvent[] = []
+    const events2: RoutingEvent[] = []
+    router.onRoutingEvent((e) => events1.push(e))
+    router.onRoutingEvent((e) => events2.push(e))
+
+    router.route(makeTask())
+
+    expect(events1).toHaveLength(1)
+    expect(events2).toHaveLength(1)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// No providers
+// ──────────────────────────────────────────────────
+
+describe("ProviderRouter — no providers", () => {
+  it("throws when no providers are registered", () => {
+    const router = createRouter()
+    expect(() => router.route(makeTask())).toThrow("All provider circuits are open")
+  })
+})

--- a/packages/shared/src/__tests__/registry-router.test.ts
+++ b/packages/shared/src/__tests__/registry-router.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { BackendRegistry } from "../backends/registry.js"
+import type {
+  BackendCapabilities,
+  BackendHealthReport,
+  ExecutionBackend,
+  ExecutionTask,
+} from "../backends/types.js"
+
+// ──────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────
+
+function createMockBackend(id: string): ExecutionBackend {
+  return {
+    backendId: id,
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({
+      backendId: id,
+      status: "healthy",
+      checkedAt: new Date().toISOString(),
+      latencyMs: 50,
+      details: {},
+    } satisfies BackendHealthReport),
+    executeTask: vi.fn().mockRejectedValue(new Error("Not implemented")),
+    getCapabilities: vi.fn().mockReturnValue({
+      supportsStreaming: true,
+      supportsFileEdit: true,
+      supportsShellExecution: true,
+      reportsTokenUsage: true,
+      supportsCancellation: true,
+      supportedGoalTypes: ["code_edit"],
+      maxContextTokens: 200_000,
+    } satisfies BackendCapabilities),
+  }
+}
+
+function makeTask(): ExecutionTask {
+  return {
+    id: "task-001",
+    jobId: "job-001",
+    agentId: "agent-001",
+    instruction: { prompt: "Do something", goalType: "code_edit" },
+    context: {
+      workspacePath: "/workspace",
+      systemPrompt: "",
+      memories: [],
+      relevantFiles: {},
+      environment: {},
+    },
+    constraints: {
+      timeoutMs: 60_000,
+      maxTokens: 200_000,
+      model: "test-model",
+      allowedTools: [],
+      deniedTools: [],
+      maxTurns: 10,
+      networkAccess: false,
+      shellAccess: true,
+    },
+  }
+}
+
+// ──────────────────────────────────────────────────
+// Circuit Breaker per Backend
+// ──────────────────────────────────────────────────
+
+describe("BackendRegistry — circuit breakers", () => {
+  it("creates a circuit breaker for each registered backend", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("a"))
+    await registry.register(createMockBackend("b"))
+
+    const breaker = registry.getCircuitBreaker("a")
+    expect(breaker).toBeDefined()
+    expect(breaker!.getState()).toBe("CLOSED")
+
+    const breakerB = registry.getCircuitBreaker("b")
+    expect(breakerB).toBeDefined()
+  })
+
+  it("returns undefined circuit breaker for unregistered backend", async () => {
+    const registry = new BackendRegistry()
+    expect(registry.getCircuitBreaker("nonexistent")).toBeUndefined()
+  })
+
+  it("getCircuitStates returns state for all backends", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("a"), {}, 1, { failureThreshold: 1 })
+    await registry.register(createMockBackend("b"))
+
+    registry.recordOutcome("a", false, "transient")
+
+    const states = registry.getCircuitStates()
+    expect(states.size).toBe(2)
+    expect(states.get("a")).toBe("OPEN")
+    expect(states.get("b")).toBe("CLOSED")
+  })
+
+  it("getCircuitStats returns stats for all backends", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("a"))
+
+    registry.recordOutcome("a", true)
+
+    const stats = registry.getCircuitStats()
+    expect(stats.size).toBe(1)
+    const statA = stats.get("a")!
+    expect(statA.state).toBe("CLOSED")
+    expect(statA.windowTotalCalls).toBeGreaterThanOrEqual(1)
+  })
+
+  it("accepts custom circuit breaker config per backend", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("a"), {}, 1, { failureThreshold: 2 })
+
+    // First failure should not trip
+    registry.recordOutcome("a", false, "transient")
+    expect(registry.getCircuitBreaker("a")!.getState()).toBe("CLOSED")
+
+    // Second failure should trip
+    registry.recordOutcome("a", false, "transient")
+    expect(registry.getCircuitBreaker("a")!.getState()).toBe("OPEN")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// recordOutcome (direct, no router)
+// ──────────────────────────────────────────────────
+
+describe("BackendRegistry — recordOutcome (direct)", () => {
+  it("records success on circuit breaker", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("a"))
+
+    registry.recordOutcome("a", true)
+    expect(registry.getCircuitBreaker("a")!.getState()).toBe("CLOSED")
+  })
+
+  it("records failure on circuit breaker", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("a"), {}, 1, { failureThreshold: 1 })
+
+    registry.recordOutcome("a", false, "transient")
+    expect(registry.getCircuitBreaker("a")!.getState()).toBe("OPEN")
+  })
+
+  it("ignores outcome for unknown backend", async () => {
+    const registry = new BackendRegistry()
+    // Should not throw
+    registry.recordOutcome("nonexistent", true)
+    registry.recordOutcome("nonexistent", false, "transient")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// routeTask (without router)
+// ──────────────────────────────────────────────────
+
+describe("BackendRegistry — routeTask (no router)", () => {
+  it("returns default backend when no preferred ID", async () => {
+    const registry = new BackendRegistry()
+    const backend = createMockBackend("default-backend")
+    await registry.register(backend)
+
+    const result = registry.routeTask(makeTask())
+    expect(result.providerId).toBe("default-backend")
+    expect(result.backend).toBe(backend)
+  })
+
+  it("returns preferred backend by ID", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("a"))
+    const backendB = createMockBackend("b")
+    await registry.register(backendB)
+
+    const result = registry.routeTask(makeTask(), "b")
+    expect(result.providerId).toBe("b")
+    expect(result.backend).toBe(backendB)
+  })
+
+  it("throws when no backend available", async () => {
+    const registry = new BackendRegistry()
+
+    expect(() => registry.routeTask(makeTask())).toThrow(
+      "No execution backend available",
+    )
+  })
+
+  it("throws when preferred backend not found", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("a"))
+
+    expect(() => registry.routeTask(makeTask(), "nonexistent")).toThrow(
+      "No execution backend available (requested: nonexistent)",
+    )
+  })
+})
+
+// ──────────────────────────────────────────────────
+// configureRouter and routeTask (with router)
+// ──────────────────────────────────────────────────
+
+describe("BackendRegistry — configureRouter", () => {
+  it("creates router with all registered backends", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("a"))
+    await registry.register(createMockBackend("b"))
+
+    const router = registry.configureRouter()
+    expect(router).toBeDefined()
+    expect(router.getProviderIds()).toEqual(["a", "b"])
+  })
+
+  it("routeTask uses router when configured", async () => {
+    const registry = new BackendRegistry()
+    const backendA = createMockBackend("a")
+    await registry.register(backendA)
+    await registry.register(createMockBackend("b"))
+
+    registry.configureRouter()
+
+    const result = registry.routeTask(makeTask())
+    expect(result.providerId).toBe("a")
+    expect(result.backend).toBe(backendA)
+  })
+
+  it("router failover works through registry", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("primary"), {}, 1, { failureThreshold: 1 })
+    const fallback = createMockBackend("fallback")
+    await registry.register(fallback)
+
+    const router = registry.configureRouter()
+
+    // Trip primary circuit via router
+    router.recordOutcome("primary", false, "transient")
+
+    const result = registry.routeTask(makeTask())
+    expect(result.providerId).toBe("fallback")
+    expect(result.backend).toBe(fallback)
+  })
+
+  it("getRouter returns configured router", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("a"))
+
+    expect(registry.getRouter()).toBeUndefined()
+
+    registry.configureRouter()
+    expect(registry.getRouter()).toBeDefined()
+  })
+
+  it("recordOutcome goes through router when configured", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("a"), {}, 1, { failureThreshold: 1 })
+    await registry.register(createMockBackend("b"))
+
+    const router = registry.configureRouter()
+
+    registry.recordOutcome("a", false, "transient")
+
+    // Verify via router's circuit state
+    const states = router.getCircuitStates()
+    expect(states.get("a")).toBe("OPEN")
+  })
+
+  it("accepts external router", async () => {
+    const registry = new BackendRegistry()
+    const backendA = createMockBackend("a")
+    await registry.register(backendA)
+
+    const { ProviderRouter } = await import("../backends/provider-router.js")
+    const externalRouter = new ProviderRouter()
+    externalRouter.addProvider({ providerId: "a", backend: backendA, priority: 1 })
+
+    registry.configureRouter(externalRouter)
+
+    expect(registry.getRouter()).toBe(externalRouter)
+    const result = registry.routeTask(makeTask())
+    expect(result.providerId).toBe("a")
+  })
+})
+
+// ──────────────────────────────────────────────────
+// stopAll clears circuit breakers and router
+// ──────────────────────────────────────────────────
+
+describe("BackendRegistry — stopAll with circuit breakers", () => {
+  it("clears circuit breakers on stopAll", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("a"))
+
+    expect(registry.getCircuitBreaker("a")).toBeDefined()
+
+    await registry.stopAll()
+
+    expect(registry.getCircuitBreaker("a")).toBeUndefined()
+  })
+
+  it("clears router on stopAll", async () => {
+    const registry = new BackendRegistry()
+    await registry.register(createMockBackend("a"))
+    registry.configureRouter()
+
+    expect(registry.getRouter()).toBeDefined()
+
+    await registry.stopAll()
+
+    expect(registry.getRouter()).toBeUndefined()
+  })
+})

--- a/packages/shared/src/backends/circuit-breaker.ts
+++ b/packages/shared/src/backends/circuit-breaker.ts
@@ -1,0 +1,187 @@
+/**
+ * Circuit Breaker
+ *
+ * Per-provider sliding-window circuit breaker with three states:
+ *   CLOSED  (healthy)  → requests pass through normally
+ *   OPEN    (tripped)  → requests immediately fail, no calls to backend
+ *   HALF_OPEN (probing) → limited canary traffic to test recovery
+ *
+ * See: docs/issues/098-multi-provider-routing.md
+ */
+
+// ──────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────
+
+export type CircuitState = "CLOSED" | "OPEN" | "HALF_OPEN"
+
+export interface CircuitBreakerConfig {
+  /** Number of failures in window to trip the breaker. */
+  failureThreshold: number
+  /** Sliding window duration (ms). */
+  windowMs: number
+  /** How long to stay OPEN before transitioning to HALF_OPEN (ms). */
+  openDurationMs: number
+  /** Max concurrent requests allowed in HALF_OPEN state. */
+  halfOpenMaxAttempts: number
+  /** Consecutive successes in HALF_OPEN needed to close the breaker. */
+  successThresholdToClose: number
+}
+
+export interface CircuitStats {
+  state: CircuitState
+  windowFailureCount: number
+  windowTotalCalls: number
+  consecutiveHalfOpenSuccesses: number
+  lastStateChange: string
+}
+
+export const DEFAULT_CIRCUIT_BREAKER_CONFIG: CircuitBreakerConfig = {
+  failureThreshold: 5,
+  windowMs: 60_000,
+  openDurationMs: 30_000,
+  halfOpenMaxAttempts: 1,
+  successThresholdToClose: 3,
+}
+
+// ──────────────────────────────────────────────────
+// Circuit Breaker
+// ──────────────────────────────────────────────────
+
+interface TimestampedFailure {
+  timestamp: number
+  classification: string
+}
+
+export class CircuitBreaker {
+  private state: CircuitState = "CLOSED"
+  private failures: TimestampedFailure[] = []
+  private successes: number[] = []
+  private lastStateChange: number
+  private openedAt: number | null = null
+  private halfOpenActive = 0
+  private consecutiveHalfOpenSuccesses = 0
+  private readonly config: CircuitBreakerConfig
+  private readonly now: () => number
+
+  constructor(config?: Partial<CircuitBreakerConfig>, now?: () => number) {
+    this.config = { ...DEFAULT_CIRCUIT_BREAKER_CONFIG, ...config }
+    this.now = now ?? Date.now
+    this.lastStateChange = this.now()
+  }
+
+  canExecute(): boolean {
+    this.maybeTransition()
+
+    switch (this.state) {
+      case "CLOSED":
+        return true
+      case "OPEN":
+        return false
+      case "HALF_OPEN":
+        return this.halfOpenActive < this.config.halfOpenMaxAttempts
+    }
+  }
+
+  recordSuccess(): void {
+    this.maybeTransition()
+    const now = this.now()
+    this.successes.push(now)
+
+    if (this.state === "HALF_OPEN") {
+      this.halfOpenActive = Math.max(0, this.halfOpenActive - 1)
+      this.consecutiveHalfOpenSuccesses++
+
+      if (this.consecutiveHalfOpenSuccesses >= this.config.successThresholdToClose) {
+        this.transitionTo("CLOSED")
+      }
+    }
+  }
+
+  recordFailure(classification: string): void {
+    this.maybeTransition()
+    const now = this.now()
+
+    // Only count transient/retryable failures for tripping the breaker
+    if (classification !== "transient" && classification !== "resource") {
+      return
+    }
+
+    this.failures.push({ timestamp: now, classification })
+
+    if (this.state === "HALF_OPEN") {
+      this.halfOpenActive = Math.max(0, this.halfOpenActive - 1)
+      this.consecutiveHalfOpenSuccesses = 0
+      this.transitionTo("OPEN")
+      return
+    }
+
+    if (this.state === "CLOSED") {
+      this.pruneWindow()
+      if (this.failures.length >= this.config.failureThreshold) {
+        this.transitionTo("OPEN")
+      }
+    }
+  }
+
+  getState(): CircuitState {
+    this.maybeTransition()
+    return this.state
+  }
+
+  getStats(): CircuitStats {
+    this.maybeTransition()
+    this.pruneWindow()
+
+    return {
+      state: this.state,
+      windowFailureCount: this.failures.length,
+      windowTotalCalls: this.failures.length + this.successes.filter(
+        (t) => t > this.now() - this.config.windowMs,
+      ).length,
+      consecutiveHalfOpenSuccesses: this.consecutiveHalfOpenSuccesses,
+      lastStateChange: new Date(this.lastStateChange).toISOString(),
+    }
+  }
+
+  /** Track that a half-open request has been dispatched (occupies a slot). */
+  acquireHalfOpenSlot(): void {
+    this.maybeTransition()
+    if (this.state === "HALF_OPEN") {
+      this.halfOpenActive++
+    }
+  }
+
+  private maybeTransition(): void {
+    if (this.state === "OPEN" && this.openedAt !== null) {
+      const elapsed = this.now() - this.openedAt
+      if (elapsed >= this.config.openDurationMs) {
+        this.transitionTo("HALF_OPEN")
+      }
+    }
+  }
+
+  private transitionTo(newState: CircuitState): void {
+    this.state = newState
+    this.lastStateChange = this.now()
+
+    if (newState === "OPEN") {
+      this.openedAt = this.now()
+    } else if (newState === "CLOSED") {
+      this.openedAt = null
+      this.failures = []
+      this.successes = []
+      this.halfOpenActive = 0
+      this.consecutiveHalfOpenSuccesses = 0
+    } else if (newState === "HALF_OPEN") {
+      this.halfOpenActive = 0
+      this.consecutiveHalfOpenSuccesses = 0
+    }
+  }
+
+  private pruneWindow(): void {
+    const cutoff = this.now() - this.config.windowMs
+    this.failures = this.failures.filter((f) => f.timestamp > cutoff)
+    this.successes = this.successes.filter((t) => t > cutoff)
+  }
+}

--- a/packages/shared/src/backends/index.ts
+++ b/packages/shared/src/backends/index.ts
@@ -1,4 +1,18 @@
 export {
+  CircuitBreaker,
+  DEFAULT_CIRCUIT_BREAKER_CONFIG,
+  type CircuitBreakerConfig,
+  type CircuitState,
+  type CircuitStats,
+} from "./circuit-breaker.js"
+export {
+  ProviderRouter,
+  type ProviderEntry,
+  type RouteResult,
+  type RoutingEvent,
+  type RoutingEventListener,
+} from "./provider-router.js"
+export {
   BackendRegistry,
   BackendSemaphore,
   CachedHealthCheck,

--- a/packages/shared/src/backends/provider-router.ts
+++ b/packages/shared/src/backends/provider-router.ts
@@ -1,0 +1,216 @@
+/**
+ * Provider Router
+ *
+ * Routes execution requests across multiple backends with failover.
+ * Uses circuit breakers to skip unhealthy providers and tries the
+ * next provider in priority order on failure.
+ *
+ * See: docs/issues/098-multi-provider-routing.md
+ */
+
+import { CircuitBreaker, type CircuitBreakerConfig, type CircuitState } from "./circuit-breaker.js"
+import type { ExecutionBackend, ExecutionTask } from "./types.js"
+
+// ──────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────
+
+export interface ProviderEntry {
+  providerId: string
+  backend: ExecutionBackend
+  priority: number
+  circuitBreakerConfig?: Partial<CircuitBreakerConfig>
+}
+
+export interface RouteResult {
+  backend: ExecutionBackend
+  providerId: string
+}
+
+export interface RoutingEvent {
+  type: "route_selected" | "route_failover" | "route_skipped" | "route_exhausted"
+  providerId: string
+  reason?: string
+  timestamp: string
+}
+
+export type RoutingEventListener = (event: RoutingEvent) => void
+
+// ──────────────────────────────────────────────────
+// Provider Router
+// ──────────────────────────────────────────────────
+
+export class ProviderRouter {
+  private readonly providers: ProviderEntry[] = []
+  private readonly breakers = new Map<string, CircuitBreaker>()
+  private readonly listeners: RoutingEventListener[] = []
+  private readonly now: () => number
+
+  constructor(now?: () => number) {
+    this.now = now ?? Date.now
+  }
+
+  addProvider(entry: ProviderEntry): void {
+    this.providers.push(entry)
+    // Keep sorted by priority (lower = higher priority)
+    this.providers.sort((a, b) => a.priority - b.priority)
+
+    if (!this.breakers.has(entry.providerId)) {
+      this.breakers.set(
+        entry.providerId,
+        new CircuitBreaker(entry.circuitBreakerConfig, this.now),
+      )
+    }
+  }
+
+  route(_task: ExecutionTask): RouteResult {
+    const sorted = this.providers
+
+    for (const entry of sorted) {
+      const breaker = this.breakers.get(entry.providerId)!
+      const state = breaker.getState()
+
+      if (state === "OPEN") {
+        this.emit({
+          type: "route_skipped",
+          providerId: entry.providerId,
+          reason: "circuit_open",
+          timestamp: new Date(this.now()).toISOString(),
+        })
+        continue
+      }
+
+      if (state === "HALF_OPEN" && !breaker.canExecute()) {
+        this.emit({
+          type: "route_skipped",
+          providerId: entry.providerId,
+          reason: "half_open_at_capacity",
+          timestamp: new Date(this.now()).toISOString(),
+        })
+        continue
+      }
+
+      // Acquire half-open slot if needed
+      if (state === "HALF_OPEN") {
+        breaker.acquireHalfOpenSlot()
+      }
+
+      this.emit({
+        type: "route_selected",
+        providerId: entry.providerId,
+        timestamp: new Date(this.now()).toISOString(),
+      })
+
+      return { backend: entry.backend, providerId: entry.providerId }
+    }
+
+    // All circuits are open
+    this.emit({
+      type: "route_exhausted",
+      providerId: "",
+      reason: "all_circuits_open",
+      timestamp: new Date(this.now()).toISOString(),
+    })
+
+    throw new Error("All provider circuits are open — no backend available for execution")
+  }
+
+  routeWithFailover(task: ExecutionTask): RouteResult {
+    const sorted = this.providers
+    const skipped: string[] = []
+
+    for (const entry of sorted) {
+      const breaker = this.breakers.get(entry.providerId)!
+      const state = breaker.getState()
+
+      if (state === "OPEN") {
+        this.emit({
+          type: "route_skipped",
+          providerId: entry.providerId,
+          reason: "circuit_open",
+          timestamp: new Date(this.now()).toISOString(),
+        })
+        skipped.push(entry.providerId)
+        continue
+      }
+
+      if (state === "HALF_OPEN" && !breaker.canExecute()) {
+        this.emit({
+          type: "route_skipped",
+          providerId: entry.providerId,
+          reason: "half_open_at_capacity",
+          timestamp: new Date(this.now()).toISOString(),
+        })
+        skipped.push(entry.providerId)
+        continue
+      }
+
+      if (state === "HALF_OPEN") {
+        breaker.acquireHalfOpenSlot()
+      }
+
+      if (skipped.length > 0) {
+        this.emit({
+          type: "route_failover",
+          providerId: entry.providerId,
+          reason: `failover from ${skipped[skipped.length - 1]}`,
+          timestamp: new Date(this.now()).toISOString(),
+        })
+      } else {
+        this.emit({
+          type: "route_selected",
+          providerId: entry.providerId,
+          timestamp: new Date(this.now()).toISOString(),
+        })
+      }
+
+      return { backend: entry.backend, providerId: entry.providerId }
+    }
+
+    this.emit({
+      type: "route_exhausted",
+      providerId: "",
+      reason: "all_circuits_open",
+      timestamp: new Date(this.now()).toISOString(),
+    })
+
+    throw new Error("All provider circuits are open — no backend available for execution")
+  }
+
+  recordOutcome(providerId: string, success: boolean, classification?: string): void {
+    const breaker = this.breakers.get(providerId)
+    if (!breaker) return
+
+    if (success) {
+      breaker.recordSuccess()
+    } else {
+      breaker.recordFailure(classification ?? "transient")
+    }
+  }
+
+  getCircuitStates(): Map<string, CircuitState> {
+    const states = new Map<string, CircuitState>()
+    for (const [id, breaker] of this.breakers) {
+      states.set(id, breaker.getState())
+    }
+    return states
+  }
+
+  getCircuitBreaker(providerId: string): CircuitBreaker | undefined {
+    return this.breakers.get(providerId)
+  }
+
+  onRoutingEvent(listener: RoutingEventListener): void {
+    this.listeners.push(listener)
+  }
+
+  getProviderIds(): string[] {
+    return this.providers.map((p) => p.providerId)
+  }
+
+  private emit(event: RoutingEvent): void {
+    for (const listener of this.listeners) {
+      listener(event)
+    }
+  }
+}

--- a/packages/shared/src/backends/registry.ts
+++ b/packages/shared/src/backends/registry.ts
@@ -7,7 +7,9 @@
  * See: docs/spikes/037-execution-backends.md — "Artifact: Backend Registry Pattern"
  */
 
-import type { BackendHealthReport, ExecutionBackend } from "./types.js"
+import { CircuitBreaker, type CircuitBreakerConfig, type CircuitState, type CircuitStats } from "./circuit-breaker.js"
+import { ProviderRouter, type RouteResult } from "./provider-router.js"
+import type { BackendHealthReport, ExecutionBackend, ExecutionTask } from "./types.js"
 
 // ──────────────────────────────────────────────────
 // Semaphore for WIP Limiting
@@ -104,7 +106,10 @@ export class BackendRegistry {
   private readonly backends = new Map<string, ExecutionBackend>()
   private readonly healthChecks = new Map<string, CachedHealthCheck>()
   private readonly semaphores = new Map<string, BackendSemaphore>()
+  private readonly circuitBreakers = new Map<string, CircuitBreaker>()
+  private readonly circuitBreakerConfigs = new Map<string, Partial<CircuitBreakerConfig> | undefined>()
   private defaultBackendId: string | undefined
+  private router: ProviderRouter | undefined
 
   /**
    * Register a backend. Calls backend.start() to initialize it.
@@ -113,6 +118,7 @@ export class BackendRegistry {
     backend: ExecutionBackend,
     config: Record<string, unknown> = {},
     maxConcurrent: number = 1,
+    circuitBreakerConfig?: Partial<CircuitBreakerConfig>,
   ): Promise<void> {
     if (this.backends.has(backend.backendId)) {
       throw new Error(`Backend '${backend.backendId}' already registered`)
@@ -123,6 +129,8 @@ export class BackendRegistry {
     this.backends.set(backend.backendId, backend)
     this.healthChecks.set(backend.backendId, new CachedHealthCheck(backend, 30_000))
     this.semaphores.set(backend.backendId, new BackendSemaphore(maxConcurrent))
+    this.circuitBreakers.set(backend.backendId, new CircuitBreaker(circuitBreakerConfig))
+    this.circuitBreakerConfigs.set(backend.backendId, circuitBreakerConfig)
 
     if (!this.defaultBackendId) {
       this.defaultBackendId = backend.backendId
@@ -174,6 +182,101 @@ export class BackendRegistry {
     return [...this.backends.keys()]
   }
 
+  // ── Circuit Breaker & Router Integration ──
+
+  /** Get the circuit breaker for a specific backend. */
+  getCircuitBreaker(backendId: string): CircuitBreaker | undefined {
+    return this.circuitBreakers.get(backendId)
+  }
+
+  /** Get circuit states for all registered backends. */
+  getCircuitStates(): Map<string, CircuitState> {
+    const states = new Map<string, CircuitState>()
+    for (const [id, breaker] of this.circuitBreakers) {
+      states.set(id, breaker.getState())
+    }
+    return states
+  }
+
+  /** Get circuit stats for all registered backends. */
+  getCircuitStats(): Map<string, CircuitStats> {
+    const stats = new Map<string, CircuitStats>()
+    for (const [id, breaker] of this.circuitBreakers) {
+      stats.set(id, breaker.getStats())
+    }
+    return stats
+  }
+
+  /**
+   * Configure the provider router for failover-aware dispatch.
+   * Registers all current backends with the router in registration order.
+   */
+  configureRouter(router?: ProviderRouter): ProviderRouter {
+    if (router) {
+      this.router = router
+      return router
+    }
+
+    this.router = new ProviderRouter()
+    let priority = 0
+    for (const [backendId, backend] of this.backends) {
+      this.router.addProvider({
+        providerId: backendId,
+        backend,
+        priority: priority++,
+        circuitBreakerConfig: this.circuitBreakerConfigs.get(backendId),
+      })
+    }
+    return this.router
+  }
+
+  /** Get the configured router (if any). */
+  getRouter(): ProviderRouter | undefined {
+    return this.router
+  }
+
+  /**
+   * Route a task using the provider router with failover.
+   * Falls back to direct registry.get() / getDefault() if no router is configured.
+   */
+  routeTask(task: ExecutionTask, preferredBackendId?: string): RouteResult {
+    if (this.router) {
+      return this.router.route(task)
+    }
+
+    // Fallback: no router configured — use direct lookup
+    const backend = preferredBackendId
+      ? this.backends.get(preferredBackendId)
+      : this.getDefault()
+
+    if (!backend) {
+      throw new Error(
+        `No execution backend available${preferredBackendId ? ` (requested: ${preferredBackendId})` : ""}`,
+      )
+    }
+
+    return { backend, providerId: backend.backendId }
+  }
+
+  /** Record an execution outcome for the circuit breaker. */
+  recordOutcome(providerId: string, success: boolean, classification?: string): void {
+    // Update router if configured
+    if (this.router) {
+      this.router.recordOutcome(providerId, success, classification)
+      return
+    }
+
+    // Otherwise update circuit breaker directly
+    const breaker = this.circuitBreakers.get(providerId)
+    if (!breaker) return
+
+    if (success) {
+      breaker.recordSuccess()
+    } else {
+      breaker.recordFailure(classification ?? "transient")
+    }
+  }
+
   /** Graceful shutdown — stop all backends. */
   async stopAll(): Promise<void> {
     const stops = [...this.backends.values()].map((b) => b.stop())
@@ -181,6 +284,9 @@ export class BackendRegistry {
     this.backends.clear()
     this.healthChecks.clear()
     this.semaphores.clear()
+    this.circuitBreakers.clear()
+    this.circuitBreakerConfigs.clear()
     this.defaultBackendId = undefined
+    this.router = undefined
   }
 }


### PR DESCRIPTION
Closes #98.

**Circuit Breaker** — Per-provider sliding-window (CLOSED→OPEN→HALF_OPEN→CLOSED), configurable thresholds, canary traffic in HALF_OPEN.

**Provider Router** — Priority-based failover, skips OPEN circuits, emits routing events for observability.

**Echo Backend** — Test backend with configurable latency/failure rate for failover testing.

**Registry Integration** — routeTask(), recordOutcome(), configureRouter(), getCircuitStates/Stats().

**Health Endpoint** — /health/backends exposes per-provider circuit state.

**agent-execute** — Uses routeTask() for failover-aware dispatch, records outcomes.

+2,578 lines, 77 new tests, 559 total passing.