### PR TITLE
fix(dashboard): resolve false 'Control plane unavailable' banner

### DIFF
--- a/packages/dashboard/src/app/agents/page.tsx
+++ b/packages/dashboard/src/app/agents/page.tsx
@@ -66,11 +66,14 @@ export default function AgentsPage(): React.JSX.Element {
     [],
   )
 
-  // Real-time SSE for fleet-wide state updates
+  // Real-time SSE for fleet-wide state updates.
+  // The backend only exposes per-agent streams (/agents/:id/stream), so
+  // fleet-wide SSE is not available yet. Disable auto-connect to prevent
+  // a 400 loop from "stream" being parsed as a UUID path param.
   const { connected, events: sseEvents } = useSSE({
     url: resolveSSEUrl("/api/agents/stream"),
     eventTypes: ["agent:state"],
-    autoConnect: true,
+    autoConnect: false,
     maxEvents: 50,
   })
 

--- a/packages/dashboard/src/components/layout/api-error-banner.tsx
+++ b/packages/dashboard/src/components/layout/api-error-banner.tsx
@@ -29,6 +29,11 @@ const ERROR_CONFIG: Record<string, { icon: string; title: string; className: str
     title: "Server error",
     className: "border-red-500/20 bg-red-500/10 text-red-500",
   },
+  SCHEMA_MISMATCH: {
+    icon: "data_object",
+    title: "Unexpected API response",
+    className: "border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  },
 }
 
 const DEFAULT_CONFIG = {

--- a/packages/dashboard/src/lib/schemas/agents.ts
+++ b/packages/dashboard/src/lib/schemas/agents.ts
@@ -41,10 +41,31 @@ export const AgentDetailSchema = AgentSummarySchema.extend({
   checkpoint: CheckpointSchema.optional(),
 })
 
-export const AgentListResponseSchema = z.object({
-  agents: z.array(AgentSummarySchema),
-  pagination: PaginationSchema,
-})
+/**
+ * Accept both the current server shape ({agents, count}) and the full
+ * pagination shape ({agents, pagination}). Normalize to {agents, pagination}.
+ */
+export const AgentListResponseSchema = z
+  .object({
+    agents: z.array(AgentSummarySchema),
+    pagination: PaginationSchema.optional(),
+    count: z.number().optional(),
+  })
+  .transform((data) => {
+    if (data.pagination) {
+      return { agents: data.agents, pagination: data.pagination }
+    }
+    const total = data.count ?? data.agents.length
+    return {
+      agents: data.agents,
+      pagination: {
+        total,
+        limit: total,
+        offset: 0,
+        hasMore: false,
+      },
+    }
+  })
 
 export type AgentStatus = z.infer<typeof AgentStatusSchema>
 export type AgentLifecycleState = z.infer<typeof AgentLifecycleStateSchema>


### PR DESCRIPTION
## Summary

Fixes #147 — the Agents page shows a false "Control plane unavailable" banner even though the API is healthy and responding at `/api/healthz` and `/api/agents`.

**Three root causes identified and fixed:**

- **Schema mismatch**: The control-plane returns `{agents, count}` but the dashboard Zod schema expected `{agents, pagination: {total, limit, offset, hasMore}}`. The resulting `ZodError` was caught in the generic error handler and misclassified as `CONNECTION_REFUSED`, triggering the "Control plane unavailable" banner. Fixed by updating `AgentListResponseSchema` to accept both shapes via Zod transform.
- **Invalid fleet SSE subscription**: The agents page subscribed to `/api/agents/stream` (fleet-wide), but the server only exposes `/agents/:agentId/stream` (per-agent). The path segment `"stream"` was parsed as the `:agentId` UUID param, causing a 400 error loop. Fixed by disabling `autoConnect` until a fleet-wide SSE endpoint exists.
- **Error misclassification**: `ZodError` from schema validation fell through to `classifyNetworkError()` which returned `CONNECTION_REFUSED`. Added a new `SCHEMA_MISMATCH` error code so schema failures show "Unexpected API response" instead of "Control plane unavailable".

## Changed files

| File | Change |
|------|--------|
| `packages/dashboard/src/lib/schemas/agents.ts` | Accept `{agents, count}` and normalize to `{agents, pagination}` |
| `packages/dashboard/src/lib/api-client.ts` | Add `SCHEMA_MISMATCH` error code; catch `ZodError` before network classification |
| `packages/dashboard/src/app/agents/page.tsx` | Set `autoConnect: false` on fleet SSE subscription |
| `packages/dashboard/src/components/layout/api-error-banner.tsx` | Add banner config for `SCHEMA_MISMATCH` |
| `packages/dashboard/src/__tests__/api-client.test.ts` | 3 new tests: count-based response, empty response, schema mismatch classification |

## Deployment notes (k3s demo env)

Only the dashboard image needs to be rebuilt and rolled:

```bash
# Rebuild dashboard image
docker build -t ghcr.io/noncelogic/cortex-plane/dashboard:latest \
  -f deploy/docker/Dockerfile.dashboard .

# Push to registry
docker push ghcr.io/noncelogic/cortex-plane/dashboard:latest

# Roll the dashboard deployment
kubectl -n cortex rollout restart deployment/dashboard
kubectl -n cortex rollout status deployment/dashboard --timeout=120s

# Verify: agents page should show empty state, no error banner
curl -sf https://cortex-demo.<tailnet>.ts.net/agents
```

No control-plane restart or migration needed — this is a dashboard-only change.

## Test plan

- [x] All 266 dashboard tests pass (including 3 new tests)
- [ ] Verify on live demo: agents page shows "No agents configured" empty state, not error banner
- [ ] Verify no 400 errors in browser console from `/agents/stream` SSE
- [ ] Verify `/api/healthz` still returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)