### PR TITLE
feat(ci): self-hosted k3s deployment workflow

### DIFF
--- a/.github/workflows/deploy-self-hosted.yml
+++ b/.github/workflows/deploy-self-hosted.yml
@@ -1,0 +1,56 @@
+name: Deploy to k3s (self-hosted)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-k3s-prod
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, linux, cortex-k3s]
+    environment: production
+
+    env:
+      NAMESPACE: cortex
+      OVERLAY_DIR: deploy/k8s/overlays/prod
+      IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/cortex
+      IMAGE_TAG: ${{ github.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Set up kustomize
+        uses: imranismail/setup-kustomize@v2
+
+      - name: Write kubeconfig from secret (optional)
+        if: ${{ secrets.K3S_KUBECONFIG != '' }}
+        env:
+          K3S_KUBECONFIG: ${{ secrets.K3S_KUBECONFIG }}
+        run: |
+          set -euo pipefail
+          umask 077
+          printf '%s\n' "$K3S_KUBECONFIG" > "$RUNNER_TEMP/kubeconfig"
+          echo "KUBECONFIG=$RUNNER_TEMP/kubeconfig" >> "$GITHUB_ENV"
+
+      - name: Verify cluster access
+        run: |
+          set -euo pipefail
+          kubectl version --client=true
+          kubectl get namespace "$NAMESPACE"
+
+      - name: Deploy overlay and run smoke checks
+        run: |
+          set -euo pipefail
+          chmod +x scripts/deploy-k3s.sh
+          ./scripts/deploy-k3s.sh

--- a/docs/deploy/k3s.md
+++ b/docs/deploy/k3s.md
@@ -2,6 +2,9 @@
 
 Step-by-step runbook: blank Ubuntu VM to a healthy Cortex Plane cluster on k3s.
 
+For GitHub Actions automation on a private VM runner, see
+`docs/deploy/self-hosted-actions-runner-k3s.md`.
+
 ---
 
 ## 1. VM Preparation

--- a/docs/deploy/self-hosted-actions-runner-k3s.md
+++ b/docs/deploy/self-hosted-actions-runner-k3s.md
@@ -1,0 +1,113 @@
+# Self-Hosted GitHub Actions Deploys on k3s
+
+This runbook configures a private self-hosted GitHub Actions runner on your k3s VM so `main` pushes can deploy `deploy/k8s/overlays/prod` automatically.
+
+## 1. Prerequisites
+
+- A private k3s VM with cluster access for the runner user.
+- Repository admin access in `noncelogic/cortex-plane`.
+- Existing prod namespace `cortex` and app secrets.
+- `ghcr-secret` in namespace `cortex` so workloads can pull private images.
+
+## 2. Install Runner on the k3s VM
+
+Run as a non-root user dedicated to automation.
+
+```bash
+sudo apt update
+sudo apt install -y curl jq ca-certificates
+
+mkdir -p ~/actions-runner && cd ~/actions-runner
+# Replace with the latest release URL from GitHub Actions runner releases.
+curl -L -o actions-runner.tar.gz \
+  https://github.com/actions/runner/releases/download/v2.325.0/actions-runner-linux-x64-2.325.0.tar.gz
+tar xzf actions-runner.tar.gz
+```
+
+In GitHub: `Settings -> Actions -> Runners -> New self-hosted runner`, then use the generated configure command. Example:
+
+```bash
+./config.sh \
+  --url https://github.com/noncelogic/cortex-plane \
+  --token <registration-token> \
+  --labels self-hosted,linux,cortex-k3s \
+  --name cortex-k3s-runner
+```
+
+Install and start as a service:
+
+```bash
+sudo ./svc.sh install
+sudo ./svc.sh start
+sudo ./svc.sh status
+```
+
+## 3. Configure kubeconfig for the Runner
+
+Use one of these approaches:
+
+1. Recommended: put kubeconfig at `/home/<runner-user>/.kube/config` with access to namespace `cortex`.
+2. Optional fallback: add repo secret `K3S_KUBECONFIG` (full kubeconfig YAML). Workflow writes this to a temporary file.
+
+For local kubeconfig on the VM:
+
+```bash
+mkdir -p ~/.kube
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+sudo chown $(id -u):$(id -g) ~/.kube/config
+```
+
+If needed, edit the kubeconfig server address from `127.0.0.1` to the VM IP.
+
+## 4. Required Cluster Secrets and Objects
+
+The deploy workflow assumes these are already present in namespace `cortex`:
+
+- `control-plane-secrets`
+- `postgresql-app`
+- `postgresql-backup-s3` (if backups enabled)
+- `ghcr-secret` (image pull secret for GHCR)
+
+Example `ghcr-secret` creation:
+
+```bash
+kubectl -n cortex create secret docker-registry ghcr-secret \
+  --docker-server=ghcr.io \
+  --docker-username=<github-username> \
+  --docker-password=<github-classic-pat-or-fine-grained-token> \
+  --docker-email=<email>
+```
+
+## 5. Workflow Environment and Permissions
+
+Workflow file: `.github/workflows/deploy-self-hosted.yml`
+
+- Trigger: push to `main` and manual dispatch.
+- Runner labels: `self-hosted`, `linux`, `cortex-k3s`.
+- Namespace: `cortex`.
+- Overlay: `deploy/k8s/overlays/prod`.
+- Image tags: immutable SHA-based tags from `${GITHUB_SHA}`.
+
+Required workflow permissions:
+
+- `contents: read`
+- `packages: read`
+
+## 6. Deploy Sequence Per Run
+
+The workflow executes `scripts/deploy-k3s.sh`, which:
+
+1. Pins `control-plane` and `dashboard` images to commit SHA tags.
+2. Pins `playwright-sidecar` tag too when that image exists in rendered manifests.
+3. Applies `deploy/k8s/overlays/prod` with `kubectl apply -k`.
+4. Waits for rollout status on key deployments in namespace `cortex`.
+5. Runs smoke checks:
+   - `control-plane /healthz`
+   - `control-plane /readyz`
+   - `dashboard /`
+
+## 7. Operational Notes
+
+- Keep the runner private to your trusted network.
+- For long-term security, prefer ephemeral registration tokens and rotate PATs used by `ghcr-secret`.
+- If deploy fails with image pull errors, verify the image for that commit SHA was published and `ghcr-secret` is valid.

--- a/scripts/deploy-k3s.sh
+++ b/scripts/deploy-k3s.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-cortex}"
+OVERLAY_DIR="${OVERLAY_DIR:-deploy/k8s/overlays/prod}"
+IMAGE_PREFIX="${IMAGE_PREFIX:-ghcr.io/noncelogic/cortex}"
+ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-300s}"
+RESTORE_OVERLAY="${RESTORE_OVERLAY:-1}"
+
+if [ -n "${IMAGE_TAG:-}" ]; then
+  TAG="$IMAGE_TAG"
+elif [ -n "${GITHUB_SHA:-}" ]; then
+  TAG="${GITHUB_SHA:0:7}"
+else
+  echo "ERROR: IMAGE_TAG or GITHUB_SHA must be set" >&2
+  exit 1
+fi
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+check_http() {
+  local url="$1"
+  local expected_regex="$2"
+  local label="$3"
+
+  local status
+  status="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$url" || echo "000")"
+  if [[ "$status" =~ $expected_regex ]]; then
+    echo "PASS: ${label} returned HTTP ${status}"
+  else
+    echo "ERROR: ${label} expected ${expected_regex}, got HTTP ${status}" >&2
+    return 1
+  fi
+}
+
+wait_for_http() {
+  local url="$1"
+  local attempts="${2:-20}"
+  local sleep_seconds="${3:-2}"
+
+  local i
+  for i in $(seq 1 "$attempts"); do
+    if curl -sS -o /dev/null --max-time 5 "$url"; then
+      return 0
+    fi
+    sleep "$sleep_seconds"
+  done
+
+  echo "ERROR: timeout waiting for ${url}" >&2
+  return 1
+}
+
+pick_port() {
+  shuf -i "$1"-"$2" -n 1
+}
+
+require_cmd kubectl
+require_cmd kustomize
+require_cmd curl
+require_cmd shuf
+
+if [ ! -d "$OVERLAY_DIR" ]; then
+  echo "ERROR: overlay directory not found: $OVERLAY_DIR" >&2
+  exit 1
+fi
+
+OVERLAY_KUSTOMIZATION="$OVERLAY_DIR/kustomization.yaml"
+if [ ! -f "$OVERLAY_KUSTOMIZATION" ]; then
+  echo "ERROR: missing kustomization: $OVERLAY_KUSTOMIZATION" >&2
+  exit 1
+fi
+
+echo "Deploying to namespace '$NAMESPACE' using overlay '$OVERLAY_DIR'"
+echo "Using immutable image tag: $TAG"
+
+backup_file=""
+if [ "$RESTORE_OVERLAY" = "1" ]; then
+  backup_file="$(mktemp)"
+  cp "$OVERLAY_KUSTOMIZATION" "$backup_file"
+fi
+
+PF_CP_PID=""
+PF_DASH_PID=""
+cleanup() {
+  if [ -n "$PF_CP_PID" ]; then
+    kill "$PF_CP_PID" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$PF_DASH_PID" ]; then
+    kill "$PF_DASH_PID" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$backup_file" ] && [ -f "$backup_file" ]; then
+    cp "$backup_file" "$OVERLAY_KUSTOMIZATION"
+    rm -f "$backup_file"
+  fi
+}
+trap cleanup EXIT
+
+pushd "$OVERLAY_DIR" >/dev/null
+manifest_before="$(kustomize build .)"
+
+images=(
+  "${IMAGE_PREFIX}-control-plane=${IMAGE_PREFIX}-control-plane:${TAG}"
+  "${IMAGE_PREFIX}-dashboard=${IMAGE_PREFIX}-dashboard:${TAG}"
+)
+
+if echo "$manifest_before" | grep -q 'cortex-playwright-sidecar'; then
+  sidecar_repo="$(echo "$manifest_before" | sed -nE 's/^[[:space:]]*image:[[:space:]]*([^[:space:]]*cortex-playwright-sidecar)(:[^[:space:]]+)?$/\1/p' | head -n 1)"
+  if [ -z "$sidecar_repo" ]; then
+    sidecar_repo="${IMAGE_PREFIX}-playwright-sidecar"
+  fi
+  images+=("${sidecar_repo}=${sidecar_repo}:${TAG}")
+  echo "Detected sidecar image in manifests; pinning tag for $sidecar_repo"
+fi
+
+kustomize edit set image "${images[@]}"
+popd >/dev/null
+
+echo "Applying manifests"
+kubectl apply -k "$OVERLAY_DIR"
+
+echo "Waiting for rollout status"
+rollout_targets=(control-plane dashboard)
+for optional in qdrant postgres; do
+  if kubectl -n "$NAMESPACE" get "deployment/${optional}" >/dev/null 2>&1; then
+    rollout_targets+=("$optional")
+  fi
+done
+
+for deploy in "${rollout_targets[@]}"; do
+  kubectl -n "$NAMESPACE" rollout status "deployment/${deploy}" --timeout="$ROLLOUT_TIMEOUT"
+done
+
+echo "Running smoke checks"
+CP_PORT="$(pick_port 32000 36999)"
+DASH_PORT="$(pick_port 37000 41999)"
+
+kubectl -n "$NAMESPACE" port-forward service/control-plane "${CP_PORT}:4000" >/tmp/cortex-pf-control-plane.log 2>&1 &
+PF_CP_PID=$!
+kubectl -n "$NAMESPACE" port-forward service/dashboard "${DASH_PORT}:3000" >/tmp/cortex-pf-dashboard.log 2>&1 &
+PF_DASH_PID=$!
+
+wait_for_http "http://127.0.0.1:${CP_PORT}/healthz"
+wait_for_http "http://127.0.0.1:${DASH_PORT}/"
+
+check_http "http://127.0.0.1:${CP_PORT}/healthz" '^200$' 'control-plane /healthz'
+check_http "http://127.0.0.1:${CP_PORT}/readyz" '^200$' 'control-plane /readyz'
+check_http "http://127.0.0.1:${DASH_PORT}/" '^(200|301|302|307|308)$' 'dashboard /'
+
+echo "Deployed images"
+for deploy in control-plane dashboard; do
+  kubectl -n "$NAMESPACE" get "deployment/${deploy}" -o jsonpath='{.spec.template.spec.containers[*].name}{"="}{.spec.template.spec.containers[*].image}{"\n"}'
+done
+
+echo "Deployment completed successfully"


### PR DESCRIPTION
Closes #175

## Changes
- **Deploy workflow:** `.github/workflows/deploy-self-hosted.yml` — runs on `[self-hosted, linux, cortex-k3s]` runners, triggers on push to main + manual dispatch.
- **Deploy script:** `scripts/deploy-k3s.sh` — kustomize build, SHA-pinned image injection, rollout status, smoke checks (`/healthz`, `/readyz`, dashboard).
- **Runner docs:** `docs/deploy/self-hosted-actions-runner-k3s.md` — bootstrap guide for registering a runner on the k3s VM.
- **Concurrency lock:** Only one deploy at a time, no cancel-in-progress.

## How it works
1. Push to main triggers image build (existing workflow)
2. Self-hosted runner picks up deploy job
3. Script patches image tags to commit SHA via kustomize
4. Applies to `cortex` namespace
5. Waits for rollout + runs smoke checks
6. Reports success/failure

## Prerequisites
- Self-hosted runner registered with labels `self-hosted, linux, cortex-k3s`
- Runner has kubectl access to k3s cluster
- Optional: `K3S_KUBECONFIG` secret for explicit kubeconfig