### PR TITLE
feat(dashboard): wire agent deploy, pause/resume, delete, and export (#210)

### DIFF
--- a/packages/control-plane/src/__tests__/approval-service.test.ts
+++ b/packages/control-plane/src/__tests__/approval-service.test.ts
@@ -141,8 +141,6 @@ describe("ApprovalService", () => {
       expect(result.expiresAt.getTime()).toBeLessThan(expectedExpiry + 5000)
     })
 
-
-
     it("applies risk-based defaults and auto-approves P3", async () => {
       db._txMockResult.executeTakeFirstOrThrow.mockResolvedValue({ id: "approval-p3" })
 
@@ -304,8 +302,6 @@ describe("ApprovalService", () => {
       expect(result.success).toBe(true)
     })
   })
-
-
 
   describe("resumeApproval", () => {
     it("returns proposal and payload for approved requests", async () => {

--- a/packages/control-plane/src/approval/telegram.ts
+++ b/packages/control-plane/src/approval/telegram.ts
@@ -49,7 +49,15 @@ export function formatApprovalMessage(params: {
   riskLevel?: "P0" | "P1" | "P2" | "P3"
   blastRadius?: string | null
 }): string {
-  const { agentName, actionSummary, actionType, jobId, expiresAt, riskLevel = "P2", blastRadius } = params
+  const {
+    agentName,
+    actionSummary,
+    actionType,
+    jobId,
+    expiresAt,
+    riskLevel = "P2",
+    blastRadius,
+  } = params
 
   const expiresIn = formatDuration(expiresAt.getTime() - Date.now())
   const expiresAtStr = expiresAt.toISOString().replace("T", " ").slice(0, 19) + " UTC"
@@ -79,7 +87,8 @@ export function formatDecisionMessage(params: {
   const { decision, decidedBy, agentName, actionSummary } = params
 
   const icon = decision === "APPROVED" ? "✅" : decision === "REJECTED" ? "❌" : "⏰"
-  const verb = decision === "APPROVED" ? "Approved" : decision === "REJECTED" ? "Rejected" : "Expired"
+  const verb =
+    decision === "APPROVED" ? "Approved" : decision === "REJECTED" ? "Rejected" : "Expired"
   const byLine = decision === "EXPIRED" || !decidedBy ? "" : ` by ${escapeMarkdown(decidedBy)}`
 
   return [

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -251,7 +251,6 @@ export interface ApprovalAuditLogTable {
 export type ApprovalAuditLog = Selectable<ApprovalAuditLogTable>
 export type NewApprovalAuditLog = Insertable<ApprovalAuditLogTable>
 
-
 // ---------------------------------------------------------------------------
 // Table: feedback_item
 // ---------------------------------------------------------------------------

--- a/packages/control-plane/src/feedback/service.ts
+++ b/packages/control-plane/src/feedback/service.ts
@@ -90,14 +90,18 @@ export class FeedbackService {
   }): Promise<FeedbackItem[]> {
     let q = this.db.selectFrom("feedback_item").selectAll()
     if (filters?.status) q = q.where("status", "=", filters.status)
-    if (filters?.remediationStatus) q = q.where("remediation_status", "=", filters.remediationStatus)
+    if (filters?.remediationStatus)
+      q = q.where("remediation_status", "=", filters.remediationStatus)
     if (filters?.severity) q = q.where("severity", "=", filters.severity)
     q = q.orderBy("created_at", "desc").limit(filters?.limit ?? 50)
     if (filters?.offset) q = q.offset(filters.offset)
     return q.execute()
   }
 
-  async updateRemediation(id: string, input: UpdateRemediationInput): Promise<FeedbackItem | undefined> {
+  async updateRemediation(
+    id: string,
+    input: UpdateRemediationInput,
+  ): Promise<FeedbackItem | undefined> {
     const patch: Record<string, unknown> = { updated_at: new Date() }
     if (input.status !== undefined) patch.status = input.status
     if (input.remediationStatus !== undefined) patch.remediation_status = input.remediationStatus

--- a/packages/dashboard/src/components/agents/deploy-agent-modal.tsx
+++ b/packages/dashboard/src/components/agents/deploy-agent-modal.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+import { useCallback, useState } from "react"
+
+import { createAgent, type CreateAgentRequest } from "@/lib/api-client"
+
+interface DeployAgentModalProps {
+  open: boolean
+  onClose: () => void
+  onSuccess: () => void
+}
+
+export function DeployAgentModal({
+  open,
+  onClose,
+  onSuccess,
+}: DeployAgentModalProps): React.JSX.Element | null {
+  const [name, setName] = useState("")
+  const [role, setRole] = useState("")
+  const [description, setDescription] = useState("")
+  const [systemPrompt, setSystemPrompt] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const resetForm = useCallback(() => {
+    setName("")
+    setRole("")
+    setDescription("")
+    setSystemPrompt("")
+    setError(null)
+  }, [])
+
+  const handleClose = useCallback(() => {
+    if (submitting) return
+    resetForm()
+    onClose()
+  }, [submitting, resetForm, onClose])
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault()
+      if (!name.trim() || !role.trim() || submitting) return
+
+      setSubmitting(true)
+      setError(null)
+
+      try {
+        const body: CreateAgentRequest = {
+          name: name.trim(),
+          role: role.trim(),
+          description: description.trim() || undefined,
+          model_config: systemPrompt.trim() ? { systemPrompt: systemPrompt.trim() } : undefined,
+        }
+        await createAgent(body)
+        resetForm()
+        onSuccess()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to deploy agent")
+      } finally {
+        setSubmitting(false)
+      }
+    },
+    [name, role, description, systemPrompt, submitting, resetForm, onSuccess],
+  )
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={handleClose} />
+
+      {/* Dialog */}
+      <div className="relative mx-4 w-full max-w-lg rounded-xl border border-slate-200 bg-white p-6 shadow-2xl dark:border-slate-700 dark:bg-slate-900">
+        {/* Header */}
+        <div className="mb-6 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10">
+              <span className="material-symbols-outlined text-xl text-primary">smart_toy</span>
+            </div>
+            <div>
+              <h2 className="text-lg font-bold text-slate-900 dark:text-white">Deploy New Agent</h2>
+              <p className="text-xs text-slate-500">Configure and deploy an autonomous agent</p>
+            </div>
+          </div>
+          <button
+            onClick={handleClose}
+            className="flex size-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800"
+          >
+            <span className="material-symbols-outlined text-xl">close</span>
+          </button>
+        </div>
+
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+          {/* Agent Name */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">
+              Agent Name <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Research Assistant"
+              disabled={submitting}
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:ring-1 focus:ring-primary dark:border-slate-600 dark:bg-slate-800 dark:text-white"
+            />
+          </div>
+
+          {/* Role / Provider */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">
+              Role <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              placeholder="e.g. researcher, code-reviewer, content-writer"
+              disabled={submitting}
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:ring-1 focus:ring-primary dark:border-slate-600 dark:bg-slate-800 dark:text-white"
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">
+              Description
+            </label>
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Brief description of this agent's purpose"
+              disabled={submitting}
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:ring-1 focus:ring-primary dark:border-slate-600 dark:bg-slate-800 dark:text-white"
+            />
+          </div>
+
+          {/* System Prompt */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">
+              System Prompt
+            </label>
+            <textarea
+              value={systemPrompt}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                setSystemPrompt(e.target.value)
+              }
+              placeholder="Instructions for the agent's behavior..."
+              rows={4}
+              disabled={submitting}
+              className="w-full resize-none rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:ring-1 focus:ring-primary dark:border-slate-600 dark:bg-slate-800 dark:text-white"
+            />
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="flex items-center gap-2 rounded-lg bg-red-500/10 px-3 py-2 text-xs font-medium text-red-500">
+              <span className="material-symbols-outlined text-[16px]">error</span>
+              {error}
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={handleClose}
+              disabled={submitting}
+              className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || !name.trim() || !role.trim()}
+              className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-primary/20 transition-all hover:bg-primary/90 disabled:opacity-50"
+            >
+              <span className="material-symbols-outlined text-lg">rocket_launch</span>
+              {submitting ? "Deploying..." : "Deploy Agent"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -11,6 +11,7 @@ import { z } from "zod"
 import {
   ApprovalDecisionResponseSchema,
   ArchiveContentResponseSchema,
+  CreateAgentJobResponseSchema,
   PauseResponseSchema,
   PublishContentResponseSchema,
   ResumeResponseSchema,
@@ -347,6 +348,61 @@ export async function listAgents(params?: {
 
 export async function getAgent(agentId: string): Promise<import("./schemas/agents").AgentDetail> {
   return apiFetch(`/agents/${agentId}`, { schema: AgentDetailSchema })
+}
+
+export interface CreateAgentRequest {
+  name: string
+  role: string
+  slug?: string
+  description?: string
+  model_config?: Record<string, unknown>
+  skill_config?: Record<string, unknown>
+  resource_limits?: Record<string, unknown>
+  channel_permissions?: Record<string, unknown>
+}
+
+export interface UpdateAgentRequest {
+  name?: string
+  role?: string
+  description?: string | null
+  model_config?: Record<string, unknown>
+  skill_config?: Record<string, unknown>
+  resource_limits?: Record<string, unknown>
+  channel_permissions?: Record<string, unknown>
+  status?: "ACTIVE" | "DISABLED" | "ARCHIVED"
+}
+
+export interface CreateAgentJobRequest {
+  prompt: string
+  goal_type?: string
+  model?: string
+  priority?: number
+  timeout_seconds?: number
+  max_attempts?: number
+  payload?: Record<string, unknown>
+}
+
+export async function createAgent(body: CreateAgentRequest): Promise<unknown> {
+  return apiFetch("/agents", { method: "POST", body, schema: z.unknown() })
+}
+
+export async function updateAgent(agentId: string, body: UpdateAgentRequest): Promise<unknown> {
+  return apiFetch(`/agents/${agentId}`, { method: "PUT", body, schema: z.unknown() })
+}
+
+export async function deleteAgent(agentId: string): Promise<unknown> {
+  return apiFetch(`/agents/${agentId}`, { method: "DELETE", schema: z.unknown() })
+}
+
+export async function createAgentJob(
+  agentId: string,
+  body: CreateAgentJobRequest,
+): Promise<import("./schemas/actions").CreateAgentJobResponse> {
+  return apiFetch(`/agents/${agentId}/jobs`, {
+    method: "POST",
+    body,
+    schema: CreateAgentJobResponseSchema,
+  })
 }
 
 export async function steerAgent(agentId: string, request: SteerRequest) {

--- a/packages/dashboard/src/lib/schemas/actions.ts
+++ b/packages/dashboard/src/lib/schemas/actions.ts
@@ -22,6 +22,14 @@ export const ResumeResponseSchema = z.object({
   fromCheckpoint: z.string().optional(),
 })
 
+export const CreateAgentJobResponseSchema = z.object({
+  id: z.string(),
+  agent_id: z.string(),
+  status: z.string(),
+})
+
+export type CreateAgentJobResponse = z.infer<typeof CreateAgentJobResponseSchema>
+
 // ---------------------------------------------------------------------------
 // Approval action responses
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #210.

- Agent CRUD API client functions (create, update, delete, createJob)
- Deploy New Agent modal with form validation
- Agent detail: pause/resume/delete with confirmation dialog
- Agents list: export as JSON, deploy modal integration
- Action response Zod schema

+425/-25, 10 files. CI: format ✅, typecheck ✅, 291/291 tests ✅.