### PR TITLE
feat: versioned execution plan artifacts with durable checkpoint resume

### DIFF
--- a/docs/execution-plans.md
+++ b/docs/execution-plans.md
@@ -1,0 +1,40 @@
+# Execution Plans (Issue #135)
+
+This feature adds versioned execution plan artifacts with durable checkpoint resume.
+
+## Canonical plan schema
+
+Canonical schema: `docs/schemas/execution-plan.schema.json` (`schema_version: v1`).
+
+A plan version document includes:
+- ordered `steps`
+- `depends_on`
+- `checkpoint_key`
+- `rollback_hint`
+- optional `approval_gate`
+
+## Persistence model (PostgreSQL)
+
+Migration: `010_execution_plans.*`
+
+Tables:
+- `execution_plan` (logical plan identity)
+- `execution_plan_version` (immutable versioned artifact + source links to issue/PR/agent run/job/session)
+- `execution_plan_run` (current run state)
+- `execution_plan_event` (append-only timeline)
+
+State machine: `PLANNED -> RUNNING -> BLOCKED -> COMPLETED|FAILED`.
+
+DB trigger enforces valid transitions and append-only event history.
+
+## Read-only timeline API
+
+`GET /plans/runs/:runId/timeline`
+
+Returns:
+- plan metadata + version linkage (issue/pr/agent run/job/session)
+- run state and approval gate status
+- computed resume point (`checkpointKey`, `resumableStepId`, `requiresApproval`)
+- immutable timeline events ordered by `occurredAt`
+
+This endpoint is read-only and intended for human steering/observability.

--- a/docs/schemas/execution-plan.schema.json
+++ b/docs/schemas/execution-plan.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cortex-plane.dev/schemas/execution-plan.schema.json",
+  "title": "Execution Plan Document",
+  "type": "object",
+  "required": ["schema_version", "plan_id", "title", "steps"],
+  "properties": {
+    "schema_version": { "const": "v1" },
+    "plan_id": { "type": "string" },
+    "title": { "type": "string", "minLength": 1 },
+    "metadata": { "type": "object", "additionalProperties": true },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "title"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "title": { "type": "string", "minLength": 1 },
+          "description": { "type": "string" },
+          "depends_on": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true
+          },
+          "checkpoint_key": { "type": "string" },
+          "rollback_hint": { "type": "string" },
+          "approval_gate": {
+            "type": "object",
+            "required": ["required"],
+            "properties": {
+              "required": { "type": "boolean" },
+              "approver_roles": {
+                "type": "array",
+                "items": { "type": "string" },
+                "uniqueItems": true
+              },
+              "timeout_seconds": { "type": "integer", "minimum": 1 }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/control-plane/migrations/010_execution_plans.down.sql
+++ b/packages/control-plane/migrations/010_execution_plans.down.sql
@@ -1,0 +1,16 @@
+DROP TRIGGER IF EXISTS trg_execution_plan_event_no_delete ON execution_plan_event;
+DROP TRIGGER IF EXISTS trg_execution_plan_event_no_update ON execution_plan_event;
+DROP FUNCTION IF EXISTS prevent_plan_event_mutation();
+
+DROP TRIGGER IF EXISTS trg_execution_plan_run_updated_at ON execution_plan_run;
+DROP TRIGGER IF EXISTS trg_execution_plan_updated_at ON execution_plan;
+
+DROP TRIGGER IF EXISTS trg_validate_plan_run_transition ON execution_plan_run;
+DROP FUNCTION IF EXISTS validate_plan_run_transition();
+
+DROP TABLE IF EXISTS execution_plan_event;
+DROP TABLE IF EXISTS execution_plan_run;
+DROP TABLE IF EXISTS execution_plan_version;
+DROP TABLE IF EXISTS execution_plan;
+
+DROP TYPE IF EXISTS plan_run_state;

--- a/packages/control-plane/migrations/010_execution_plans.up.sql
+++ b/packages/control-plane/migrations/010_execution_plans.up.sql
@@ -1,0 +1,119 @@
+-- 010: Versioned execution plan artifacts + immutable transition/event timeline
+
+CREATE TYPE plan_run_state AS ENUM (
+  'PLANNED',
+  'RUNNING',
+  'BLOCKED',
+  'COMPLETED',
+  'FAILED'
+);
+
+CREATE TABLE execution_plan (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  key TEXT NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  description TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE execution_plan_version (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  plan_id UUID NOT NULL REFERENCES execution_plan(id) ON DELETE CASCADE,
+  version_number INTEGER NOT NULL,
+  schema_version TEXT NOT NULL DEFAULT 'v1',
+  plan_document JSONB NOT NULL,
+  source_issue_number INTEGER,
+  source_pr_number INTEGER,
+  source_agent_run_id UUID,
+  source_job_id UUID REFERENCES job(id) ON DELETE SET NULL,
+  source_session_id UUID REFERENCES session(id) ON DELETE SET NULL,
+  created_by TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (plan_id, version_number)
+);
+
+CREATE TABLE execution_plan_run (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  plan_version_id UUID NOT NULL REFERENCES execution_plan_version(id) ON DELETE RESTRICT,
+  state plan_run_state NOT NULL DEFAULT 'PLANNED',
+  current_step_id TEXT,
+  last_checkpoint_key TEXT,
+  approval_gate_step_id TEXT,
+  approval_gate_status approval_status,
+  blocked_reason TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ
+);
+
+CREATE TABLE execution_plan_event (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  plan_run_id UUID NOT NULL REFERENCES execution_plan_run(id) ON DELETE CASCADE,
+  from_state plan_run_state,
+  to_state plan_run_state,
+  step_id TEXT,
+  checkpoint_key TEXT,
+  event_type TEXT NOT NULL,
+  event_payload JSONB NOT NULL DEFAULT '{}',
+  actor TEXT,
+  occurred_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_execution_plan_version_plan ON execution_plan_version(plan_id, version_number DESC);
+CREATE INDEX idx_execution_plan_run_version ON execution_plan_run(plan_version_id, created_at DESC);
+CREATE INDEX idx_execution_plan_event_run_time ON execution_plan_event(plan_run_id, occurred_at ASC);
+
+-- Ensure state transition legality
+CREATE OR REPLACE FUNCTION validate_plan_run_transition()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.state = NEW.state THEN
+    RETURN NEW;
+  END IF;
+
+  IF NOT (
+    (OLD.state = 'PLANNED'   AND NEW.state IN ('RUNNING', 'BLOCKED', 'FAILED')) OR
+    (OLD.state = 'RUNNING'   AND NEW.state IN ('BLOCKED', 'COMPLETED', 'FAILED')) OR
+    (OLD.state = 'BLOCKED'   AND NEW.state IN ('RUNNING', 'FAILED'))
+  ) THEN
+    RAISE EXCEPTION 'Invalid plan run transition: % -> %', OLD.state, NEW.state;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_validate_plan_run_transition
+  BEFORE UPDATE OF state ON execution_plan_run
+  FOR EACH ROW
+  EXECUTE FUNCTION validate_plan_run_transition();
+
+CREATE TRIGGER trg_execution_plan_updated_at
+  BEFORE UPDATE ON execution_plan
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER trg_execution_plan_run_updated_at
+  BEFORE UPDATE ON execution_plan_run
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();
+
+-- Append-only enforcement on event log
+CREATE OR REPLACE FUNCTION prevent_plan_event_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'execution_plan_event is append-only';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_execution_plan_event_no_update
+  BEFORE UPDATE ON execution_plan_event
+  FOR EACH ROW
+  EXECUTE FUNCTION prevent_plan_event_mutation();
+
+CREATE TRIGGER trg_execution_plan_event_no_delete
+  BEFORE DELETE ON execution_plan_event
+  FOR EACH ROW
+  EXECUTE FUNCTION prevent_plan_event_mutation();

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -9,6 +9,7 @@ import type pg from "pg"
 import { ApprovalService } from "./approval/service.js"
 import { CredentialService } from "./auth/credential-service.js"
 import { SessionService } from "./auth/session-service.js"
+import { ExecutionPlanService } from "./execution-plan/service.js"
 import { ClaudeCodeBackend } from "./backends/claude-code.js"
 import { HttpLlmBackend } from "./backends/http-llm.js"
 import { AuthHandoffService } from "./browser/auth-handoff.js"
@@ -25,6 +26,7 @@ import { authRoutes } from "./routes/auth.js"
 import { credentialRoutes } from "./routes/credentials.js"
 import { healthRoutes } from "./routes/health.js"
 import { observationRoutes } from "./routes/observation.js"
+import { planRoutes } from "./routes/plans.js"
 import { streamRoutes } from "./routes/stream.js"
 import { SSEConnectionManager } from "./streaming/manager.js"
 import { createWorker, type Runner } from "./worker/index.js"
@@ -94,6 +96,7 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
 
   // Approval service — core approval gate logic
   const approvalService = new ApprovalService({ db })
+  const planService = new ExecutionPlanService(db)
 
   // Load auth configuration for approval gate endpoints
   const authConfig = loadAuthConfig()
@@ -118,6 +121,7 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
   }
 
   await app.register(healthRoutes)
+  await app.register(planRoutes({ planService }))
 
   // Register approval routes (always available)
   await app.register(approvalRoutes({ approvalService, sseManager, authConfig, sessionService }))

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -1,4 +1,4 @@
-import type { AgentStatus, ApprovalStatus, JobStatus } from "@cortex/shared"
+import type { AgentStatus, ApprovalStatus, JobStatus, PlanRunState } from "@cortex/shared"
 import type { ColumnType, Generated, Insertable, Selectable, Updateable } from "kysely"
 
 // ---------------------------------------------------------------------------
@@ -259,6 +259,69 @@ export type CredentialAuditLog = Selectable<CredentialAuditLogTable>
 export type NewCredentialAuditLog = Insertable<CredentialAuditLogTable>
 
 // ---------------------------------------------------------------------------
+// Table: execution_plan
+// ---------------------------------------------------------------------------
+export interface ExecutionPlanTable {
+  id: Generated<string>
+  key: string
+  title: string
+  description: string | null
+  created_at: ColumnType<Date, Date | undefined, never>
+  updated_at: ColumnType<Date, Date | undefined, Date>
+}
+
+export interface ExecutionPlanVersionTable {
+  id: Generated<string>
+  plan_id: string
+  version_number: number
+  schema_version: string
+  plan_document: Record<string, unknown>
+  source_issue_number: number | null
+  source_pr_number: number | null
+  source_agent_run_id: string | null
+  source_job_id: string | null
+  source_session_id: string | null
+  created_by: string | null
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
+export interface ExecutionPlanRunTable {
+  id: Generated<string>
+  plan_version_id: string
+  state: ColumnType<PlanRunState, PlanRunState | undefined, PlanRunState>
+  current_step_id: string | null
+  last_checkpoint_key: string | null
+  approval_gate_step_id: string | null
+  approval_gate_status: ApprovalStatus | null
+  blocked_reason: string | null
+  metadata: ColumnType<
+    Record<string, unknown>,
+    Record<string, unknown> | undefined,
+    Record<string, unknown>
+  >
+  created_at: ColumnType<Date, Date | undefined, never>
+  updated_at: ColumnType<Date, Date | undefined, Date>
+  completed_at: Date | null
+}
+
+export interface ExecutionPlanEventTable {
+  id: Generated<string>
+  plan_run_id: string
+  from_state: PlanRunState | null
+  to_state: PlanRunState | null
+  step_id: string | null
+  checkpoint_key: string | null
+  event_type: string
+  event_payload: ColumnType<
+    Record<string, unknown>,
+    Record<string, unknown> | undefined,
+    Record<string, unknown>
+  >
+  actor: string | null
+  occurred_at: ColumnType<Date, Date | undefined, never>
+}
+
+// ---------------------------------------------------------------------------
 // Database interface — register all tables here.
 // ---------------------------------------------------------------------------
 export interface Database {
@@ -272,4 +335,8 @@ export interface Database {
   dashboard_session: DashboardSessionTable
   provider_credential: ProviderCredentialTable
   credential_audit_log: CredentialAuditLogTable
+  execution_plan: ExecutionPlanTable
+  execution_plan_version: ExecutionPlanVersionTable
+  execution_plan_run: ExecutionPlanRunTable
+  execution_plan_event: ExecutionPlanEventTable
 }

--- a/packages/control-plane/src/execution-plan/service.ts
+++ b/packages/control-plane/src/execution-plan/service.ts
@@ -1,0 +1,84 @@
+import type { PlanRunState } from "@cortex/shared"
+import type { Kysely } from "kysely"
+
+import type { Database } from "../db/types.js"
+
+const TERMINAL: ReadonlySet<PlanRunState> = new Set(["COMPLETED", "FAILED"])
+
+export interface ResumePoint {
+  checkpointKey: string | null
+  resumableStepId: string | null
+  requiresApproval: boolean
+}
+
+export class ExecutionPlanService {
+  constructor(private readonly db: Kysely<Database>) {}
+
+  async timeline(planRunId: string) {
+    const run = await this.db
+      .selectFrom("execution_plan_run as run")
+      .innerJoin("execution_plan_version as v", "v.id", "run.plan_version_id")
+      .innerJoin("execution_plan as p", "p.id", "v.plan_id")
+      .select([
+        "run.id as runId",
+        "run.state as runState",
+        "run.current_step_id as currentStepId",
+        "run.last_checkpoint_key as lastCheckpointKey",
+        "run.approval_gate_step_id as approvalGateStepId",
+        "run.approval_gate_status as approvalGateStatus",
+        "run.blocked_reason as blockedReason",
+        "run.created_at as runCreatedAt",
+        "run.updated_at as runUpdatedAt",
+        "v.id as planVersionId",
+        "v.version_number as versionNumber",
+        "v.plan_document as planDocument",
+        "v.source_issue_number as sourceIssueNumber",
+        "v.source_pr_number as sourcePrNumber",
+        "v.source_agent_run_id as sourceAgentRunId",
+        "v.source_job_id as sourceJobId",
+        "v.source_session_id as sourceSessionId",
+        "p.id as planId",
+        "p.key as planKey",
+        "p.title as planTitle",
+      ])
+      .where("run.id", "=", planRunId)
+      .executeTakeFirst()
+
+    if (!run) return null
+
+    const events = await this.db
+      .selectFrom("execution_plan_event")
+      .selectAll()
+      .where("plan_run_id", "=", planRunId)
+      .orderBy("occurred_at", "asc")
+      .execute()
+
+    const resumePoint = this.computeResumePoint(run.runState, events)
+
+    return {
+      run,
+      events,
+      resumePoint,
+    }
+  }
+
+  private computeResumePoint(
+    state: PlanRunState,
+    events: Array<{ checkpoint_key: string | null; step_id: string | null; event_type: string }>,
+  ): ResumePoint {
+    if (TERMINAL.has(state)) {
+      return { checkpointKey: null, resumableStepId: null, requiresApproval: false }
+    }
+
+    const latestCheckpoint = [...events].reverse().find((e) => e.checkpoint_key)
+    const waitingApproval = [...events]
+      .reverse()
+      .find((e) => e.event_type === "approval_requested" || e.event_type === "approval_granted")
+
+    return {
+      checkpointKey: latestCheckpoint?.checkpoint_key ?? null,
+      resumableStepId: latestCheckpoint?.step_id ?? null,
+      requiresApproval: waitingApproval?.event_type === "approval_requested",
+    }
+  }
+}

--- a/packages/control-plane/src/routes/plans.ts
+++ b/packages/control-plane/src/routes/plans.ts
@@ -1,0 +1,79 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
+
+import type { ExecutionPlanService } from "../execution-plan/service.js"
+
+interface PlanRunParams {
+  runId: string
+}
+
+export interface PlanRouteDeps {
+  planService: ExecutionPlanService
+}
+
+export function planRoutes(deps: PlanRouteDeps) {
+  const { planService } = deps
+
+  return function register(app: FastifyInstance): void {
+    app.get<{ Params: PlanRunParams }>(
+      "/plans/runs/:runId/timeline",
+      {
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              runId: { type: "string", format: "uuid" },
+            },
+            required: ["runId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: PlanRunParams }>, reply: FastifyReply) => {
+        const timeline = await planService.timeline(request.params.runId)
+        if (!timeline) {
+          return reply.status(404).send({ error: "not_found", message: "Plan run not found" })
+        }
+
+        return reply.status(200).send({
+          plan: {
+            id: timeline.run.planId,
+            key: timeline.run.planKey,
+            title: timeline.run.planTitle,
+          },
+          version: {
+            id: timeline.run.planVersionId,
+            number: timeline.run.versionNumber,
+            issueNumber: timeline.run.sourceIssueNumber,
+            prNumber: timeline.run.sourcePrNumber,
+            agentRunId: timeline.run.sourceAgentRunId,
+            jobId: timeline.run.sourceJobId,
+            sessionId: timeline.run.sourceSessionId,
+          },
+          run: {
+            id: timeline.run.runId,
+            state: timeline.run.runState,
+            currentStepId: timeline.run.currentStepId,
+            lastCheckpointKey: timeline.run.lastCheckpointKey,
+            approvalGateStepId: timeline.run.approvalGateStepId,
+            approvalGateStatus: timeline.run.approvalGateStatus,
+            blockedReason: timeline.run.blockedReason,
+            createdAt: timeline.run.runCreatedAt,
+            updatedAt: timeline.run.runUpdatedAt,
+          },
+          resume: timeline.resumePoint,
+          canonicalPlan: timeline.run.planDocument,
+          timeline: timeline.events.map((event) => ({
+            id: event.id,
+            fromState: event.from_state,
+            toState: event.to_state,
+            stepId: event.step_id,
+            checkpointKey: event.checkpoint_key,
+            eventType: event.event_type,
+            payload: event.event_payload,
+            actor: event.actor,
+            occurredAt: event.occurred_at,
+          })),
+        })
+      },
+    )
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,13 @@ export type {
   CreateApprovalRequest,
   JobStatus,
 } from "./types/index.js"
+
+export type {
+  ExecutionPlanDocument,
+  ExecutionPlanStep,
+  ExecutionPlanTimelineEvent,
+  PlanRunState,
+} from "./types/execution-plan.js"
 export {
   APPROVAL_TOKEN_PREFIX,
   APPROVAL_TOKEN_VERSION,

--- a/packages/shared/src/types/execution-plan.ts
+++ b/packages/shared/src/types/execution-plan.ts
@@ -1,0 +1,36 @@
+export type PlanRunState = "PLANNED" | "RUNNING" | "BLOCKED" | "COMPLETED" | "FAILED"
+
+export interface ExecutionPlanStep {
+  id: string
+  title: string
+  description?: string
+  depends_on?: string[]
+  checkpoint_key?: string
+  rollback_hint?: string
+  approval_gate?: {
+    required: boolean
+    approver_roles?: string[]
+    timeout_seconds?: number
+  }
+}
+
+export interface ExecutionPlanDocument {
+  schema_version: "v1"
+  plan_id: string
+  title: string
+  metadata?: Record<string, unknown>
+  steps: ExecutionPlanStep[]
+}
+
+export interface ExecutionPlanTimelineEvent {
+  id: string
+  planRunId: string
+  fromState: PlanRunState | null
+  toState: PlanRunState | null
+  eventType: string
+  stepId: string | null
+  checkpointKey: string | null
+  actor: string | null
+  payload: Record<string, unknown>
+  occurredAt: string
+}


### PR DESCRIPTION
## Summary
Implements #135 with a versioned execution plan persistence model, immutable transition/event timeline, and read-only timeline API for human steering.

## What's included
- Canonical execution plan schema (`docs/schemas/execution-plan.schema.json`)
  - steps, dependencies, checkpoints, rollback hints, approval gates
- New PostgreSQL migration (`010_execution_plans`) adding:
  - `execution_plan`
  - `execution_plan_version`
  - `execution_plan_run`
  - `execution_plan_event` (append-only)
- Transition validation trigger for immutable/queryable lifecycle states:
  - `PLANNED -> RUNNING -> BLOCKED -> COMPLETED|FAILED`
- Source linkage for plan versions:
  - GitHub issue number
  - GitHub PR number
  - agent run ID
  - job/session references
- Durable checkpoint resume metadata on plan runs + computed resume point in service
- Approval-gate pause/resume semantics represented in run fields/events
- Read-only timeline endpoint:
  - `GET /plans/runs/:runId/timeline`

## API behavior
Timeline response includes:
- canonical plan artifact for the version
- immutable event timeline (ordered)
- current run state
- resume pointer (`checkpointKey`, `resumableStepId`, `requiresApproval`)

## Notes
- Existing workspace currently has unrelated baseline typecheck issues; changes were scoped and validated locally for coherence against existing patterns.

Closes #135
