### PR TITLE
feat: wire Settings page provider connect/disconnect/API key flows

### DIFF
--- a/packages/dashboard/src/lib/schemas/credentials.ts
+++ b/packages/dashboard/src/lib/schemas/credentials.ts
@@ -1,0 +1,37 @@
+import { z } from "zod"
+
+export const ProviderInfoSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  authType: z.enum(["oauth", "api_key"]),
+  description: z.string(),
+})
+
+export const CredentialSchema = z.object({
+  id: z.string(),
+  provider: z.string(),
+  credentialType: z.string(),
+  displayLabel: z.string().nullable(),
+  maskedKey: z.string().nullable(),
+  status: z.string(),
+  lastUsedAt: z.string().nullable(),
+  createdAt: z.string(),
+})
+
+export const ProviderListResponseSchema = z.object({
+  providers: z.array(ProviderInfoSchema),
+})
+
+export const CredentialListResponseSchema = z.object({
+  credentials: z.array(CredentialSchema),
+})
+
+export const OAuthInitResultSchema = z.object({
+  authUrl: z.string(),
+  codeVerifier: z.string(),
+  state: z.string(),
+})
+
+export type ProviderInfo = z.infer<typeof ProviderInfoSchema>
+export type Credential = z.infer<typeof CredentialSchema>
+export type OAuthInitResult = z.infer<typeof OAuthInitResultSchema>


### PR DESCRIPTION
Closes #209

## Changes
- **New Zod schemas** (`credentials.ts`): `ProviderInfo`, `Credential`, `OAuthInitResult`
- **New API functions** in `api-client.ts`: `listProviders`, `listCredentials`, `initOAuthConnect`, `exchangeOAuthConnect`, `saveProviderApiKey`, `deleteCredential`
- **Settings page**: replaced raw `fetch` calls with centralized `apiClient` functions. All buttons now wired:
  - Connect (OAuth code-paste flow) → `initOAuthConnect` → display authUrl → paste redirect → `exchangeOAuthConnect`
  - Disconnect → `deleteCredential`
  - API Key save → `saveProviderApiKey`
  - Provider status fetched on mount via `listCredentials`

## Testing
- 291 tests passing
- Format, lint, typecheck all clean