### PR TITLE
fix(dashboard): resolve false outage state from API surface mismatch

### DIFF
--- a/packages/dashboard/src/__tests__/dashboard-error-classification.test.ts
+++ b/packages/dashboard/src/__tests__/dashboard-error-classification.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for issue #151: Dashboard false outage due to API surface mismatch.
+ *
+ * Verifies that:
+ * 1. NOT_FOUND (404) on feature endpoints is classified as feature-unavailable,
+ *    not as a connection failure.
+ * 2. Dashboard stats don't fall back to mock data when feature routes 404.
+ * 3. The error banner only shows for genuine connectivity problems.
+ * 4. ApiError.isFeatureUnavailable correctly identifies 404 errors.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { ApiError, type ApiErrorCode } from "@/lib/api-client"
+
+// ---------------------------------------------------------------------------
+// ApiError.isFeatureUnavailable
+// ---------------------------------------------------------------------------
+
+describe("ApiError.isFeatureUnavailable", () => {
+  it("returns true for NOT_FOUND (404)", () => {
+    const err = new ApiError(404, "Not Found", undefined, "NOT_FOUND")
+    expect(err.isFeatureUnavailable).toBe(true)
+  })
+
+  it("returns false for CONNECTION_REFUSED", () => {
+    const err = new ApiError(0, "Could not connect", undefined, "CONNECTION_REFUSED")
+    expect(err.isFeatureUnavailable).toBe(false)
+  })
+
+  it("returns false for TIMEOUT", () => {
+    const err = new ApiError(0, "Request timed out", undefined, "TIMEOUT")
+    expect(err.isFeatureUnavailable).toBe(false)
+  })
+
+  it("returns false for SERVER_ERROR", () => {
+    const err = new ApiError(500, "Internal error", undefined, "SERVER_ERROR")
+    expect(err.isFeatureUnavailable).toBe(false)
+  })
+
+  it("returns false for TRANSIENT", () => {
+    const err = new ApiError(503, "Unavailable", undefined, "TRANSIENT")
+    expect(err.isFeatureUnavailable).toBe(false)
+  })
+
+  it("returns false for AUTH_ERROR", () => {
+    const err = new ApiError(401, "Unauthorized", undefined, "AUTH_ERROR")
+    expect(err.isFeatureUnavailable).toBe(false)
+  })
+
+  it("returns false for SCHEMA_MISMATCH", () => {
+    const err = new ApiError(0, "Unexpected format", undefined, "SCHEMA_MISMATCH")
+    expect(err.isFeatureUnavailable).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error classification: connectivity vs feature-unavailable
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirror of the connectivity check used in use-dashboard.ts.
+ * Kept in sync with the hook to validate the classification logic in isolation.
+ */
+const CONNECTIVITY_ERROR_CODES = new Set<ApiErrorCode>([
+  "CONNECTION_REFUSED",
+  "TIMEOUT",
+  "SERVER_ERROR",
+  "TRANSIENT",
+  "AUTH_ERROR",
+])
+
+function isConnectivityError(code: ApiErrorCode | null): boolean {
+  return code !== null && CONNECTIVITY_ERROR_CODES.has(code)
+}
+
+describe("error classification for dashboard banner", () => {
+  it("NOT_FOUND is NOT a connectivity error", () => {
+    expect(isConnectivityError("NOT_FOUND")).toBe(false)
+  })
+
+  it("SCHEMA_MISMATCH is NOT a connectivity error", () => {
+    expect(isConnectivityError("SCHEMA_MISMATCH")).toBe(false)
+  })
+
+  it("UNKNOWN is NOT a connectivity error", () => {
+    expect(isConnectivityError("UNKNOWN")).toBe(false)
+  })
+
+  it("null is NOT a connectivity error", () => {
+    expect(isConnectivityError(null)).toBe(false)
+  })
+
+  it.each([
+    "CONNECTION_REFUSED",
+    "TIMEOUT",
+    "SERVER_ERROR",
+    "TRANSIENT",
+    "AUTH_ERROR",
+  ] satisfies ApiErrorCode[])("%s IS a connectivity error", (code) => {
+    expect(isConnectivityError(code)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Dashboard state scenarios
+// ---------------------------------------------------------------------------
+
+describe("dashboard error aggregation scenarios", () => {
+  /**
+   * Simulates the connectivityFailure logic from useDashboard.
+   * Takes an array of { error, code } representing each API query result
+   * and returns the first connectivity error, or null.
+   */
+  function findConnectivityFailure(
+    sources: Array<{ error: string | null; code: ApiErrorCode | null }>,
+  ): { error: string; code: ApiErrorCode } | null {
+    return (
+      (sources.find((s) => isConnectivityError(s.code)) as {
+        error: string
+        code: ApiErrorCode
+      }) ?? null
+    )
+  }
+
+  it("returns null when all queries succeed", () => {
+    const result = findConnectivityFailure([
+      { error: null, code: null },
+      { error: null, code: null },
+      { error: null, code: null },
+      { error: null, code: null },
+    ])
+    expect(result).toBeNull()
+  })
+
+  it("returns null when some queries 404 (feature unavailable) but core is healthy", () => {
+    // Scenario: /agents OK, /jobs 404, /approvals OK, /memory/search 404
+    const result = findConnectivityFailure([
+      { error: null, code: null },
+      { error: "Not Found", code: "NOT_FOUND" },
+      { error: null, code: null },
+      { error: "Not Found", code: "NOT_FOUND" },
+    ])
+    expect(result).toBeNull()
+  })
+
+  it("returns null when ALL queries 404", () => {
+    // Even if every feature route is missing, 404 is not a connection failure
+    const result = findConnectivityFailure([
+      { error: "Not Found", code: "NOT_FOUND" },
+      { error: "Not Found", code: "NOT_FOUND" },
+      { error: "Not Found", code: "NOT_FOUND" },
+      { error: "Not Found", code: "NOT_FOUND" },
+    ])
+    expect(result).toBeNull()
+  })
+
+  it("returns the connectivity error when control plane is truly down", () => {
+    const result = findConnectivityFailure([
+      { error: "Could not connect", code: "CONNECTION_REFUSED" },
+      { error: "Could not connect", code: "CONNECTION_REFUSED" },
+      { error: "Could not connect", code: "CONNECTION_REFUSED" },
+      { error: "Could not connect", code: "CONNECTION_REFUSED" },
+    ])
+    expect(result).not.toBeNull()
+    expect(result!.code).toBe("CONNECTION_REFUSED")
+  })
+
+  it("surfaces connectivity error even when mixed with 404s", () => {
+    // Scenario: /agents times out, /jobs 404, /approvals OK, /memory 404
+    const result = findConnectivityFailure([
+      { error: "Request timed out", code: "TIMEOUT" },
+      { error: "Not Found", code: "NOT_FOUND" },
+      { error: null, code: null },
+      { error: "Not Found", code: "NOT_FOUND" },
+    ])
+    expect(result).not.toBeNull()
+    expect(result!.code).toBe("TIMEOUT")
+  })
+
+  it("picks the first connectivity error when multiple exist", () => {
+    const result = findConnectivityFailure([
+      { error: null, code: null },
+      { error: "Server error", code: "SERVER_ERROR" },
+      { error: "Request timed out", code: "TIMEOUT" },
+      { error: null, code: null },
+    ])
+    expect(result).not.toBeNull()
+    expect(result!.code).toBe("SERVER_ERROR")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Feature page NOT_FOUND suppression
+// ---------------------------------------------------------------------------
+
+describe("feature page 404 suppression", () => {
+  /**
+   * Mirrors the pattern used in use-jobs-page.ts, use-memory-explorer.ts,
+   * and use-pulse-pipeline.ts to suppress NOT_FOUND errors.
+   */
+  function suppressNotFound(
+    rawError: string | null,
+    rawErrorCode: ApiErrorCode | null,
+  ): { error: string | null; errorCode: ApiErrorCode | null } {
+    return {
+      error: rawErrorCode === "NOT_FOUND" ? null : rawError,
+      errorCode: rawErrorCode === "NOT_FOUND" ? null : rawErrorCode,
+    }
+  }
+
+  it("suppresses NOT_FOUND error and code", () => {
+    const result = suppressNotFound("Not Found", "NOT_FOUND")
+    expect(result.error).toBeNull()
+    expect(result.errorCode).toBeNull()
+  })
+
+  it("passes through CONNECTION_REFUSED", () => {
+    const result = suppressNotFound("Could not connect", "CONNECTION_REFUSED")
+    expect(result.error).toBe("Could not connect")
+    expect(result.errorCode).toBe("CONNECTION_REFUSED")
+  })
+
+  it("passes through TIMEOUT", () => {
+    const result = suppressNotFound("Request timed out", "TIMEOUT")
+    expect(result.error).toBe("Request timed out")
+    expect(result.errorCode).toBe("TIMEOUT")
+  })
+
+  it("passes through SERVER_ERROR", () => {
+    const result = suppressNotFound("Internal error", "SERVER_ERROR")
+    expect(result.error).toBe("Internal error")
+    expect(result.errorCode).toBe("SERVER_ERROR")
+  })
+
+  it("passes through null (no error)", () => {
+    const result = suppressNotFound(null, null)
+    expect(result.error).toBeNull()
+    expect(result.errorCode).toBeNull()
+  })
+})

--- a/packages/dashboard/src/hooks/use-dashboard.ts
+++ b/packages/dashboard/src/hooks/use-dashboard.ts
@@ -22,6 +22,23 @@ export interface DashboardData {
   refetch: () => void
 }
 
+/**
+ * Error codes that indicate the control plane is genuinely unreachable or
+ * broken. A NOT_FOUND (404) on a list/search endpoint simply means the feature
+ * route is not deployed — it should NOT trigger the outage banner.
+ */
+const CONNECTIVITY_ERROR_CODES = new Set<ApiErrorCode>([
+  "CONNECTION_REFUSED",
+  "TIMEOUT",
+  "SERVER_ERROR",
+  "TRANSIENT",
+  "AUTH_ERROR",
+])
+
+function isConnectivityError(code: ApiErrorCode | null): boolean {
+  return code !== null && CONNECTIVITY_ERROR_CODES.has(code)
+}
+
 export function useDashboard(): DashboardData {
   const {
     data: agentData,
@@ -35,37 +52,66 @@ export function useDashboard(): DashboardData {
     data: jobData,
     isLoading: jobsLoading,
     error: jobsError,
+    errorCode: jobsErrorCode,
     refetch: refetchJobs,
   } = useApiQuery(() => listJobs({ limit: 5 }), [])
 
   const {
     data: approvalData,
     isLoading: approvalsLoading,
+    error: approvalsError,
+    errorCode: approvalsErrorCode,
     refetch: refetchApprovals,
   } = useApiQuery(() => listApprovals({ status: "PENDING", limit: 1 }), [])
 
   const {
     data: memoryData,
     isLoading: memoryLoading,
+    error: memoryError,
+    errorCode: memoryErrorCode,
     refetch: refetchMemory,
   } = useApiQuery(() => searchMemory({ agentId: "*", query: "all", limit: 1 }), [])
 
   const isLoading = agentsLoading || jobsLoading || approvalsLoading || memoryLoading
-  const error = agentsError || jobsError
-  const errorCode = agentsErrorCode
+
+  // Only surface errors that indicate a real control-plane connectivity
+  // problem. A 404 on /jobs or /memory/search just means the feature isn't
+  // deployed yet — not that the plane is down.
+  const connectivityFailure = useMemo(() => {
+    const sources = [
+      { error: agentsError, code: agentsErrorCode },
+      { error: jobsError, code: jobsErrorCode },
+      { error: approvalsError, code: approvalsErrorCode },
+      { error: memoryError, code: memoryErrorCode },
+    ]
+    return sources.find((s) => isConnectivityError(s.code)) ?? null
+  }, [
+    agentsError,
+    agentsErrorCode,
+    jobsError,
+    jobsErrorCode,
+    approvalsError,
+    approvalsErrorCode,
+    memoryError,
+    memoryErrorCode,
+  ])
+
+  const error = connectivityFailure?.error ?? null
+  const errorCode = connectivityFailure?.code ?? null
 
   const stats = useMemo<DashboardStats>(() => {
-    if (isMockEnabled() || (error && !agentData)) return getDashboardStats()
+    if (isMockEnabled()) return getDashboardStats()
+    // Use real data where available; features that 404'd stay at 0.
     return {
       totalAgents: agentData?.pagination?.total ?? 0,
       activeJobs: jobData?.pagination?.total ?? 0,
       pendingApprovals: approvalData?.pagination?.total ?? 0,
       memoryRecords: memoryData?.results?.length ?? 0,
     }
-  }, [agentData, jobData, approvalData, memoryData, error])
+  }, [agentData, jobData, approvalData, memoryData])
 
   const recentJobs = useMemo<RecentJob[]>(() => {
-    if (isMockEnabled() || (error && !jobData)) return getRecentJobs()
+    if (isMockEnabled()) return getRecentJobs()
     if (!jobData?.jobs || jobData.jobs.length === 0) return []
     return jobData.jobs.map((j) => ({
       id: j.id,
@@ -74,7 +120,7 @@ export function useDashboard(): DashboardData {
       type: j.type,
       createdAt: j.createdAt,
     }))
-  }, [jobData, error])
+  }, [jobData])
 
   const refetch = useCallback(() => {
     void refetchAgents()

--- a/packages/dashboard/src/hooks/use-jobs-page.ts
+++ b/packages/dashboard/src/hooks/use-jobs-page.ts
@@ -23,10 +23,18 @@ function statusCounts(jobs: JobSummary[]): { running: number; failed: number; co
 export function useJobsPage() {
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null)
 
-  const { data, isLoading, error, errorCode, refetch } = useApiQuery(
-    () => listJobs({ limit: 100 }),
-    [],
-  )
+  const {
+    data,
+    isLoading,
+    error: rawError,
+    errorCode: rawErrorCode,
+    refetch,
+  } = useApiQuery(() => listJobs({ limit: 100 }), [])
+
+  // A 404 means the /jobs route isn't deployed — not a connection failure.
+  // Suppress it so the page shows the empty state instead of an error banner.
+  const error = rawErrorCode === "NOT_FOUND" ? null : rawError
+  const errorCode = rawErrorCode === "NOT_FOUND" ? null : rawErrorCode
 
   const jobs: JobSummary[] = useMemo(() => {
     // Mock mode: always return mock data

--- a/packages/dashboard/src/hooks/use-memory-explorer.ts
+++ b/packages/dashboard/src/hooks/use-memory-explorer.ts
@@ -62,10 +62,19 @@ export function useMemoryExplorer() {
     timeRange: "ALL",
   })
 
-  const { data, isLoading, error, errorCode } = useApiQuery(
+  const {
+    data,
+    isLoading,
+    error: rawError,
+    errorCode: rawErrorCode,
+  } = useApiQuery(
     () => searchMemory({ agentId: MOCK_AGENT_ID, query: searchQuery || "all", limit: 50 }),
     [searchQuery],
   )
+
+  // A 404 means the /memory/search route isn't deployed — not a connection failure.
+  const error = rawErrorCode === "NOT_FOUND" ? null : rawError
+  const errorCode = rawErrorCode === "NOT_FOUND" ? null : rawErrorCode
 
   const allRecords: MemoryRecord[] = useMemo(() => {
     if (isMockEnabled()) return generateMockMemories()

--- a/packages/dashboard/src/hooks/use-pulse-pipeline.ts
+++ b/packages/dashboard/src/hooks/use-pulse-pipeline.ts
@@ -41,7 +41,16 @@ export function usePulsePipeline() {
   })
   const [publishingId, setPublishingId] = useState<string | null>(null)
 
-  const { data, isLoading, error, errorCode } = useApiQuery(() => listContent({ limit: 100 }), [])
+  const {
+    data,
+    isLoading,
+    error: rawError,
+    errorCode: rawErrorCode,
+  } = useApiQuery(() => listContent({ limit: 100 }), [])
+
+  // A 404 means the /content route isn't deployed — not a connection failure.
+  const error = rawErrorCode === "NOT_FOUND" ? null : rawError
+  const errorCode = rawErrorCode === "NOT_FOUND" ? null : rawErrorCode
 
   const allPieces: ContentPiece[] = useMemo(() => {
     if (isMockEnabled()) return generateMockContent()

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -311,6 +311,11 @@ export class ApiError extends Error {
   get isTransient(): boolean {
     return this.code === "TRANSIENT"
   }
+
+  /** True when the endpoint itself doesn't exist (feature not deployed). */
+  get isFeatureUnavailable(): boolean {
+    return this.code === "NOT_FOUND"
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #151

- **Classify NOT_FOUND (404) as feature-unavailable**, not connectivity failure. Only genuine errors (CONNECTION_REFUSED, TIMEOUT, SERVER_ERROR, TRANSIENT, AUTH_ERROR) trigger the "Control plane unavailable" banner.
- **Remove production mock fallback** — the `(error && !agentData)` race condition that showed fake KPI values (5 agents, 3 jobs, 7 approvals, 8 records) when feature routes 404'd before core queries resolved. Mock data now only activates when `NEXT_PUBLIC_USE_MOCK_DATA=true`.
- **Suppress NOT_FOUND in feature page hooks** (jobs, memory, pulse) so pages show their normal empty states instead of error banners when the route isn't deployed yet.
- **Add `ApiError.isFeatureUnavailable`** getter and **27 new tests** covering error classification, dashboard aggregation scenarios, and 404 suppression.

## Files changed

| File | Change |
|------|--------|
| `src/lib/api-client.ts` | Add `isFeatureUnavailable` getter to `ApiError` |
| `src/hooks/use-dashboard.ts` | Track all 4 query error codes; filter to connectivity errors only; remove mock fallback on error |
| `src/hooks/use-jobs-page.ts` | Suppress NOT_FOUND → show empty state |
| `src/hooks/use-memory-explorer.ts` | Suppress NOT_FOUND → show empty state |
| `src/hooks/use-pulse-pipeline.ts` | Suppress NOT_FOUND → show empty state |
| `src/__tests__/dashboard-error-classification.test.ts` | 27 new tests |

## Test plan

- [x] All 293 tests pass (including 27 new)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify on demo URL: banner gone when `/healthz` 200 and feature routes 404
- [ ] Verify KPI cards show 0 (not mock values) for unavailable features
- [ ] Verify error banner still appears when control plane is truly down

## Deployment notes

Rebuild and redeploy the dashboard container. No backend changes needed.

```bash
# From project root
docker build -t ghcr.io/noncelogic/cortex-dashboard:latest -f packages/dashboard/Dockerfile .
docker push ghcr.io/noncelogic/cortex-dashboard:latest
kubectl rollout restart deployment/cortex-dashboard -n cortex
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)