### PR TITLE
fix(deploy): remove fixed postgresql parameter rejected by CNPG

### DIFF
--- a/deploy/k8s/postgresql/cluster.yaml
+++ b/deploy/k8s/postgresql/cluster.yaml
@@ -41,7 +41,6 @@ spec:
       max_wal_senders: "10"
       max_replication_slots: "10"
       wal_keep_size: "2GB"
-      shared_preload_libraries: pg_stat_statements
 
   backup:
     retentionPolicy: "7d"


### PR DESCRIPTION
CNPG manages `shared_preload_libraries` internally — setting it in the Cluster spec causes: `Can't set fixed configuration parameter`. This was the last deploy failure blocking the self-hosted workflow.

One-line fix: remove the parameter, let CNPG handle it.