### PR TITLE
fix(control-plane): add requireAuth to session and protected auth routes

### DIFF
--- a/packages/control-plane/src/routes/auth.ts
+++ b/packages/control-plane/src/routes/auth.ts
@@ -26,6 +26,7 @@ import {
 import { findOrCreateOAuthUser, SessionService } from "../auth/session-service.js"
 import type { AuthOAuthConfig, OAuthProviderConfig } from "../config.js"
 import type { Database } from "../db/types.js"
+import { createRequireAuth, type PreHandler } from "../middleware/auth.js"
 import type { AuthenticatedRequest } from "../middleware/types.js"
 
 // In-memory store for PKCE verifiers (keyed by state nonce).
@@ -44,6 +45,10 @@ export function authRoutes(deps: AuthRouteDeps) {
 
   return function register(app: FastifyInstance): void {
     const isSecure = authConfig.dashboardUrl.startsWith("https")
+    const requireAuth: PreHandler = createRequireAuth({
+      config: { apiKeys: [], requireAuth: true },
+      sessionService,
+    })
 
     /**
      * GET /auth/providers — list configured login providers
@@ -194,50 +199,67 @@ export function authRoutes(deps: AuthRouteDeps) {
     /**
      * GET /auth/session — get current session info (no secrets)
      */
-    app.get("/auth/session", async (request: FastifyRequest, reply: FastifyReply) => {
-      const principal = (request as AuthenticatedRequest).principal
-      if (!principal) {
-        reply.status(401).send({ error: "unauthorized", message: "Not authenticated" })
-        return
-      }
+    app.get(
+      "/auth/session",
+      { preHandler: [requireAuth] },
+      async (request: FastifyRequest, reply: FastifyReply) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          reply.status(401).send({ error: "unauthorized", message: "Not authenticated" })
+          return
+        }
 
-      return {
-        userId: principal.userId,
-        displayName: principal.displayName,
-        email: principal.email ?? null,
-        avatarUrl: principal.avatarUrl ?? null,
-        role: principal.userRole ?? null,
-        authMethod: principal.authMethod,
-      }
-    })
+        let avatarUrl = principal.avatarUrl ?? null
+        if (principal.authMethod === "session") {
+          const sessionId = SessionService.parseSessionCookie(request.headers.cookie)
+          if (sessionId) {
+            const sessionData = await sessionService.validateSession(sessionId)
+            avatarUrl = sessionData?.user.avatarUrl ?? avatarUrl
+          }
+        }
+
+        return {
+          userId: principal.userId,
+          displayName: principal.displayName,
+          email: principal.email ?? null,
+          avatarUrl,
+          role: principal.userRole ?? null,
+          authMethod: principal.authMethod,
+        }
+      },
+    )
 
     /**
      * POST /auth/logout — destroy session
      */
-    app.post("/auth/logout", async (request: FastifyRequest, reply: FastifyReply) => {
-      const principal = (request as AuthenticatedRequest).principal
-      if (principal?.authMethod === "session") {
-        const cookieHeader = request.headers.cookie
-        const sessionId = SessionService.parseSessionCookie(cookieHeader)
-        if (sessionId) {
-          await sessionService.deleteSession(sessionId)
+    app.post(
+      "/auth/logout",
+      { preHandler: [requireAuth] },
+      async (request: FastifyRequest, reply: FastifyReply) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (principal?.authMethod === "session") {
+          const cookieHeader = request.headers.cookie
+          const sessionId = SessionService.parseSessionCookie(cookieHeader)
+          if (sessionId) {
+            await sessionService.deleteSession(sessionId)
 
-          await db
-            .insertInto("credential_audit_log")
-            .values({
-              user_account_id: principal.userId,
-              event_type: "logout",
-              details: { ip: request.ip },
-              ip_address: request.ip,
-            })
-            .execute()
+            await db
+              .insertInto("credential_audit_log")
+              .values({
+                user_account_id: principal.userId,
+                event_type: "logout",
+                details: { ip: request.ip },
+                ip_address: request.ip,
+              })
+              .execute()
+          }
         }
-      }
 
-      const cookie = SessionService.clearCookie(isSecure)
-      reply.header("Set-Cookie", cookie)
-      return { ok: true }
-    })
+        const cookie = SessionService.clearCookie(isSecure)
+        reply.header("Set-Cookie", cookie)
+        return { ok: true }
+      },
+    )
 
     /**
      * GET /auth/connect/:provider — initiate LLM provider OAuth (PKCE)
@@ -245,6 +267,7 @@ export function authRoutes(deps: AuthRouteDeps) {
      */
     app.get<{ Params: { provider: string } }>(
       "/auth/connect/:provider",
+      { preHandler: [requireAuth] },
       async (request: FastifyRequest<{ Params: { provider: string } }>, reply: FastifyReply) => {
         const principal = (request as AuthenticatedRequest).principal
         if (!principal) {


### PR DESCRIPTION
Adds `requireAuth` preHandler to `/auth/session`, `/auth/logout`, and `/auth/connect/:provider`.

Without this middleware, the session cookie is never parsed into `request.principal`, so `/auth/session` always returns 401 — even immediately after a successful OAuth callback.

Also enriches the session response with `avatarUrl` from session data.

Closes #152

Supersedes #160 (which also included frontend changes already covered by #176 and #184).