### PR TITLE
fix: proxy API calls through Next.js rewrites instead of public endpoint (#197)

### DIFF
--- a/deploy/k8s/dashboard/configmap.yaml
+++ b/deploy/k8s/dashboard/configmap.yaml
@@ -12,4 +12,4 @@ data:
   PORT: "3000"
   NODE_ENV: "production"
   CORTEX_API_URL: "http://control-plane:4000"
-  NEXT_PUBLIC_CORTEX_API_URL: "https://cortex.example.com/api"
+  NEXT_PUBLIC_CORTEX_API_URL: "/api"

--- a/deploy/k8s/overlays/prod/ingress.yaml
+++ b/deploy/k8s/overlays/prod/ingress.yaml
@@ -27,24 +27,3 @@ spec:
                 name: dashboard
                 port:
                   number: 3000
-          - path: /api
-            pathType: Prefix
-            backend:
-              service:
-                name: control-plane
-                port:
-                  number: 4000
-          - path: /healthz
-            pathType: Exact
-            backend:
-              service:
-                name: control-plane
-                port:
-                  number: 4000
-          - path: /readyz
-            pathType: Exact
-            backend:
-              service:
-                name: control-plane
-                port:
-                  number: 4000

--- a/deploy/k8s/tailscale-proxy/configmap.yaml
+++ b/deploy/k8s/tailscale-proxy/configmap.yaml
@@ -24,15 +24,6 @@ data:
           "Handlers": {
             "/": {
               "Proxy": "http://dashboard.cortex.svc.cluster.local:3000"
-            },
-            "/api": {
-              "Proxy": "http://control-plane.cortex.svc.cluster.local:4000"
-            },
-            "/healthz": {
-              "Proxy": "http://control-plane.cortex.svc.cluster.local:4000"
-            },
-            "/readyz": {
-              "Proxy": "http://control-plane.cortex.svc.cluster.local:4000"
             }
           }
         }
@@ -52,15 +43,6 @@ data:
           "Handlers": {
             "/": {
               "Proxy": "http://dashboard.cortex.svc.cluster.local:3000"
-            },
-            "/api": {
-              "Proxy": "http://control-plane.cortex.svc.cluster.local:4000"
-            },
-            "/healthz": {
-              "Proxy": "http://control-plane.cortex.svc.cluster.local:4000"
-            },
-            "/readyz": {
-              "Proxy": "http://control-plane.cortex.svc.cluster.local:4000"
             }
           }
         }

--- a/packages/dashboard/src/__tests__/api-client.test.ts
+++ b/packages/dashboard/src/__tests__/api-client.test.ts
@@ -72,8 +72,8 @@ function statusForCode(code: number): string {
 // Tests
 // ---------------------------------------------------------------------------
 
-// API_BASE is evaluated at module load time, defaulting to localhost:4000
-const API_BASE = "http://localhost:4000"
+// API_BASE is evaluated at module load time, defaulting to /api
+const API_BASE = "/api"
 
 describe("API Client", () => {
   afterEach(() => {

--- a/packages/dashboard/src/__tests__/browser.test.ts
+++ b/packages/dashboard/src/__tests__/browser.test.ts
@@ -38,7 +38,7 @@ function statusForCode(code: number): string {
   return map[code] ?? "Unknown"
 }
 
-const API_BASE = "http://localhost:4000"
+const API_BASE = "/api"
 
 // ---------------------------------------------------------------------------
 // ConnectionStatus logic tests

--- a/packages/dashboard/src/__tests__/jobs.test.ts
+++ b/packages/dashboard/src/__tests__/jobs.test.ts
@@ -38,7 +38,7 @@ function statusForCode(code: number): string {
   return map[code] ?? "Unknown"
 }
 
-const API_BASE = "http://localhost:4000"
+const API_BASE = "/api"
 
 // ---------------------------------------------------------------------------
 // JobStatusBadge logic tests

--- a/packages/dashboard/src/__tests__/memory.test.ts
+++ b/packages/dashboard/src/__tests__/memory.test.ts
@@ -28,7 +28,7 @@ function statusForCode(code: number): string {
   return map[code] ?? "Unknown"
 }
 
-const API_BASE = "http://localhost:4000"
+const API_BASE = "/api"
 
 // ---------------------------------------------------------------------------
 // Mock memory records

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -117,7 +117,7 @@ function classifyNetworkError(err: unknown): ApiErrorCode {
 // API Client
 // ---------------------------------------------------------------------------
 
-const API_BASE = process.env.NEXT_PUBLIC_CORTEX_API_URL ?? "http://localhost:4000"
+const API_BASE = process.env.NEXT_PUBLIC_CORTEX_API_URL ?? "/api"
 
 const DEFAULT_TIMEOUT_MS = 10_000
 const MAX_RETRIES = 2


### PR DESCRIPTION
Fixes #197.

## Problem
Dashboard browser-side JS called `https://cortex-demo.../api/auth/session` through Tailscale proxy → control-plane:4000. Tailscale Serve preserves the `/api` prefix, but Fastify routes have no prefix → 404 on every client-side API call.

## Fix
The Next.js rewrite rule was already in `next.config.ts` from initial scaffold — it just wasn't being used because `NEXT_PUBLIC_CORTEX_API_URL` was an absolute URL that bypassed it.

Changes:
- `NEXT_PUBLIC_CORTEX_API_URL`: `https://cortex.example.com/api` → `/api` (relative, same-origin)
- `api-client.ts` default: `http://localhost:4000` → `/api`
- Tailscale serve config: removed `/api`, `/healthz`, `/readyz` handlers (internal-only)
- Prod ingress: removed (control-plane should not be publicly exposed)
- Tests updated to use `/api` base

Browser → Next.js (same origin) → control-plane (cluster-internal). No public API surface.

CI: format ✅ lint ✅ typecheck ✅ 899 tests ✅