### PR TITLE
fix(ci): chain deploy after image build and publish latest tags

### DIFF
--- a/.github/workflows/deploy-self-hosted.yml
+++ b/.github/workflows/deploy-self-hosted.yml
@@ -1,7 +1,9 @@
 name: Deploy to k3s (self-hosted)
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Build & Publish Images"]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -15,6 +17,10 @@ permissions:
 
 jobs:
   deploy:
+    # Only deploy if image build succeeded (or manual dispatch)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: [self-hosted, linux, cortex-k3s]
     environment: production
 
@@ -22,10 +28,22 @@ jobs:
       NAMESPACE: cortex
       OVERLAY_DIR: deploy/k8s/overlays/prod
       IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/cortex
-      IMAGE_TAG: ${{ github.sha }}
 
     steps:
+      - name: Resolve commit SHA
+        id: sha
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            FULL_SHA="${{ github.event.workflow_run.head_sha }}"
+          else
+            FULL_SHA="${{ github.sha }}"
+          fi
+          echo "full=${FULL_SHA}" >> "$GITHUB_OUTPUT"
+          echo "short=${FULL_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.sha.outputs.full }}
 
       - name: Set up kubectl
         uses: azure/setup-kubectl@v4
@@ -50,6 +68,8 @@ jobs:
           kubectl get namespace "$NAMESPACE"
 
       - name: Deploy overlay and run smoke checks
+        env:
+          IMAGE_TAG: ${{ steps.sha.outputs.short }}
         run: |
           set -euo pipefail
           chmod +x scripts/deploy-k3s.sh

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,6 +49,7 @@ jobs:
           tags: |
             type=sha,prefix=
             type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 


### PR DESCRIPTION
Closes #182

## Changes
- **Deploy waits for images:** Changed trigger from `push` to `workflow_run` on "Build & Publish Images" completion. Deploy only runs if build succeeds.
- **SHA tag alignment:** Resolves correct commit SHA from `workflow_run` event and passes 7-char short SHA to `deploy-k3s.sh` (matches `docker/metadata-action` `type=sha,prefix=`).
- **Latest tags:** Added `type=raw,value=latest,enable={{is_default_branch}}` to docker-publish so main branch builds also push `:latest`.
- **CNPG operator:** Installed CNPG v1.25.1 on k3s cluster (out-of-band, CRDs now available).

## Deploy flow after this
1. Push to main → Build & Publish Images (ubuntu-latest)
2. Build succeeds → Deploy to k3s (self-hosted runner)
3. Deploy pins images to 7-char SHA → kustomize apply → rollout check → smoke test
