### PR TITLE
feat(dashboard): wire job monitoring, SSE streaming, export, and agent jobs tab (#211)

### DIFF
--- a/packages/dashboard/src/app/agents/[agentId]/page.tsx
+++ b/packages/dashboard/src/app/agents/[agentId]/page.tsx
@@ -4,6 +4,7 @@ import { use, useCallback, useMemo, useState } from "react"
 
 import { AgentConsole } from "@/components/agents/agent-console"
 import { AgentHeader } from "@/components/agents/agent-header"
+import { AgentJobsTab } from "@/components/agents/agent-jobs-tab"
 import { type LifecycleStep, LifecycleTimeline } from "@/components/agents/lifecycle-timeline"
 import { ResourceSparklines } from "@/components/agents/resource-sparklines"
 import { SteerInput } from "@/components/agents/steer-input"
@@ -23,7 +24,7 @@ import {
 // Mobile tabs
 // ---------------------------------------------------------------------------
 
-const MOBILE_TABS = ["Output", "Details", "Browser", "Memory"] as const
+const MOBILE_TABS = ["Output", "Details", "Jobs", "Browser", "Memory"] as const
 type MobileTab = (typeof MOBILE_TABS)[number]
 
 // ---------------------------------------------------------------------------
@@ -290,6 +291,7 @@ export default function AgentDetailPage({ params }: Props): React.JSX.Element {
             <LifecycleDetails transitions={transitions} currentState={currentState} />
           </div>
         )}
+        {mobileTab === "Jobs" && <AgentJobsTab agentId={agentId} />}
         {mobileTab === "Browser" && (
           <div className="flex flex-1 items-center justify-center rounded-xl border border-surface-border bg-surface-dark p-8">
             <div className="text-center">

--- a/packages/dashboard/src/app/jobs/page.tsx
+++ b/packages/dashboard/src/app/jobs/page.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useState } from "react"
+
 import { JobCard } from "@/components/jobs/job-card"
 import { JobDetailDrawer } from "@/components/jobs/job-detail-drawer"
 import { JobTable } from "@/components/jobs/job-table"
@@ -18,11 +20,16 @@ export default function JobsPage(): React.JSX.Element {
     counts,
     selectedJobId,
     setSelectedJobId,
+    statusFilter,
+    setStatusFilter,
     isLoading,
     error,
     errorCode,
     handleRefresh,
+    exportJobs,
   } = useJobsPage()
+
+  const [showExportMenu, setShowExportMenu] = useState(false)
 
   // Loading skeleton
   if (isLoading && jobs.length === 0) {
@@ -56,13 +63,50 @@ export default function JobsPage(): React.JSX.Element {
           </p>
         </div>
         <div className="flex gap-3">
-          <button
-            type="button"
-            className="flex items-center gap-2 rounded-lg bg-slate-200 px-4 py-2 text-sm font-semibold transition-all hover:bg-slate-300 dark:bg-slate-800 dark:hover:bg-slate-700"
-          >
-            <span className="material-symbols-outlined text-lg">download</span>
-            Export CSV
-          </button>
+          {/* Export dropdown */}
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setShowExportMenu((v) => !v)}
+              className="flex items-center gap-2 rounded-lg bg-slate-200 px-4 py-2 text-sm font-semibold transition-all hover:bg-slate-300 dark:bg-slate-800 dark:hover:bg-slate-700"
+            >
+              <span className="material-symbols-outlined text-lg">download</span>
+              Export
+            </button>
+            {showExportMenu && (
+              <>
+                <div className="fixed inset-0 z-40" onClick={() => setShowExportMenu(false)} />
+                <div className="absolute right-0 z-50 mt-1 w-36 overflow-hidden rounded-lg border border-surface-border bg-surface-light shadow-lg">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      exportJobs("csv")
+                      setShowExportMenu(false)
+                    }}
+                    className="flex w-full items-center gap-2 px-4 py-2.5 text-sm text-text-main transition-colors hover:bg-secondary"
+                  >
+                    <span className="material-symbols-outlined text-base text-text-muted">
+                      table_chart
+                    </span>
+                    CSV
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      exportJobs("json")
+                      setShowExportMenu(false)
+                    }}
+                    className="flex w-full items-center gap-2 px-4 py-2.5 text-sm text-text-main transition-colors hover:bg-secondary"
+                  >
+                    <span className="material-symbols-outlined text-base text-text-muted">
+                      data_object
+                    </span>
+                    JSON
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
           <button
             type="button"
             onClick={handleRefresh}
@@ -114,7 +158,13 @@ export default function JobsPage(): React.JSX.Element {
         <>
           {/* Desktop: Table view */}
           <div className="hidden md:block">
-            <JobTable jobs={jobs} onSelectJob={setSelectedJobId} onRetried={handleRefresh} />
+            <JobTable
+              jobs={jobs}
+              onSelectJob={setSelectedJobId}
+              onRetried={handleRefresh}
+              statusFilter={statusFilter}
+              onStatusFilterChange={setStatusFilter}
+            />
           </div>
 
           {/* Mobile: Card view */}

--- a/packages/dashboard/src/components/agents/agent-jobs-tab.tsx
+++ b/packages/dashboard/src/components/agents/agent-jobs-tab.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import { useCallback, useMemo, useState } from "react"
+
+import { JobDetailDrawer } from "@/components/jobs/job-detail-drawer"
+import { JobStatusBadge } from "@/components/jobs/job-status-badge"
+import { useApi, useApiQuery } from "@/hooks/use-api"
+import type { CreateAgentJobRequest, JobSummary } from "@/lib/api-client"
+import { createAgentJob, listJobs } from "@/lib/api-client"
+import { duration, relativeTime, truncateUuid } from "@/lib/format"
+
+interface AgentJobsTabProps {
+  agentId: string
+}
+
+export function AgentJobsTab({ agentId }: AgentJobsTabProps): React.JSX.Element {
+  const { data, isLoading, error, refetch } = useApiQuery(
+    () => listJobs({ agentId, limit: 50 }),
+    [agentId],
+  )
+
+  const jobs: JobSummary[] = useMemo(() => data?.jobs ?? [], [data])
+
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null)
+  const [prompt, setPrompt] = useState("")
+  const {
+    execute: execCreate,
+    isLoading: creating,
+    error: createError,
+  } = useApi(createAgentJob as (...args: unknown[]) => Promise<unknown>)
+  const [createSuccess, setCreateSuccess] = useState(false)
+
+  const handleCreateJob = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault()
+      if (!prompt.trim() || creating) return
+      const body: CreateAgentJobRequest = { prompt: prompt.trim() }
+      const result = await execCreate(agentId, body)
+      if (result) {
+        setPrompt("")
+        setCreateSuccess(true)
+        void refetch()
+        setTimeout(() => setCreateSuccess(false), 3000)
+      }
+    },
+    [agentId, prompt, creating, execCreate, refetch],
+  )
+
+  return (
+    <div className="space-y-6">
+      {/* Create Job form */}
+      <div className="rounded-xl border border-surface-border bg-surface-light p-5">
+        <div className="mb-4 flex items-center gap-2">
+          <span className="material-symbols-outlined text-primary">add_task</span>
+          <h3 className="text-xs font-bold uppercase tracking-widest text-text-muted">
+            Create Job
+          </h3>
+        </div>
+        <form onSubmit={(e) => void handleCreateJob(e)} className="space-y-3">
+          <textarea
+            value={prompt}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setPrompt(e.target.value)}
+            placeholder="Describe the task for this agent..."
+            rows={3}
+            disabled={creating}
+            className="w-full resize-none rounded-lg border border-surface-border bg-bg-light p-3 text-sm text-text-main placeholder:text-text-muted focus:border-primary focus:ring-1 focus:ring-primary"
+          />
+          <button
+            type="submit"
+            disabled={creating || !prompt.trim()}
+            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-bold text-white shadow-lg shadow-primary/20 transition-all hover:bg-primary/90 disabled:opacity-50"
+          >
+            <span className="material-symbols-outlined text-[18px]">
+              {creating ? "sync" : "play_arrow"}
+            </span>
+            {creating ? "Creating..." : "Create Job"}
+          </button>
+          {createSuccess && (
+            <div className="flex items-center gap-2 rounded-lg bg-emerald-500/10 px-3 py-2 text-xs font-medium text-emerald-500">
+              <span className="material-symbols-outlined text-[16px]">check_circle</span>
+              Job created successfully
+            </div>
+          )}
+          {createError && (
+            <div className="flex items-center gap-2 rounded-lg bg-red-500/10 px-3 py-2 text-xs font-medium text-red-500">
+              <span className="material-symbols-outlined text-[16px]">error</span>
+              {createError}
+            </div>
+          )}
+        </form>
+      </div>
+
+      {/* Job list */}
+      <div className="rounded-xl border border-surface-border bg-surface-light">
+        <div className="flex items-center justify-between border-b border-surface-border p-4">
+          <div className="flex items-center gap-2">
+            <span className="material-symbols-outlined text-primary">list_alt</span>
+            <h3 className="text-xs font-bold uppercase tracking-widest text-text-muted">
+              Job History
+            </h3>
+          </div>
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            className="rounded-lg p-1.5 text-text-muted transition-colors hover:bg-secondary hover:text-primary"
+            title="Refresh"
+          >
+            <span className="material-symbols-outlined text-lg">refresh</span>
+          </button>
+        </div>
+
+        {isLoading && jobs.length === 0 ? (
+          <div className="flex items-center justify-center py-12">
+            <span className="material-symbols-outlined animate-spin text-2xl text-text-muted">
+              sync
+            </span>
+          </div>
+        ) : error ? (
+          <div className="px-4 py-8 text-center text-sm text-text-muted">{error}</div>
+        ) : jobs.length === 0 ? (
+          <div className="px-4 py-8 text-center">
+            <span className="material-symbols-outlined mb-2 text-3xl text-text-muted">
+              work_history
+            </span>
+            <p className="text-sm text-text-muted">No jobs for this agent yet.</p>
+          </div>
+        ) : (
+          <div className="divide-y divide-surface-border">
+            {jobs.map((job) => {
+              const durationMs =
+                job.completedAt && job.createdAt
+                  ? new Date(job.completedAt).getTime() - new Date(job.createdAt).getTime()
+                  : null
+              return (
+                <button
+                  key={job.id}
+                  type="button"
+                  onClick={() => setSelectedJobId(job.id)}
+                  className="flex w-full items-center gap-4 px-4 py-3 text-left transition-colors hover:bg-primary/5"
+                >
+                  <span className="font-mono text-xs font-bold text-primary">
+                    {truncateUuid(job.id)}
+                  </span>
+                  <JobStatusBadge status={job.status} />
+                  <span className="rounded-md bg-secondary px-2 py-0.5 text-xs text-text-muted">
+                    {job.type}
+                  </span>
+                  <span className="ml-auto font-mono text-xs text-text-muted">
+                    {durationMs !== null ? duration(durationMs) : "—"}
+                  </span>
+                  <span className="text-xs text-text-muted">{relativeTime(job.createdAt)}</span>
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Detail Drawer */}
+      <JobDetailDrawer
+        jobId={selectedJobId}
+        onClose={() => setSelectedJobId(null)}
+        onRetried={() => void refetch()}
+      />
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/jobs/job-detail-drawer.tsx
+++ b/packages/dashboard/src/components/jobs/job-detail-drawer.tsx
@@ -278,6 +278,21 @@ export function JobDetailDrawer({
           <div className="flex items-center justify-between border-t border-surface-border p-4">
             <button
               type="button"
+              onClick={() => {
+                if (!job.logs.length) return
+                const lines = job.logs.map(
+                  (l) => `${new Date(l.timestamp).toISOString()} [${l.level}] ${l.message}`,
+                )
+                const blob = new Blob([lines.join("\n")], { type: "text/plain" })
+                const url = URL.createObjectURL(blob)
+                const a = document.createElement("a")
+                a.href = url
+                a.download = `job-${jobId.slice(0, 8)}-logs.txt`
+                document.body.appendChild(a)
+                a.click()
+                document.body.removeChild(a)
+                URL.revokeObjectURL(url)
+              }}
               className="flex items-center gap-2 rounded-lg bg-secondary px-4 py-2 text-sm font-bold text-text-main transition-colors hover:bg-surface-border"
             >
               <span className="material-symbols-outlined text-lg">download</span>

--- a/packages/dashboard/src/lib/sse-client.ts
+++ b/packages/dashboard/src/lib/sse-client.ts
@@ -35,6 +35,10 @@ const KNOWN_EVENT_TYPES = [
   "browser:screenshot",
   "browser:trace:state",
   "browser:annotation:ack",
+  "job:created",
+  "job:updated",
+  "job:completed",
+  "job:failed",
 ] as const
 
 /**


### PR DESCRIPTION
Closes #211.

- SSE job events (created/updated/completed/failed) wired to dashboard
- Server-side status filtering on jobs list
- CSV/JSON export for jobs
- Job detail drawer: download logs as .txt
- Agent-specific jobs tab with create job form
- AgentJobsTab component integrated into agent detail page

+425 lines, 7 files. CI: format ✅, typecheck ✅, 291/291 tests ✅.