### PR TITLE
feat(shared,control-plane): End-to-end OpenTelemetry tracing (#97)

### DIFF
--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@cortex/shared": "workspace:*",
     "@fastify/env": "^5.0.0",
+    "@opentelemetry/api": "^1.9.0",
     "@fastify/websocket": "^11.0.0",
     "@kubernetes/client-node": "^1.4.0",
     "@qdrant/js-client-rest": "^1.12.0",

--- a/packages/control-plane/src/backends/claude-code.ts
+++ b/packages/control-plane/src/backends/claude-code.ts
@@ -27,6 +27,8 @@ import type {
   OutputUsageEvent,
   TokenUsage,
 } from "@cortex/shared"
+import { trace } from "@opentelemetry/api"
+import { CortexAttributes } from "@cortex/shared/tracing"
 
 const execFile = promisify(execFileCb)
 
@@ -403,6 +405,16 @@ class ClaudeCodeHandle implements ExecutionHandle {
         costUsd: 0,
         cacheReadTokens: 0,
         cacheCreationTokens: 0,
+      }
+
+      // Record token usage as span attributes for observability
+      const activeSpan = trace.getActiveSpan()
+      if (activeSpan) {
+        activeSpan.setAttribute(CortexAttributes.TOKEN_INPUT, tokenUsage.inputTokens)
+        activeSpan.setAttribute(CortexAttributes.TOKEN_OUTPUT, tokenUsage.outputTokens)
+        activeSpan.setAttribute(CortexAttributes.TOKEN_CACHE_READ, tokenUsage.cacheReadTokens)
+        activeSpan.setAttribute(CortexAttributes.TOKEN_CACHE_CREATION, tokenUsage.cacheCreationTokens)
+        activeSpan.setAttribute(CortexAttributes.TOKEN_COST_USD, tokenUsage.costUsd)
       }
 
       events.push({

--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -1,15 +1,32 @@
+import { initTracing, shutdownTracing } from "@cortex/shared/tracing"
 import { buildApp } from "./app.js"
 import { loadConfig } from "./config.js"
 import { createDatabase } from "./db/index.js"
 
 const config = loadConfig()
+
+// Initialize tracing before anything else
+initTracing({
+  enabled: config.tracing.enabled,
+  serviceName: config.tracing.serviceName,
+  endpoint: config.tracing.endpoint,
+  sampleRate: config.tracing.sampleRate,
+  exporterType: config.tracing.exporterType,
+})
+
 const { db, pool } = createDatabase(config.databaseUrl)
 const { app } = await buildApp({ db, pool, config })
+
+// Shutdown tracing on app close
+app.addHook("onClose", async () => {
+  await shutdownTracing()
+})
 
 try {
   const address = await app.listen({ port: config.port, host: config.host })
   app.log.info(`Control plane listening on ${address}`)
 } catch (err) {
   app.log.fatal(err)
+  await shutdownTracing()
   process.exit(1)
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -21,6 +21,10 @@
     "./channels": {
       "import": "./dist/channels/index.js",
       "types": "./dist/channels/index.d.ts"
+    },
+    "./tracing": {
+      "import": "./dist/tracing/index.js",
+      "types": "./dist/tracing/index.d.ts"
     }
   },
   "scripts": {
@@ -31,12 +35,18 @@
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+    "@opentelemetry/resources": "^1.30.0",
+    "@opentelemetry/sdk-trace-base": "^1.30.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@qdrant/js-client-rest": "^1.12.0",
     "chokidar": "^4.0.0",
     "uuid": "^11.0.0"
   },
   "devDependencies": {
     "@cortex/config": "workspace:*",
+    "@opentelemetry/sdk-trace-node": "^2.5.1",
     "@types/node": "^22.0.0",
     "@types/uuid": "^10.0.0",
     "vitest": "^3.0.0"

--- a/packages/shared/src/__tests__/tracing-init.test.ts
+++ b/packages/shared/src/__tests__/tracing-init.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  initTracing,
+  shutdownTracing,
+  isTracingInitialized,
+  resetTracing,
+} from "../tracing/index.js"
+
+describe("initTracing", () => {
+  afterEach(async () => {
+    await resetTracing()
+  })
+
+  it("does nothing when enabled is false", () => {
+    initTracing({
+      enabled: false,
+      serviceName: "test-service",
+    })
+    expect(isTracingInitialized()).toBe(false)
+  })
+
+  it("initializes tracing when enabled", () => {
+    initTracing({
+      enabled: true,
+      serviceName: "test-service",
+      exporterType: "console",
+    })
+    expect(isTracingInitialized()).toBe(true)
+  })
+
+  it("is idempotent — second call is a no-op", () => {
+    initTracing({
+      enabled: true,
+      serviceName: "test-service",
+      exporterType: "console",
+    })
+    expect(isTracingInitialized()).toBe(true)
+
+    // Call again — should not throw
+    initTracing({
+      enabled: true,
+      serviceName: "test-service-2",
+      exporterType: "console",
+    })
+    expect(isTracingInitialized()).toBe(true)
+  })
+})
+
+describe("shutdownTracing", () => {
+  afterEach(async () => {
+    await resetTracing()
+  })
+
+  it("is safe to call when not initialized", async () => {
+    await expect(shutdownTracing()).resolves.toBeUndefined()
+  })
+
+  it("shuts down and clears the provider", async () => {
+    initTracing({
+      enabled: true,
+      serviceName: "test-service",
+      exporterType: "console",
+    })
+    expect(isTracingInitialized()).toBe(true)
+
+    await shutdownTracing()
+    expect(isTracingInitialized()).toBe(false)
+  })
+})
+
+describe("resetTracing", () => {
+  it("resets even after initialization", async () => {
+    initTracing({
+      enabled: true,
+      serviceName: "test-service",
+      exporterType: "console",
+    })
+    expect(isTracingInitialized()).toBe(true)
+
+    await resetTracing()
+    expect(isTracingInitialized()).toBe(false)
+  })
+
+  it("is safe to call multiple times", async () => {
+    await resetTracing()
+    await resetTracing()
+    expect(isTracingInitialized()).toBe(false)
+  })
+})

--- a/packages/shared/src/__tests__/tracing-logger.test.ts
+++ b/packages/shared/src/__tests__/tracing-logger.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the structured TracingLogger.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { trace } from "@opentelemetry/api"
+import { NodeTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-node"
+
+import { TracingLogger } from "../tracing/logger.js"
+
+// Single provider for the entire file — NodeTracerProvider registers
+// an AsyncHooks context manager for proper startActiveSpan support.
+const exporter = new InMemorySpanExporter()
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+})
+
+beforeAll(() => {
+  provider.register()
+})
+
+afterAll(async () => {
+  await provider.shutdown()
+})
+
+describe("TracingLogger", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stdoutWrite: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stderrWrite: any
+
+  beforeEach(() => {
+    stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+    stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    stdoutWrite.mockRestore()
+    stderrWrite.mockRestore()
+  })
+
+  function parseStdout(): Record<string, unknown> {
+    return JSON.parse(String(stdoutWrite.mock.calls[0]?.[0]))
+  }
+
+  function parseStderr(): Record<string, unknown> {
+    return JSON.parse(String(stderrWrite.mock.calls[0]?.[0]))
+  }
+
+  it("logs info messages to stdout as JSON", () => {
+    const logger = new TracingLogger({ level: "info", serviceName: "test" })
+    logger.info("hello world")
+
+    expect(stdoutWrite).toHaveBeenCalledOnce()
+    const output = parseStdout()
+    expect(output.level).toBe("info")
+    expect(output.msg).toBe("hello world")
+    expect(output.service).toBe("test")
+    expect(output.time).toBeDefined()
+  })
+
+  it("logs error messages to stderr", () => {
+    const logger = new TracingLogger({ level: "info" })
+    logger.error("something broke")
+
+    expect(stderrWrite).toHaveBeenCalledOnce()
+    const output = parseStderr()
+    expect(output.level).toBe("error")
+    expect(output.msg).toBe("something broke")
+  })
+
+  it("logs warn messages to stderr", () => {
+    const logger = new TracingLogger({ level: "info" })
+    logger.warn("careful")
+
+    expect(stderrWrite).toHaveBeenCalledOnce()
+    const output = parseStderr()
+    expect(output.level).toBe("warn")
+  })
+
+  it("respects minimum log level", () => {
+    const logger = new TracingLogger({ level: "warn" })
+    logger.debug("hidden")
+    logger.info("hidden too")
+    logger.warn("visible")
+
+    expect(stdoutWrite).not.toHaveBeenCalled()
+    expect(stderrWrite).toHaveBeenCalledOnce()
+  })
+
+  it("includes extra fields in output", () => {
+    const logger = new TracingLogger({ level: "info" })
+    logger.info("with extras", { jobId: "j-1", count: 42 })
+
+    const output = parseStdout()
+    expect(output.jobId).toBe("j-1")
+    expect(output.count).toBe(42)
+  })
+
+  it("includes traceId and spanId from active span", async () => {
+    const logger = new TracingLogger({ level: "info" })
+    const tracer = trace.getTracer("test")
+
+    await tracer.startActiveSpan("test.log", async (span) => {
+      logger.info("inside span")
+      span.end()
+    })
+
+    const output = parseStdout()
+    expect(output.traceId).toBeDefined()
+    expect(output.spanId).toBeDefined()
+    expect(output.traceId).toMatch(/^[0-9a-f]{32}$/)
+    expect(output.spanId).toMatch(/^[0-9a-f]{16}$/)
+  })
+
+  it("does not include traceId/spanId when no active span", () => {
+    const logger = new TracingLogger({ level: "info" })
+    logger.info("no span")
+
+    const output = parseStdout()
+    expect(output.traceId).toBeUndefined()
+    expect(output.spanId).toBeUndefined()
+  })
+
+  it("defaults to cortex service name", () => {
+    const logger = new TracingLogger()
+    logger.info("default service")
+
+    const output = parseStdout()
+    expect(output.service).toBe("cortex")
+  })
+})

--- a/packages/shared/src/__tests__/tracing-spans.test.ts
+++ b/packages/shared/src/__tests__/tracing-spans.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for tracing span utilities.
+ *
+ * Uses NodeTracerProvider which registers an AsyncHooks context manager,
+ * enabling proper context propagation needed by startActiveSpan.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { trace, SpanStatusCode } from "@opentelemetry/api"
+import { NodeTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-node"
+
+import { CortexAttributes, extractTraceContext } from "../tracing/spans.js"
+
+// Single provider for the entire file — NodeTracerProvider registers
+// an AsyncHooks context manager so startActiveSpan works properly.
+const exporter = new InMemorySpanExporter()
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+})
+
+beforeAll(() => {
+  provider.register()
+})
+
+afterAll(async () => {
+  await provider.shutdown()
+})
+
+describe("CortexAttributes", () => {
+  it("contains expected attribute keys", () => {
+    expect(CortexAttributes.JOB_ID).toBe("cortex.job.id")
+    expect(CortexAttributes.AGENT_ID).toBe("cortex.agent.id")
+    expect(CortexAttributes.TOKEN_INPUT).toBe("cortex.tokens.input")
+    expect(CortexAttributes.CIRCUIT_STATE).toBe("cortex.circuit.state")
+  })
+})
+
+describe("withSpan", () => {
+  it("creates a span and returns the function result", async () => {
+    exporter.reset()
+    const { withSpan } = await import("../tracing/spans.js")
+
+    const result = await withSpan("test.operation", async () => {
+      return 42
+    })
+
+    expect(result).toBe(42)
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+    const span = spans[0]!
+    expect(span.name).toBe("test.operation")
+    expect(span.status.code).toBe(SpanStatusCode.OK)
+  })
+
+  it("sets attributes on the span", async () => {
+    exporter.reset()
+    const { withSpan } = await import("../tracing/spans.js")
+
+    await withSpan(
+      "test.with-attrs",
+      async () => "ok",
+      { "test.key": "value", "test.num": 123 },
+    )
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+    const span = spans[0]!
+    expect(span.attributes["test.key"]).toBe("value")
+    expect(span.attributes["test.num"]).toBe(123)
+  })
+
+  it("marks span as error when function throws", async () => {
+    exporter.reset()
+    const { withSpan } = await import("../tracing/spans.js")
+
+    await expect(
+      withSpan("test.error", async () => {
+        throw new Error("boom")
+      }),
+    ).rejects.toThrow("boom")
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+    const span = spans[0]!
+    expect(span.status.code).toBe(SpanStatusCode.ERROR)
+    expect(span.status.message).toBe("boom")
+    expect(span.events).toHaveLength(1)
+    expect(span.events[0]!.name).toBe("exception")
+  })
+
+  it("allows setting custom attributes inside the callback", async () => {
+    exporter.reset()
+    const { withSpan } = await import("../tracing/spans.js")
+
+    await withSpan("test.custom", async (span) => {
+      span.setAttribute(CortexAttributes.JOB_ID, "job-123")
+    })
+
+    const spans = exporter.getFinishedSpans()
+    const span = spans[0]!
+    expect(span.attributes[CortexAttributes.JOB_ID]).toBe("job-123")
+  })
+})
+
+describe("injectTraceContext", () => {
+  it("returns traceparent header within an active span", async () => {
+    const { injectTraceContext } = await import("../tracing/spans.js")
+    const tracer = trace.getTracer("test")
+
+    await tracer.startActiveSpan("test.inject", async (span) => {
+      const headers = injectTraceContext()
+      expect(headers.traceparent).toBeDefined()
+      expect(headers.traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[0-9a-f]$/)
+      span.end()
+    })
+  })
+})
+
+describe("extractTraceContext", () => {
+  it("returns current context when no traceparent header", () => {
+    const ctx = extractTraceContext({})
+    expect(ctx).toBeDefined()
+  })
+
+  it("returns current context for invalid traceparent", () => {
+    const ctx = extractTraceContext({ traceparent: "invalid" })
+    expect(ctx).toBeDefined()
+  })
+
+  it("extracts span context from valid traceparent", () => {
+    const traceId = "0af7651916cd43dd8448eb211c80319c"
+    const spanId = "b7ad6b7169203331"
+    const traceparent = `00-${traceId}-${spanId}-01`
+
+    const ctx = extractTraceContext({ traceparent })
+    const extracted = trace.getSpanContext(ctx)
+
+    expect(extracted).toBeDefined()
+    expect(extracted?.traceId).toBe(traceId)
+    expect(extracted?.spanId).toBe(spanId)
+    expect(extracted?.isRemote).toBe(true)
+  })
+})

--- a/packages/shared/src/tracing/index.ts
+++ b/packages/shared/src/tracing/index.ts
@@ -1,0 +1,136 @@
+/**
+ * OpenTelemetry SDK initialization for Cortex services.
+ *
+ * Configures OTLP and/or console exporters with configurable sampling.
+ * Initialization is idempotent — calling initTracing() multiple times is safe.
+ */
+
+import { DiagConsoleLogger, DiagLogLevel, diag } from "@opentelemetry/api"
+import { Resource } from "@opentelemetry/resources"
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions"
+import {
+  BasicTracerProvider,
+  BatchSpanProcessor,
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+  type SpanExporter,
+} from "@opentelemetry/sdk-trace-base"
+import { TraceIdRatioBasedSampler, AlwaysOnSampler } from "@opentelemetry/sdk-trace-base"
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http"
+
+export {
+  CortexAttributes,
+  withSpan,
+  injectTraceContext,
+  extractTraceContext,
+} from "./spans.js"
+export { TracingLogger, type LogLevel, type TracingLoggerOptions } from "./logger.js"
+
+// ──────────────────────────────────────────────────
+// Config types
+// ──────────────────────────────────────────────────
+
+export interface TracingInitConfig {
+  /** Whether tracing is enabled. If false, initTracing is a no-op. */
+  enabled: boolean
+  /** Service name for the resource. */
+  serviceName: string
+  /** Service version string. */
+  serviceVersion?: string
+  /** OTLP endpoint URL (e.g. http://localhost:4318/v1/traces). */
+  endpoint?: string
+  /** Sample rate: 0.0 to 1.0. 1.0 = sample everything. */
+  sampleRate?: number
+  /** Exporter type: "otlp", "console", or "both". */
+  exporterType?: "otlp" | "console" | "both"
+  /** Enable OTel diagnostic logging (for debugging SDK issues). */
+  debug?: boolean
+}
+
+// ──────────────────────────────────────────────────
+// Singleton state
+// ──────────────────────────────────────────────────
+
+let provider: BasicTracerProvider | null = null
+
+/**
+ * Initialize the OTel tracing SDK. Idempotent — subsequent calls are no-ops.
+ */
+export function initTracing(config: TracingInitConfig): void {
+  if (!config.enabled) return
+  if (provider !== null) return // already initialized
+
+  if (config.debug) {
+    diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG)
+  }
+
+  const resource = new Resource({
+    [ATTR_SERVICE_NAME]: config.serviceName,
+    [ATTR_SERVICE_VERSION]: config.serviceVersion ?? "0.0.0",
+  })
+
+  const sampler =
+    config.sampleRate !== undefined && config.sampleRate < 1.0
+      ? new TraceIdRatioBasedSampler(config.sampleRate)
+      : new AlwaysOnSampler()
+
+  provider = new BasicTracerProvider({
+    resource,
+    sampler,
+  })
+
+  const exporterType = config.exporterType ?? "otlp"
+  const exporters: SpanExporter[] = []
+
+  if (exporterType === "otlp" || exporterType === "both") {
+    exporters.push(
+      new OTLPTraceExporter({
+        url: config.endpoint ?? "http://localhost:4318/v1/traces",
+      }),
+    )
+  }
+
+  if (exporterType === "console" || exporterType === "both") {
+    exporters.push(new ConsoleSpanExporter())
+  }
+
+  for (const exporter of exporters) {
+    // Use SimpleSpanProcessor for console (immediate output),
+    // BatchSpanProcessor for OTLP (performance).
+    if (exporter instanceof ConsoleSpanExporter) {
+      provider.addSpanProcessor(new SimpleSpanProcessor(exporter))
+    } else {
+      provider.addSpanProcessor(new BatchSpanProcessor(exporter))
+    }
+  }
+
+  provider.register()
+}
+
+/**
+ * Gracefully flush and shut down the tracing provider.
+ * Safe to call even if tracing was never initialized.
+ */
+export async function shutdownTracing(): Promise<void> {
+  if (provider === null) return
+  await provider.shutdown()
+  provider = null
+}
+
+/**
+ * Check whether tracing has been initialized.
+ * Useful in tests.
+ */
+export function isTracingInitialized(): boolean {
+  return provider !== null
+}
+
+/**
+ * Reset tracing state (for tests only).
+ */
+export async function resetTracing(): Promise<void> {
+  if (provider !== null) {
+    await provider.shutdown()
+    provider = null
+  }
+}

--- a/packages/shared/src/tracing/logger.ts
+++ b/packages/shared/src/tracing/logger.ts
@@ -1,0 +1,77 @@
+/**
+ * Structured JSON logger with automatic trace context inclusion.
+ *
+ * Every log entry includes traceId and spanId from the active OTel span
+ * (if any), enabling log→trace correlation in observability backends.
+ */
+
+import { trace } from "@opentelemetry/api"
+
+export type LogLevel = "debug" | "info" | "warn" | "error"
+
+const LOG_LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+}
+
+export interface TracingLoggerOptions {
+  /** Minimum log level to emit. Defaults to "info". */
+  level?: LogLevel
+  /** Service name to include in every log line. */
+  serviceName?: string
+}
+
+export class TracingLogger {
+  private readonly minLevel: number
+  private readonly serviceName: string
+
+  constructor(options?: TracingLoggerOptions) {
+    this.minLevel = LOG_LEVEL_ORDER[options?.level ?? "info"]
+    this.serviceName = options?.serviceName ?? "cortex"
+  }
+
+  debug(message: string, extra?: Record<string, unknown>): void {
+    this.log("debug", message, extra)
+  }
+
+  info(message: string, extra?: Record<string, unknown>): void {
+    this.log("info", message, extra)
+  }
+
+  warn(message: string, extra?: Record<string, unknown>): void {
+    this.log("warn", message, extra)
+  }
+
+  error(message: string, extra?: Record<string, unknown>): void {
+    this.log("error", message, extra)
+  }
+
+  private log(level: LogLevel, message: string, extra?: Record<string, unknown>): void {
+    if (LOG_LEVEL_ORDER[level] < this.minLevel) return
+
+    const entry: Record<string, unknown> = {
+      level,
+      time: new Date().toISOString(),
+      service: this.serviceName,
+      msg: message,
+    }
+
+    // Auto-inject trace context from active span
+    const span = trace.getActiveSpan()
+    if (span) {
+      const ctx = span.spanContext()
+      entry.traceId = ctx.traceId
+      entry.spanId = ctx.spanId
+    }
+
+    if (extra) {
+      Object.assign(entry, extra)
+    }
+
+    // Use stderr for error/warn to match unix conventions
+    const out = level === "error" || level === "warn" ? process.stderr : process.stdout
+    out.write(JSON.stringify(entry) + "\n")
+  }
+}

--- a/packages/shared/src/tracing/spans.ts
+++ b/packages/shared/src/tracing/spans.ts
@@ -1,0 +1,115 @@
+/**
+ * Span utilities for OpenTelemetry tracing.
+ *
+ * Provides withSpan() for wrapping async operations,
+ * context propagation helpers, and attribute constants.
+ */
+
+import {
+  type Span,
+  SpanStatusCode,
+  context,
+  trace,
+} from "@opentelemetry/api"
+
+// ──────────────────────────────────────────────────
+// Attribute constants
+// ──────────────────────────────────────────────────
+
+/** Standard attribute keys for Cortex spans. */
+export const CortexAttributes = {
+  JOB_ID: "cortex.job.id",
+  AGENT_ID: "cortex.agent.id",
+  AGENT_NAME: "cortex.agent.name",
+  BACKEND_ID: "cortex.backend.id",
+  PROVIDER_ID: "cortex.provider.id",
+  APPROVAL_REQUEST_ID: "cortex.approval.request_id",
+  APPROVAL_DECISION: "cortex.approval.decision",
+  CIRCUIT_STATE: "cortex.circuit.state",
+  TOKEN_INPUT: "cortex.tokens.input",
+  TOKEN_OUTPUT: "cortex.tokens.output",
+  TOKEN_CACHE_READ: "cortex.tokens.cache_read",
+  TOKEN_CACHE_CREATION: "cortex.tokens.cache_creation",
+  TOKEN_COST_USD: "cortex.tokens.cost_usd",
+  ERROR_CATEGORY: "cortex.error.category",
+  EXECUTION_STATUS: "cortex.execution.status",
+  EXECUTION_DURATION_MS: "cortex.execution.duration_ms",
+} as const
+
+// ──────────────────────────────────────────────────
+// withSpan — wraps an async function in a span
+// ──────────────────────────────────────────────────
+
+/**
+ * Execute `fn` inside a new span. If `fn` throws, the span is marked as
+ * errored and the exception is re-thrown. The span is always ended.
+ */
+export async function withSpan<T>(
+  name: string,
+  fn: (span: Span) => Promise<T>,
+  attributes?: Record<string, string | number | boolean>,
+): Promise<T> {
+  const tracer = trace.getTracer("cortex")
+  return tracer.startActiveSpan(name, { attributes }, async (span) => {
+    try {
+      const result = await fn(span)
+      span.setStatus({ code: SpanStatusCode.OK })
+      return result
+    } catch (err) {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err instanceof Error ? err.message : String(err),
+      })
+      span.recordException(err instanceof Error ? err : new Error(String(err)))
+      throw err
+    } finally {
+      span.end()
+    }
+  })
+}
+
+// ──────────────────────────────────────────────────
+// W3C Trace Context propagation helpers
+// ──────────────────────────────────────────────────
+
+/**
+ * Extract the `traceparent` header from the current active context.
+ * Returns undefined if no active span exists.
+ */
+export function injectTraceContext(): Record<string, string> {
+  const span = trace.getActiveSpan()
+  if (!span) return {}
+
+  const ctx = span.spanContext()
+  const traceparent = `00-${ctx.traceId}-${ctx.spanId}-0${ctx.traceFlags.toString(16).padStart(1, "0")}`
+  return { traceparent }
+}
+
+/**
+ * Create a context from an incoming `traceparent` header.
+ * Returns a new OTel context with the extracted span context as the remote parent.
+ */
+export function extractTraceContext(
+  headers: Record<string, string | undefined>,
+): ReturnType<typeof context.active> {
+  const traceparent = headers["traceparent"] ?? headers["Traceparent"]
+  if (!traceparent) return context.active()
+
+  // Parse W3C traceparent: version-traceId-spanId-flags
+  const parts = traceparent.split("-")
+  if (parts.length !== 4) return context.active()
+
+  const traceId = parts[1]
+  const spanId = parts[2]
+  const flags = parts[3]
+  if (!traceId || !spanId || !flags) return context.active()
+
+  const spanContext = {
+    traceId,
+    spanId,
+    traceFlags: parseInt(flags, 16),
+    isRemote: true,
+  }
+
+  return trace.setSpanContext(context.active(), spanContext)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@kubernetes/client-node':
         specifier: ^1.4.0
         version: 1.4.0
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@qdrant/js-client-rest':
         specifier: ^1.12.0
         version: 1.17.0(typescript@5.9.3)
@@ -163,7 +166,7 @@ importers:
         version: 4.2.1
       next:
         specifier: ^15.2.0
-        version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -198,6 +201,21 @@ importers:
 
   packages/shared:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.57.0
+        version: 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.28.0
+        version: 1.39.0
       '@qdrant/js-client-rest':
         specifier: ^1.12.0
         version: 1.17.0(typescript@5.9.3)
@@ -211,6 +229,9 @@ importers:
       '@cortex/config':
         specifier: workspace:*
         version: link:../config
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.5.1
+        version: 2.5.1(@opentelemetry/api@1.9.0)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
@@ -790,12 +811,136 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@opentelemetry/api-logs@0.57.2':
+    resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@2.5.1':
+    resolution: {integrity: sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.5.1':
+    resolution: {integrity: sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2':
+    resolution: {integrity: sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.57.2':
+    resolution: {integrity: sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.57.2':
+    resolution: {integrity: sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.5.1':
+    resolution: {integrity: sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.57.2':
+    resolution: {integrity: sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.30.1':
+    resolution: {integrity: sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.5.1':
+    resolution: {integrity: sha512-iZH3Gw8cxQn0gjpOjJMmKLd9GIaNh/E3v3ST67vyzLSxHBs14HsG4dy7jMYyC5WXGdBVEcM7U/XTF5hCQxjDMw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.5.1':
+    resolution: {integrity: sha512-9lopQ6ZoElETOEN0csgmtEV5/9C7BMfA7VtF4Jape3i954b6sTY2k3Xw3CxUTKreDck/vpAuJM+EDo4zheUw+A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.39.0':
+    resolution: {integrity: sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==}
+    engines: {node: '>=14'}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@qdrant/js-client-rest@1.17.0':
     resolution: {integrity: sha512-aZFQeirWVqWAa1a8vJ957LMzcXkFHGbsoRhzc8AkGfg6V0jtK8PlG8/eyyc2xhYsR961FDDx1Tx6nyE0K7lS+A==}
@@ -1949,6 +2094,9 @@ packages:
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -2182,6 +2330,10 @@ packages:
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
@@ -3094,9 +3246,128 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.12':
     optional: true
 
+  '@opentelemetry/api-logs@0.57.2':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-exporter-base@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-transformer@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      protobufjs: 7.5.4
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/sdk-trace-node@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
+
+  '@opentelemetry/semantic-conventions@1.39.0': {}
+
   '@pinojs/redact@0.4.0': {}
 
   '@pkgr/core@0.2.9': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@qdrant/js-client-rest@1.17.0(typescript@5.9.3)':
     dependencies:
@@ -4218,6 +4489,8 @@ snapshots:
 
   lodash@4.17.23: {}
 
+  long@5.3.2: {}
+
   loupe@3.2.1: {}
 
   magic-bytes.js@1.13.0: {}
@@ -4250,7 +4523,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 15.5.12
       '@swc/helpers': 0.5.15
@@ -4268,6 +4541,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.12
       '@next/swc-win32-arm64-msvc': 15.5.12
       '@next/swc-win32-x64-msvc': 15.5.12
+      '@opentelemetry/api': 1.9.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -4456,6 +4730,21 @@ snapshots:
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.19.11
+      long: 5.3.2
 
   pump@3.0.3:
     dependencies:


### PR DESCRIPTION
Closes #97.

**Tracing infrastructure** (packages/shared/src/tracing/) — OTel SDK init, OTLP+console exporters, configurable sampling, withSpan() helper, W3C traceparent propagation, structured JSON logger with traceId/spanId.

**Instrumented paths:** agent-execute (job lifecycle spans), approval service (create/decide spans), circuit breaker (state change events), claude-code backend (token usage attributes).

**Config:** TracingConfig with env var overrides (OTEL_TRACING_ENABLED, endpoint, sample rate, exporter type).

+1,173 lines, 16 files, 40 new tests.