### PR TITLE
fix(control-plane): harden backend spawn env with explicit allowlist (#99)

### DIFF
--- a/packages/control-plane/src/backends/claude-code.ts
+++ b/packages/control-plane/src/backends/claude-code.ts
@@ -27,8 +27,10 @@ import type {
   OutputUsageEvent,
   TokenUsage,
 } from "@cortex/shared/backends"
-import { trace } from "@opentelemetry/api"
 import { CortexAttributes } from "@cortex/shared/tracing"
+import { trace } from "@opentelemetry/api"
+
+import { buildBackendSpawnEnv } from "./env-policy.js"
 
 const execFile = promisify(execFileCb)
 
@@ -133,10 +135,7 @@ export class ClaudeCodeBackend implements ExecutionBackend {
 
     const subprocess = spawn(this.binaryPath, [...args, prompt], {
       cwd: task.context.workspacePath,
-      env: {
-        ...process.env,
-        ...task.context.environment,
-      },
+      env: buildBackendSpawnEnv(task.context.environment),
       stdio: ["pipe", "pipe", "pipe"],
     })
 
@@ -413,7 +412,10 @@ class ClaudeCodeHandle implements ExecutionHandle {
         activeSpan.setAttribute(CortexAttributes.TOKEN_INPUT, tokenUsage.inputTokens)
         activeSpan.setAttribute(CortexAttributes.TOKEN_OUTPUT, tokenUsage.outputTokens)
         activeSpan.setAttribute(CortexAttributes.TOKEN_CACHE_READ, tokenUsage.cacheReadTokens)
-        activeSpan.setAttribute(CortexAttributes.TOKEN_CACHE_CREATION, tokenUsage.cacheCreationTokens)
+        activeSpan.setAttribute(
+          CortexAttributes.TOKEN_CACHE_CREATION,
+          tokenUsage.cacheCreationTokens,
+        )
         activeSpan.setAttribute(CortexAttributes.TOKEN_COST_USD, tokenUsage.costUsd)
       }
 

--- a/packages/control-plane/src/backends/env-policy.ts
+++ b/packages/control-plane/src/backends/env-policy.ts
@@ -1,0 +1,32 @@
+/**
+ * Environment policy for backend child processes.
+ *
+ * Secret handoff model:
+ * - Control-plane process secrets remain private by default and are not inherited.
+ * - Only a small OS/runtime allowlist is inherited from process.env.
+ * - Task-scoped env vars are explicitly injected per task and are the only supported
+ *   channel for handing agent-specific secrets (for example model API keys).
+ */
+const BACKEND_ENV_ALLOWLIST = ["PATH", "HOME", "NODE_PATH", "LANG", "TERM"] as const
+
+export function buildBackendSpawnEnv(taskEnvironment: Record<string, string>): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {}
+
+  for (const key of BACKEND_ENV_ALLOWLIST) {
+    const value = process.env[key]
+    if (typeof value === "string" && value.length > 0) {
+      env[key] = value
+    }
+  }
+
+  // Task context env is an explicit handoff from scheduler to backend process.
+  for (const [key, value] of Object.entries(taskEnvironment)) {
+    env[key] = value
+  }
+
+  // Audit only env key names, never values.
+  const injectedEnvKeys = Object.keys(env).sort()
+  console.debug("[backend-env] injected env keys for backend process", { keys: injectedEnvKeys })
+
+  return env
+}


### PR DESCRIPTION
Closes #99. Removes full process.env passthrough from backend spawns, replaces with explicit allowlist.