### PR TITLE
feat(control-plane): wire memory extraction scheduling and drain flush

### DIFF
--- a/packages/control-plane/migrations/010_memory_extract_queue.down.sql
+++ b/packages/control-plane/migrations/010_memory_extract_queue.down.sql
@@ -1,0 +1,6 @@
+-- 010: Durable memory extraction queue state (rollback)
+
+DROP INDEX IF EXISTS idx_memory_extract_message_pending;
+DROP TABLE IF EXISTS memory_extract_message;
+DROP TABLE IF EXISTS memory_extract_session_state;
+

--- a/packages/control-plane/migrations/010_memory_extract_queue.up.sql
+++ b/packages/control-plane/migrations/010_memory_extract_queue.up.sql
@@ -1,0 +1,25 @@
+-- 010: Durable memory extraction queue state
+
+CREATE TABLE memory_extract_session_state (
+  session_id      UUID PRIMARY KEY REFERENCES session(id) ON DELETE CASCADE,
+  pending_count   INTEGER NOT NULL DEFAULT 0,
+  total_count     INTEGER NOT NULL DEFAULT 0,
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE memory_extract_message (
+  id              BIGSERIAL PRIMARY KEY,
+  session_id      UUID NOT NULL REFERENCES session(id) ON DELETE CASCADE,
+  agent_id        UUID NOT NULL REFERENCES agent(id) ON DELETE RESTRICT,
+  role            TEXT NOT NULL,
+  content         TEXT NOT NULL,
+  occurred_at     TIMESTAMPTZ NOT NULL,
+  extracted_at    TIMESTAMPTZ NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT memory_extract_role_check
+    CHECK (role IN ('user', 'assistant', 'system'))
+);
+
+CREATE INDEX idx_memory_extract_message_pending
+  ON memory_extract_message (session_id, extracted_at, id);
+

--- a/packages/control-plane/src/__tests__/config.test.ts
+++ b/packages/control-plane/src/__tests__/config.test.ts
@@ -16,7 +16,9 @@ describe("loadConfig", () => {
       nodeEnv: "development",
       logLevel: "info",
       workerConcurrency: 5,
+      memoryExtractThreshold: 50,
       qdrantUrl: "http://localhost:6333",
+      auth: undefined,
       tracing: {
         enabled: false,
         endpoint: "http://localhost:4318/v1/traces",
@@ -109,7 +111,7 @@ describe("loadConfig", () => {
           DATABASE_URL: "postgres://localhost/test",
           OTEL_EXPORTER_TYPE: "invalid",
         }),
-      ).toThrow('Invalid OTEL_EXPORTER_TYPE: invalid')
+      ).toThrow("Invalid OTEL_EXPORTER_TYPE: invalid")
     })
   })
 })

--- a/packages/control-plane/src/__tests__/memory-scheduling.integration.test.ts
+++ b/packages/control-plane/src/__tests__/memory-scheduling.integration.test.ts
@@ -1,0 +1,384 @@
+import { readdir, readFile, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import type { MemoryStore, ScoredMemoryRecord } from "@cortex/shared/memory"
+import EmbeddedPostgres from "embedded-postgres"
+import { makeWorkerUtils, run, type Runner, type WorkerUtils } from "graphile-worker"
+import { Kysely, PostgresDialect } from "kysely"
+import pg from "pg"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  BackendRegistry,
+  type ExecutionBackend,
+  type ExecutionHandle,
+  type ExecutionResult,
+  type ExecutionTask,
+  type OutputEvent,
+} from "@cortex/shared/backends"
+import type { Database } from "../db/types.js"
+import { createMemoryScheduler } from "../worker/memory-scheduler.js"
+import { createAgentExecuteTask } from "../worker/tasks/agent-execute.js"
+import {
+  type EmbeddingFn,
+  type LLMCaller,
+  createMemoryExtractTask,
+} from "../worker/tasks/memory-extract.js"
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url))
+const MIGRATIONS_DIR = join(__dirname, "../../migrations")
+const PG_DATA_DIR = join(__dirname, "../../.test-pgdata-memory-scheduling")
+const PG_PORT = 15434
+
+let embeddedPg: EmbeddedPostgres
+let pool: pg.Pool
+let db: Kysely<Database>
+let runner: Runner
+let workerUtils: WorkerUtils
+
+function mockStore(searchResults: ScoredMemoryRecord[] = []): MemoryStore {
+  return {
+    upsert: vi.fn().mockResolvedValue(undefined),
+    search: vi.fn().mockResolvedValue(searchResults),
+    getById: vi.fn().mockResolvedValue(null),
+    delete: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+const mockEmbed: EmbeddingFn = () => Promise.resolve(Array.from({ length: 16 }, () => 0.01))
+
+function createResult(status: ExecutionResult["status"] = "completed"): ExecutionResult {
+  return {
+    taskId: "task-1",
+    status,
+    exitCode: status === "completed" ? 0 : 1,
+    summary: "done",
+    fileChanges: [],
+    stdout: "",
+    stderr: "",
+    tokenUsage: {
+      inputTokens: 1,
+      outputTokens: 1,
+      costUsd: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    },
+    artifacts: [],
+    durationMs: 10,
+  }
+}
+
+function createHandle(events: OutputEvent[], result: ExecutionResult): ExecutionHandle {
+  return {
+    taskId: "task-1",
+    async *events() {
+      for (const event of events) {
+        yield event
+      }
+    },
+    async result() {
+      return result
+    },
+    async cancel() {},
+  }
+}
+
+async function createRegistry(handle: ExecutionHandle): Promise<BackendRegistry> {
+  const backend: ExecutionBackend = {
+    backendId: "test-backend",
+    async start() {},
+    async stop() {},
+    async healthCheck() {
+      return {
+        backendId: "test-backend",
+        status: "healthy",
+        checkedAt: new Date().toISOString(),
+        latencyMs: 1,
+        details: {},
+      }
+    },
+    async executeTask(_task: ExecutionTask) {
+      return handle
+    },
+    getCapabilities() {
+      return {
+        supportsStreaming: true,
+        supportsFileEdit: true,
+        supportsShellExecution: true,
+        reportsTokenUsage: true,
+        supportsCancellation: true,
+        supportedGoalTypes: [
+          "code_edit",
+          "code_generate",
+          "code_review",
+          "shell_command",
+          "research",
+        ],
+        maxContextTokens: 200_000,
+      }
+    },
+  }
+
+  const registry = new BackendRegistry()
+  await registry.register(backend, {}, 2)
+  return registry
+}
+
+async function waitFor(check: () => Promise<boolean>, timeoutMs = 15_000): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (await check()) return
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error(`Condition not met within ${timeoutMs}ms`)
+}
+
+beforeAll(async () => {
+  await rm(PG_DATA_DIR, { recursive: true, force: true })
+
+  embeddedPg = new EmbeddedPostgres({
+    databaseDir: PG_DATA_DIR,
+    user: "cortex",
+    password: "cortex_test",
+    port: PG_PORT,
+    persistent: false,
+  })
+  await embeddedPg.initialise()
+  await embeddedPg.start()
+  await embeddedPg.createDatabase("cortex_memory_scheduling_test")
+
+  pool = new pg.Pool({
+    connectionString: `postgres://cortex:cortex_test@localhost:${PG_PORT}/cortex_memory_scheduling_test`,
+  })
+
+  const client = await pool.connect()
+  try {
+    const files = await readdir(MIGRATIONS_DIR)
+    const migrations = files.filter((f) => f.endsWith(".up.sql")).sort()
+    for (const file of migrations) {
+      const sql = await readFile(join(MIGRATIONS_DIR, file), "utf-8")
+      await client.query(sql)
+    }
+  } finally {
+    client.release()
+  }
+
+  db = new Kysely<Database>({ dialect: new PostgresDialect({ pool }) })
+  workerUtils = await makeWorkerUtils({ pgPool: pool })
+}, 60_000)
+
+afterAll(async () => {
+  if (workerUtils) await workerUtils.release()
+  if (runner) await runner.stop()
+  if (db) await db.destroy()
+  if (pool) await pool.end()
+  if (embeddedPg) await embeddedPg.stop()
+}, 30_000)
+
+beforeEach(async () => {
+  if (runner) {
+    await runner.stop()
+  }
+
+  await db.deleteFrom("memory_extract_message").execute()
+  await db.deleteFrom("memory_extract_session_state").execute()
+  await db.deleteFrom("job").execute()
+  await db.deleteFrom("session").execute()
+  await db.deleteFrom("agent").execute()
+  await db.deleteFrom("user_account").execute()
+})
+
+describe("memory extraction scheduling", () => {
+  it("enqueues extraction at threshold and drains remaining messages at job end", async () => {
+    const llmCall = vi.fn<LLMCaller>().mockResolvedValue(
+      JSON.stringify({
+        facts: [
+          {
+            content: "The user wants memory extraction scheduling in place",
+            type: "fact",
+            confidence: 0.9,
+            importance: 4,
+            tags: ["memory", "scheduler"],
+            people: [],
+            projects: ["cortex"],
+            source: { sessionId: "s", turnIndex: 0, timestamp: new Date().toISOString() },
+            supersedes: [],
+          },
+        ],
+      }),
+    )
+
+    const events: OutputEvent[] = [
+      { type: "text", timestamp: new Date().toISOString(), content: "first response" },
+      { type: "text", timestamp: new Date().toISOString(), content: "second response" },
+      { type: "complete", timestamp: new Date().toISOString(), result: createResult("completed") },
+    ]
+
+    const registry = await createRegistry(createHandle(events, createResult("completed")))
+    const store = mockStore()
+
+    runner = await run({
+      pgPool: pool,
+      taskList: {
+        agent_execute: createAgentExecuteTask({ db, registry, memoryExtractThreshold: 2 }),
+        memory_extract: createMemoryExtractTask(
+          { memoryStore: store, llmCall, embed: mockEmbed },
+          db,
+        ),
+      },
+      concurrency: 2,
+      noHandleSignals: true,
+    })
+
+    const user = await db
+      .insertInto("user_account")
+      .values({ display_name: "memory tester" })
+      .returning("id")
+      .executeTakeFirstOrThrow()
+    const agent = await db
+      .insertInto("agent")
+      .values({ name: "agent-mem", slug: "agent-mem", role: "test" })
+      .returning("id")
+      .executeTakeFirstOrThrow()
+    const session = await db
+      .insertInto("session")
+      .values({ agent_id: agent.id, user_account_id: user.id, status: "active", metadata: {} })
+      .returning("id")
+      .executeTakeFirstOrThrow()
+    const job = await db
+      .insertInto("job")
+      .values({
+        agent_id: agent.id,
+        session_id: session.id,
+        payload: { prompt: "remember this conversation", goalType: "research" },
+        max_attempts: 1,
+      })
+      .returning("id")
+      .executeTakeFirstOrThrow()
+
+    await db.updateTable("job").set({ status: "SCHEDULED" }).where("id", "=", job.id).execute()
+    await workerUtils.addJob("agent_execute", { jobId: job.id }, { maxAttempts: 1 })
+
+    await waitFor(async () => {
+      const state = await db
+        .selectFrom("memory_extract_session_state")
+        .select(["pending_count", "total_count"])
+        .where("session_id", "=", session.id)
+        .executeTakeFirst()
+      const status = await db
+        .selectFrom("job")
+        .select("status")
+        .where("id", "=", job.id)
+        .executeTakeFirst()
+      return status?.status === "COMPLETED" && state?.pending_count === 0 && state.total_count === 3
+    })
+
+    const messages = await db
+      .selectFrom("memory_extract_message")
+      .select(["id", "extracted_at"])
+      .where("session_id", "=", session.id)
+      .orderBy("id", "asc")
+      .execute()
+
+    expect(messages).toHaveLength(3)
+    expect(messages.every((row) => row.extracted_at !== null)).toBe(true)
+    expect(llmCall.mock.calls.length).toBeGreaterThanOrEqual(2)
+  }, 30_000)
+
+  it("flushes pending extraction windows after restart recovery", async () => {
+    const llmCall = vi.fn<LLMCaller>().mockResolvedValue(
+      JSON.stringify({
+        facts: [
+          {
+            content: "Recovery flush replayed pending session messages",
+            type: "fact",
+            confidence: 0.8,
+            importance: 3,
+            tags: ["recovery"],
+            people: [],
+            projects: ["cortex"],
+            source: { sessionId: "s", turnIndex: 0, timestamp: new Date().toISOString() },
+            supersedes: [],
+          },
+        ],
+      }),
+    )
+    const store = mockStore()
+
+    runner = await run({
+      pgPool: pool,
+      taskList: {
+        memory_extract: createMemoryExtractTask(
+          { memoryStore: store, llmCall, embed: mockEmbed },
+          db,
+        ),
+      },
+      concurrency: 1,
+      noHandleSignals: true,
+    })
+
+    const user = await db
+      .insertInto("user_account")
+      .values({ display_name: "restart tester" })
+      .returning("id")
+      .executeTakeFirstOrThrow()
+    const agent = await db
+      .insertInto("agent")
+      .values({ name: "agent-restart", slug: "agent-restart", role: "test" })
+      .returning("id")
+      .executeTakeFirstOrThrow()
+    const session = await db
+      .insertInto("session")
+      .values({ agent_id: agent.id, user_account_id: user.id, status: "active", metadata: {} })
+      .returning("id")
+      .executeTakeFirstOrThrow()
+
+    await db
+      .insertInto("memory_extract_message")
+      .values([
+        {
+          session_id: session.id,
+          agent_id: agent.id,
+          role: "user",
+          content: "first pending message",
+          occurred_at: new Date(),
+        },
+        {
+          session_id: session.id,
+          agent_id: agent.id,
+          role: "assistant",
+          content: "second pending message",
+          occurred_at: new Date(),
+        },
+      ])
+      .execute()
+
+    await db
+      .insertInto("memory_extract_session_state")
+      .values({ session_id: session.id, pending_count: 2, total_count: 2 })
+      .execute()
+
+    const scheduler = createMemoryScheduler({ db, threshold: 50 })
+    const flushed = await scheduler.flushAllPending(workerUtils)
+
+    expect(flushed).toBe(1)
+
+    await waitFor(async () => {
+      const state = await db
+        .selectFrom("memory_extract_session_state")
+        .select("pending_count")
+        .where("session_id", "=", session.id)
+        .executeTakeFirst()
+      return state?.pending_count === 0
+    })
+
+    const rows = await db
+      .selectFrom("memory_extract_message")
+      .select("extracted_at")
+      .where("session_id", "=", session.id)
+      .execute()
+    expect(rows.every((row) => row.extracted_at !== null)).toBe(true)
+    expect(llmCall).toHaveBeenCalledTimes(1)
+  }, 30_000)
+})

--- a/packages/control-plane/src/__tests__/migrations.test.ts
+++ b/packages/control-plane/src/__tests__/migrations.test.ts
@@ -81,6 +81,8 @@ describe("PostgreSQL migrations", () => {
       expect(await tableExists(client, "user_account")).toBe(true)
       expect(await tableExists(client, "channel_mapping")).toBe(true)
       expect(await tableExists(client, "session")).toBe(true)
+      expect(await tableExists(client, "memory_extract_session_state")).toBe(true)
+      expect(await tableExists(client, "memory_extract_message")).toBe(true)
       expect(await tableExists(client, "job")).toBe(true)
       expect(await tableExists(client, "approval_request")).toBe(true)
 
@@ -260,6 +262,8 @@ describe("PostgreSQL migrations", () => {
 
       expect(await tableExists(client, "approval_request")).toBe(false)
       expect(await tableExists(client, "job")).toBe(false)
+      expect(await tableExists(client, "memory_extract_message")).toBe(false)
+      expect(await tableExists(client, "memory_extract_session_state")).toBe(false)
       expect(await tableExists(client, "session")).toBe(false)
       expect(await tableExists(client, "channel_mapping")).toBe(false)
       expect(await tableExists(client, "user_account")).toBe(false)

--- a/packages/control-plane/src/config.ts
+++ b/packages/control-plane/src/config.ts
@@ -48,6 +48,8 @@ export interface Config {
   logLevel: string
   /** Graphile Worker concurrency */
   workerConcurrency: number
+  /** Number of session messages to batch before scheduling memory extraction. */
+  memoryExtractThreshold: number
   /** Qdrant REST URL */
   qdrantUrl: string
   /** OpenTelemetry tracing configuration */
@@ -96,6 +98,7 @@ export function loadConfig(env: Record<string, string | undefined> = process.env
     nodeEnv: env.NODE_ENV ?? "development",
     logLevel: env.LOG_LEVEL ?? "info",
     workerConcurrency: parseIntOr(env.GRAPHILE_WORKER_CONCURRENCY, 5),
+    memoryExtractThreshold: parseIntOr(env.MEMORY_EXTRACT_THRESHOLD, 50),
     qdrantUrl: env.QDRANT_URL ?? "http://localhost:6333",
     tracing: {
       enabled: env.OTEL_TRACING_ENABLED === "true",

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -115,6 +115,38 @@ export type NewSession = Insertable<SessionTable>
 export type SessionUpdate = Updateable<SessionTable>
 
 // ---------------------------------------------------------------------------
+// Table: memory_extract_session_state
+// ---------------------------------------------------------------------------
+export interface MemoryExtractSessionStateTable {
+  session_id: string
+  pending_count: ColumnType<number, number | undefined, number>
+  total_count: ColumnType<number, number | undefined, number>
+  updated_at: ColumnType<Date, Date | undefined, Date>
+}
+
+export type MemoryExtractSessionState = Selectable<MemoryExtractSessionStateTable>
+export type NewMemoryExtractSessionState = Insertable<MemoryExtractSessionStateTable>
+export type MemoryExtractSessionStateUpdate = Updateable<MemoryExtractSessionStateTable>
+
+// ---------------------------------------------------------------------------
+// Table: memory_extract_message
+// ---------------------------------------------------------------------------
+export interface MemoryExtractMessageTable {
+  id: Generated<string>
+  session_id: string
+  agent_id: string
+  role: string
+  content: string
+  occurred_at: Date
+  extracted_at: Date | null
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
+export type MemoryExtractMessage = Selectable<MemoryExtractMessageTable>
+export type NewMemoryExtractMessage = Insertable<MemoryExtractMessageTable>
+export type MemoryExtractMessageUpdate = Updateable<MemoryExtractMessageTable>
+
+// ---------------------------------------------------------------------------
 // Table: job
 // ---------------------------------------------------------------------------
 export interface JobTable {
@@ -266,6 +298,8 @@ export interface Database {
   user_account: UserAccountTable
   channel_mapping: ChannelMappingTable
   session: SessionTable
+  memory_extract_session_state: MemoryExtractSessionStateTable
+  memory_extract_message: MemoryExtractMessageTable
   job: JobTable
   approval_request: ApprovalRequestTable
   approval_audit_log: ApprovalAuditLogTable

--- a/packages/control-plane/src/worker/memory-scheduler.ts
+++ b/packages/control-plane/src/worker/memory-scheduler.ts
@@ -1,0 +1,170 @@
+import type { Kysely } from "kysely"
+
+import type { Database } from "../db/types.js"
+import type { MemoryExtractPayload } from "./tasks/memory-extract.js"
+
+export interface JobQueue {
+  addJob(
+    identifier: string,
+    payload: unknown,
+    spec?: {
+      jobKey?: string
+      runAt?: Date
+      maxAttempts?: number
+    },
+  ): Promise<unknown>
+}
+
+export interface MemoryMessageInput {
+  sessionId: string
+  agentId: string
+  role: "user" | "assistant" | "system"
+  content: string
+  occurredAt?: string
+}
+
+export interface MemorySchedulerOptions {
+  db: Kysely<Database>
+  threshold: number
+}
+
+export interface MemoryScheduler {
+  recordMessage(message: MemoryMessageInput, queue: JobQueue): Promise<void>
+  flushSession(sessionId: string, queue: JobQueue): Promise<void>
+  flushAllPending(queue: JobQueue): Promise<number>
+}
+
+interface PendingWindow {
+  agentId: string
+  upToMessageId: string
+  messages: MemoryExtractPayload["messages"]
+}
+
+function normalizeThreshold(threshold: number): number {
+  return Number.isFinite(threshold) && threshold > 0 ? Math.floor(threshold) : 50
+}
+
+function buildJobKey(sessionId: string, upToMessageId: string): string {
+  return `memory-extract:${sessionId}:${upToMessageId}`
+}
+
+async function loadPendingWindow(
+  db: Kysely<Database>,
+  sessionId: string,
+): Promise<PendingWindow | null> {
+  const pendingRows = await db
+    .selectFrom("memory_extract_message")
+    .select(["id", "agent_id", "role", "content", "occurred_at"])
+    .where("session_id", "=", sessionId)
+    .where("extracted_at", "is", null)
+    .orderBy("id", "asc")
+    .execute()
+
+  if (pendingRows.length === 0) {
+    return null
+  }
+
+  const last = pendingRows[pendingRows.length - 1]!
+  return {
+    agentId: last.agent_id,
+    upToMessageId: String(last.id),
+    messages: pendingRows.map((row) => ({
+      role: row.role,
+      content: row.content,
+      timestamp: row.occurred_at.toISOString(),
+    })),
+  }
+}
+
+async function enqueuePendingWindow(
+  db: Kysely<Database>,
+  queue: JobQueue,
+  sessionId: string,
+): Promise<boolean> {
+  const window = await loadPendingWindow(db, sessionId)
+  if (!window) {
+    return false
+  }
+
+  const payload: MemoryExtractPayload = {
+    sessionId,
+    agentId: window.agentId,
+    upToMessageId: window.upToMessageId,
+    messages: window.messages,
+  }
+
+  await queue.addJob("memory_extract", payload, {
+    jobKey: buildJobKey(sessionId, window.upToMessageId),
+    maxAttempts: 1,
+  })
+  return true
+}
+
+export function createMemoryScheduler(options: MemorySchedulerOptions): MemoryScheduler {
+  const threshold = normalizeThreshold(options.threshold)
+
+  return {
+    async recordMessage(message: MemoryMessageInput, queue: JobQueue): Promise<void> {
+      const occurredAt = message.occurredAt ? new Date(message.occurredAt) : new Date()
+
+      await options.db.transaction().execute(async (trx) => {
+        await trx
+          .insertInto("memory_extract_message")
+          .values({
+            session_id: message.sessionId,
+            agent_id: message.agentId,
+            role: message.role,
+            content: message.content,
+            occurred_at: occurredAt,
+          })
+          .executeTakeFirstOrThrow()
+
+        await trx
+          .insertInto("memory_extract_session_state")
+          .values({
+            session_id: message.sessionId,
+            pending_count: 1,
+            total_count: 1,
+          })
+          .onConflict((oc) =>
+            oc.column("session_id").doUpdateSet((eb) => ({
+              pending_count: eb("memory_extract_session_state.pending_count", "+", 1),
+              total_count: eb("memory_extract_session_state.total_count", "+", 1),
+              updated_at: new Date(),
+            })),
+          )
+          .executeTakeFirstOrThrow()
+      })
+
+      const state = await options.db
+        .selectFrom("memory_extract_session_state")
+        .select("pending_count")
+        .where("session_id", "=", message.sessionId)
+        .executeTakeFirst()
+
+      if (!state || state.pending_count < threshold) {
+        return
+      }
+
+      await enqueuePendingWindow(options.db, queue, message.sessionId)
+    },
+
+    async flushSession(sessionId: string, queue: JobQueue): Promise<void> {
+      await enqueuePendingWindow(options.db, queue, sessionId)
+    },
+
+    async flushAllPending(queue: JobQueue): Promise<number> {
+      const sessions = await options.db
+        .selectFrom("memory_extract_session_state")
+        .select("session_id")
+        .where("pending_count", ">", 0)
+        .execute()
+
+      for (const session of sessions) {
+        await enqueuePendingWindow(options.db, queue, session.session_id)
+      }
+
+      return sessions.length
+    },
+  }
+}


### PR DESCRIPTION
Closes #95

## Changes
- **Migration 010**: Added `memory_extract_session_state` and `memory_extract_message` tables for durable per-session message tracking
- **Memory scheduler module**: Configurable threshold-based extraction enqueue (~50 msgs default), idempotent job keys, session flush, and global pending flush
- **Agent execution wiring**: Records prompt/output messages during execution, triggers threshold-based extraction, flushes on session end
- **Shutdown drain**: Added `onDrainStart` hook to flush all pending sessions before worker stop
- **Startup recovery**: Flushes any sessions with pending messages on worker startup (crash recovery)
- **Config**: New `MEMORY_EXTRACT_THRESHOLD` env var (default: 50)
- **Tests**: Integration tests for threshold trigger, flush, restart recovery, and idempotency

## Notes
- All extraction is non-blocking (catch + ignore on failure)
- `pnpm typecheck` passes; existing lint/test failures in `@cortex/adapter-telegram` are unrelated