### PR TITLE
fix(dashboard): gate protected routes with stable auth guard

### DIFF
--- a/packages/dashboard/src/__tests__/auth-guard-routes.test.ts
+++ b/packages/dashboard/src/__tests__/auth-guard-routes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveAuthGuard } from "@/lib/auth-guard"
+
+describe("protected route coverage", () => {
+  const protectedRoutes = [
+    "/",
+    "/agents",
+    "/agents/agt-123",
+    "/jobs",
+    "/approvals",
+    "/memory",
+    "/pulse",
+    "/settings",
+  ]
+
+  it("requires login for every protected route", () => {
+    for (const route of protectedRoutes) {
+      const result = resolveAuthGuard(route, "unauthenticated")
+      expect(result.shouldRedirectToLogin).toBe(true)
+      expect(result.shouldHideChrome).toBe(false)
+    }
+  })
+
+  it("keeps every protected route blocked during unverified session state", () => {
+    for (const route of protectedRoutes) {
+      const result = resolveAuthGuard(route, "unverified")
+      expect(result.shouldShowUnverified).toBe(true)
+      expect(result.shouldRedirectToLogin).toBe(false)
+    }
+  })
+})

--- a/packages/dashboard/src/__tests__/auth-ui.test.ts
+++ b/packages/dashboard/src/__tests__/auth-ui.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
-import { getUserInitials, isPublicAuthPath, resolveAuthGuard } from "@/lib/auth-ui"
+import { getUserInitials } from "@/lib/auth-ui"
+import { isPublicAuthPath, resolveAuthGuard } from "@/lib/auth-guard"
 
 describe("auth-ui helpers", () => {
   it("uses display name initials for authenticated users", () => {
@@ -34,31 +35,66 @@ describe("auth-ui helpers", () => {
   it("treats login and auth completion as public auth paths", () => {
     expect(isPublicAuthPath("/login")).toBe(true)
     expect(isPublicAuthPath("/auth/complete")).toBe(true)
-    expect(isPublicAuthPath("/auth/complete/step")).toBe(true)
+    expect(isPublicAuthPath("/auth/complete/step")).toBe(false)
+    expect(isPublicAuthPath("/login/")).toBe(true)
     expect(isPublicAuthPath("/")).toBe(false)
   })
 
   it("keeps protected routes loading while session state is hydrating", () => {
-    expect(resolveAuthGuard("/", true, false)).toEqual({
+    expect(resolveAuthGuard("/", "loading")).toEqual({
       shouldHideChrome: false,
       shouldShowLoading: true,
+      shouldShowUnverified: false,
       shouldRedirectToLogin: false,
+      shouldRedirectToDashboard: false,
     })
   })
 
   it("redirects protected routes to login when unauthenticated", () => {
-    expect(resolveAuthGuard("/agents", false, false)).toEqual({
+    expect(resolveAuthGuard("/agents", "unauthenticated")).toEqual({
       shouldHideChrome: false,
       shouldShowLoading: false,
+      shouldShowUnverified: false,
       shouldRedirectToLogin: true,
+      shouldRedirectToDashboard: false,
     })
   })
 
   it("allows protected routes when authenticated", () => {
-    expect(resolveAuthGuard("/jobs", false, true)).toEqual({
+    expect(resolveAuthGuard("/jobs", "authenticated")).toEqual({
       shouldHideChrome: false,
       shouldShowLoading: false,
+      shouldShowUnverified: false,
       shouldRedirectToLogin: false,
+      shouldRedirectToDashboard: false,
+    })
+  })
+
+  it("blocks protected routes in unverified state without redirecting", () => {
+    expect(resolveAuthGuard("/memory", "unverified")).toEqual({
+      shouldHideChrome: false,
+      shouldShowLoading: false,
+      shouldShowUnverified: true,
+      shouldRedirectToLogin: false,
+      shouldRedirectToDashboard: false,
+    })
+  })
+
+  it("redirects public auth routes to dashboard only when authenticated", () => {
+    expect(resolveAuthGuard("/login", "authenticated")).toEqual({
+      shouldHideChrome: true,
+      shouldShowLoading: false,
+      shouldShowUnverified: false,
+      shouldRedirectToLogin: false,
+      shouldRedirectToDashboard: true,
+    })
+
+    expect(resolveAuthGuard("/login", "unverified")).toEqual({
+      shouldHideChrome: true,
+      shouldShowLoading: false,
+      shouldShowUnverified: false,
+      shouldRedirectToLogin: false,
+      shouldRedirectToDashboard: false,
     })
   })
 })

--- a/packages/dashboard/src/app/auth/complete/page.tsx
+++ b/packages/dashboard/src/app/auth/complete/page.tsx
@@ -24,8 +24,18 @@ function AuthCompleteInner() {
       }
 
       // Refresh session first so header/menu render authenticated identity immediately.
-      await refreshSession()
-      router.replace("/")
+      const status = await refreshSession()
+      if (status === "authenticated") {
+        router.replace("/")
+        return
+      }
+
+      if (status === "unverified") {
+        router.replace("/login?error=session_unverified")
+        return
+      }
+
+      router.replace("/login?error=session_expired")
     }
 
     void finalizeLogin()

--- a/packages/dashboard/src/app/login/page.tsx
+++ b/packages/dashboard/src/app/login/page.tsx
@@ -15,6 +15,7 @@ const ERROR_MESSAGES: Record<string, string> = {
   missing_params: "Missing authentication parameters.",
   provider_not_configured: "This login provider is not configured.",
   session_expired: "Your session has expired. Please sign in again.",
+  session_unverified: "Could not verify your session. Please try signing in again.",
 }
 
 // ---------------------------------------------------------------------------
@@ -22,7 +23,7 @@ const ERROR_MESSAGES: Record<string, string> = {
 // ---------------------------------------------------------------------------
 
 function LoginInner() {
-  const { login, isAuthenticated, isLoading } = useAuth()
+  const { login, authStatus, authError } = useAuth()
   const searchParams = useSearchParams()
   const router = useRouter()
   const [providers, setProviders] = useState<{ id: string; name: string }[]>([])
@@ -32,10 +33,10 @@ function LoginInner() {
 
   // Redirect if already authenticated
   useEffect(() => {
-    if (!isLoading && isAuthenticated) {
+    if (authStatus === "authenticated") {
       router.replace("/")
     }
-  }, [isLoading, isAuthenticated, router])
+  }, [authStatus, router])
 
   // Fetch available providers
   useEffect(() => {
@@ -48,7 +49,7 @@ function LoginInner() {
       .catch(() => setLoadingProviders(false))
   }, [])
 
-  if (isLoading) {
+  if (authStatus === "loading") {
     return (
       <div className="flex min-h-screen items-center justify-center bg-surface-dark">
         <div className="size-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
@@ -74,6 +75,13 @@ function LoginInner() {
         {error && (
           <div className="mb-4 rounded-lg border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
             {ERROR_MESSAGES[error] ?? `Authentication error: ${error}`}
+          </div>
+        )}
+        {authStatus === "unverified" && (
+          <div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-400">
+            Session verification is unstable. Please retry sign in once the control-plane is
+            reachable.
+            {authError ? <span className="block text-xs opacity-80">{authError}</span> : null}
           </div>
         )}
 

--- a/packages/dashboard/src/app/settings/page.tsx
+++ b/packages/dashboard/src/app/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRouter, useSearchParams } from "next/navigation"
+import { useSearchParams } from "next/navigation"
 import { Suspense, useCallback, useEffect, useState } from "react"
 
 import { useAuth } from "@/components/auth-provider"
@@ -32,8 +32,7 @@ interface Credential {
 // ---------------------------------------------------------------------------
 
 function SettingsInner() {
-  const { user, isAuthenticated, isLoading, csrfToken } = useAuth()
-  const router = useRouter()
+  const { user, authStatus, csrfToken } = useAuth()
   const searchParams = useSearchParams()
 
   const [providers, setProviders] = useState<ProviderInfo[]>([])
@@ -51,13 +50,6 @@ function SettingsInner() {
 
   const connected = searchParams.get("connected")
   const paramError = searchParams.get("error")
-
-  // Redirect if not authenticated
-  useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
-      router.replace("/login")
-    }
-  }, [isLoading, isAuthenticated, router])
 
   // Fetch providers and credentials
   const fetchData = useCallback(async () => {
@@ -86,8 +78,8 @@ function SettingsInner() {
   }, [csrfToken])
 
   useEffect(() => {
-    if (isAuthenticated) void fetchData()
-  }, [isAuthenticated, fetchData])
+    if (authStatus === "authenticated") void fetchData()
+  }, [authStatus, fetchData])
 
   // Connect OAuth provider
   const connectOAuth = useCallback((provider: string) => {
@@ -148,7 +140,7 @@ function SettingsInner() {
     [csrfToken, fetchData],
   )
 
-  if (isLoading || loading) {
+  if (authStatus === "loading" || loading) {
     return (
       <div className="flex justify-center py-12">
         <div className="size-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />

--- a/packages/dashboard/src/components/layout/nav-shell.tsx
+++ b/packages/dashboard/src/components/layout/nav-shell.tsx
@@ -4,9 +4,8 @@ import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 
-import { useAuth } from "@/components/auth-provider"
 import { UserMenu } from "@/components/layout/user-menu"
-import { resolveAuthGuard } from "@/lib/auth-ui"
+import { useAuthGuard } from "@/hooks/use-auth-guard"
 
 /* ── Navigation items ────────────────────────────────── */
 const navItems = [
@@ -171,11 +170,9 @@ function BottomTabs() {
 
 /* ── Shell ────────────────────────────────────────────── */
 export function NavShell({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname()
   const router = useRouter()
-  const { isLoading, isAuthenticated } = useAuth()
   const [collapsed, setCollapsed] = useState(false)
-  const guardState = resolveAuthGuard(pathname, isLoading, isAuthenticated)
+  const guardState = useAuthGuard()
 
   useEffect(() => {
     if (guardState.shouldRedirectToLogin) {
@@ -192,6 +189,36 @@ export function NavShell({ children }: { children: React.ReactNode }) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-surface-dark">
         <div className="size-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    )
+  }
+
+  if (guardState.shouldShowUnverified) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-surface-dark px-4">
+        <div className="max-w-md rounded-xl border border-surface-border bg-surface-light p-6 text-center">
+          <p className="text-sm font-semibold text-text-main">Unable to verify your session</p>
+          <p className="mt-2 text-sm text-text-muted">
+            The control-plane session endpoint is temporarily unavailable. Retry when connectivity
+            stabilizes.
+          </p>
+          <div className="mt-4 flex justify-center gap-3">
+            <button
+              type="button"
+              onClick={() => void guardState.refreshSession()}
+              className="rounded-lg border border-primary/30 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary transition-colors hover:bg-primary/20"
+            >
+              Retry session check
+            </button>
+            <button
+              type="button"
+              onClick={() => router.replace("/login")}
+              className="rounded-lg border border-surface-border bg-surface-dark px-4 py-2 text-sm font-semibold text-text-main transition-colors hover:bg-secondary"
+            >
+              Go to sign in
+            </button>
+          </div>
+        </div>
       </div>
     )
   }

--- a/packages/dashboard/src/hooks/use-auth-guard.ts
+++ b/packages/dashboard/src/hooks/use-auth-guard.ts
@@ -1,0 +1,25 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+import { useMemo } from "react"
+
+import { useAuth } from "@/components/auth-provider"
+import { resolveAuthGuard } from "@/lib/auth-guard"
+
+export function useAuthGuard() {
+  const pathname = usePathname()
+  const { authStatus, authError, refreshSession } = useAuth()
+
+  const guardState = useMemo(
+    () => resolveAuthGuard(pathname, authStatus),
+    [pathname, authStatus],
+  )
+
+  return {
+    pathname,
+    authStatus,
+    authError,
+    refreshSession,
+    ...guardState,
+  }
+}

--- a/packages/dashboard/src/lib/auth-guard.ts
+++ b/packages/dashboard/src/lib/auth-guard.ts
@@ -1,0 +1,63 @@
+import type { AuthStatus } from "@/components/auth-provider"
+
+const PUBLIC_AUTH_PATHS = ["/login", "/auth/complete"] as const
+
+function normalizePath(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith("/")) {
+    return pathname.slice(0, -1)
+  }
+  return pathname
+}
+
+export function isPublicAuthPath(pathname: string): boolean {
+  const normalizedPath = normalizePath(pathname)
+  return PUBLIC_AUTH_PATHS.some((path) => normalizedPath === path)
+}
+
+export interface RouteAuthGuardState {
+  shouldHideChrome: boolean
+  shouldShowLoading: boolean
+  shouldShowUnverified: boolean
+  shouldRedirectToLogin: boolean
+  shouldRedirectToDashboard: boolean
+}
+
+export function resolveAuthGuard(pathname: string, authStatus: AuthStatus): RouteAuthGuardState {
+  if (isPublicAuthPath(pathname)) {
+    return {
+      shouldHideChrome: true,
+      shouldShowLoading: authStatus === "loading",
+      shouldShowUnverified: false,
+      shouldRedirectToLogin: false,
+      shouldRedirectToDashboard: authStatus === "authenticated",
+    }
+  }
+
+  if (authStatus === "loading") {
+    return {
+      shouldHideChrome: false,
+      shouldShowLoading: true,
+      shouldShowUnverified: false,
+      shouldRedirectToLogin: false,
+      shouldRedirectToDashboard: false,
+    }
+  }
+
+  if (authStatus === "unverified") {
+    return {
+      shouldHideChrome: false,
+      shouldShowLoading: false,
+      shouldShowUnverified: true,
+      shouldRedirectToLogin: false,
+      shouldRedirectToDashboard: false,
+    }
+  }
+
+  return {
+    shouldHideChrome: false,
+    shouldShowLoading: false,
+    shouldShowUnverified: false,
+    shouldRedirectToLogin: authStatus === "unauthenticated",
+    shouldRedirectToDashboard: false,
+  }
+}

--- a/packages/dashboard/src/lib/auth-ui.ts
+++ b/packages/dashboard/src/lib/auth-ui.ts
@@ -1,10 +1,5 @@
 import type { SessionUser } from "@/components/auth-provider"
-
-const PUBLIC_AUTH_PATHS = ["/login", "/auth/complete"] as const
-
-export function isPublicAuthPath(pathname: string): boolean {
-  return PUBLIC_AUTH_PATHS.some((path) => pathname === path || pathname.startsWith(`${path}/`))
-}
+export { isPublicAuthPath, resolveAuthGuard } from "@/lib/auth-guard"
 
 export function getUserInitials(user: SessionUser | null): string {
   const source = user?.displayName?.trim() || user?.email?.trim() || ""
@@ -12,7 +7,7 @@ export function getUserInitials(user: SessionUser | null): string {
 
   const parts = source.split(/\s+/).filter(Boolean)
   if (parts.length === 1) {
-    return parts[0].slice(0, 2).toUpperCase()
+    return (parts[0] ?? "").slice(0, 2).toUpperCase()
   }
 
   return parts
@@ -20,37 +15,4 @@ export function getUserInitials(user: SessionUser | null): string {
     .map((word) => word[0] ?? "")
     .join("")
     .toUpperCase()
-}
-
-export function resolveAuthGuard(
-  pathname: string,
-  isLoading: boolean,
-  isAuthenticated: boolean,
-): {
-  shouldHideChrome: boolean
-  shouldShowLoading: boolean
-  shouldRedirectToLogin: boolean
-} {
-  const shouldHideChrome = isPublicAuthPath(pathname)
-  if (shouldHideChrome) {
-    return {
-      shouldHideChrome: true,
-      shouldShowLoading: false,
-      shouldRedirectToLogin: false,
-    }
-  }
-
-  if (isLoading) {
-    return {
-      shouldHideChrome: false,
-      shouldShowLoading: true,
-      shouldRedirectToLogin: false,
-    }
-  }
-
-  return {
-    shouldHideChrome: false,
-    shouldShowLoading: false,
-    shouldRedirectToLogin: !isAuthenticated,
-  }
 }


### PR DESCRIPTION
Closes #157
Addresses #174

## Changes
- **Auth provider:** 4-state model (`loading | authenticated | unauthenticated | unverified`). Network errors → `unverified` (retryable). 401/403 → `unauthenticated` (hard redirect). Eliminates login↔dashboard bounce loop.
- **Auth guard module:** New `lib/auth-guard.ts` with `resolveAuthGuard()` and shared `useAuthGuard` hook. All protected routes gated consistently.
- **Nav shell:** Shows explicit 'unverified' state with Retry + Sign In buttons when control-plane is unreachable. No more zombie UI.
- **Login page:** Only auto-redirects on `authenticated`, shows warning banner on `unverified`.
- **Auth complete page:** Validates session status before redirect — routes to login with error on failure.
- **Settings page:** Removed inline auth guard (now handled by nav shell).
- **Tests:** Auth guard route tests + updated auth-ui tests.

## What this fixes
- Dashboard rendering protected pages without verified session
- Login ↔ dashboard redirect loop when control-plane is down
- Menu showing 'Sign in' while displaying authenticated user data (#174)