### PR TITLE
feat(dashboard): wire memory explorer search, viewer, editor, export (#213, #216)

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -1,47 +1,49 @@
-# Epic #212: Approve Agent Actions
+# Epic #213: Memory Explorer
 
 ## Context
 
-The Approvals page (`/approvals`) shows approval requests but has dead buttons for approve/reject and the audit drawer. Backend routes exist in `packages/control-plane/src/routes/approval.ts`.
+The Memory page (`/memory`) has dead search, sync, document viewer, and editor buttons. Also has a bug (#216): initial load sends `*` as query which backend tries to parse as UUID → crash.
 
 ## What Needs to Happen
 
-### 1. Approval List — Real Data
+### 1. Fix #216 — UUID Parse Error on Load
 
-- Verify `GET /approvals` is called on mount with real data
-- Show approval cards with risk level badges (P0-P3 from PR #190)
-- Wire filter/sort controls to query params
+- The page sends `*` as default search query on mount
+- Backend `GET /memory/search` tries to use it as UUID → Postgres rejects
+- Fix: either don't send initial query (show empty state) or handle wildcard/empty gracefully
 
-### 2. Approve/Reject Actions
+### 2. Memory Search
 
-- Wire approve button to `POST /approvals/:id/decide` with `{ decision: "approved", reason?: string }`
-- Wire reject button to `POST /approvals/:id/decide` with `{ decision: "rejected", reason?: string }`
-- Add confirmation dialog for reject
-- Show loading state during submission
-- Refresh list after decision
+- Wire search input to `GET /memory/search?query=...`
+- Show results in the results panel
+- Handle empty results gracefully
 
-### 3. Audit Trail Drawer
+### 3. Sync Status & Trigger
 
-- Wire audit drawer to load data for selected approval
-- Show decision history, timestamps, actors
-- Wire to `GET /approvals/:id` for detailed data
+- Wire sync button to `POST /memory/sync`
+- Show sync status indicator (syncing/synced/error)
+- Component at `packages/dashboard/src/components/memory/sync-status.tsx`
 
-### 4. Real-Time Updates (SSE)
+### 4. Document Viewer
 
-- Wire SSE for real-time approval notifications
-- New approval requests should appear without manual refresh
-- Status changes should update in real-time
+- Wire document viewer at `packages/dashboard/src/components/memory/document-viewer.tsx`
+- Edit/delete buttons need onClick handlers
+- View button should load full document content
 
-### 5. Approval Actions Component
+### 5. Memory Editor
 
-Check `packages/dashboard/src/components/approvals/approval-actions.tsx` for dead buttons and wire them.
+- Wire save button in `packages/dashboard/src/components/memory/memory-editor.tsx`
+- Should persist edits via appropriate API call
 
-## Backend Routes (already exist in approval.ts)
+### 6. Related Panel
 
-- `POST /approvals/:agentId/request` — create approval request
-- `POST /approvals/:id/decide` — approve or reject
-- `GET /approvals` — list all approval requests
-- `GET /approvals/:id` — get approval details
+- Wire related memories panel at `packages/dashboard/src/components/memory/related-panel.tsx`
+- Click on related item should navigate/load that memory
+
+## Backend Routes (already exist in dashboard.ts)
+
+- `GET /memory/search` — search memories (query, limit params)
+- `POST /memory/sync` — trigger memory sync
 
 ## Constraints
 
@@ -49,4 +51,4 @@ Check `packages/dashboard/src/components/approvals/approval-actions.tsx` for dea
 - Add Zod schemas if needed
 - Keep existing visual design
 - Run `pnpm format && pnpm lint && pnpm typecheck && pnpm test` before finishing
-- When completely finished, run: openclaw system event --text "JOB_DONE:issue-212" --mode now
+- When completely finished, run: openclaw system event --text "JOB_DONE:issue-213" --mode now

--- a/packages/dashboard/src/components/memory/document-viewer.tsx
+++ b/packages/dashboard/src/components/memory/document-viewer.tsx
@@ -136,6 +136,12 @@ export function DocumentViewer({
           </button>
           <button
             type="button"
+            onClick={() => {
+              if (!record) return
+              const blob = new Blob([record.content], { type: "text/plain" })
+              const url = URL.createObjectURL(blob)
+              window.open(url, "_blank")
+            }}
             className="flex items-center gap-1.5 rounded-lg bg-slate-800 px-3 py-2 text-xs font-medium text-slate-300 transition-colors hover:bg-slate-700"
           >
             <span className="material-symbols-outlined text-sm">open_in_new</span>

--- a/packages/dashboard/src/components/memory/memory-results.tsx
+++ b/packages/dashboard/src/components/memory/memory-results.tsx
@@ -94,6 +94,22 @@ export function MemoryResults({
         </span>
         <button
           type="button"
+          onClick={() => {
+            if (results.length === 0) return
+            const header = "id,type,content,importance,confidence,source,createdAt\n"
+            const rows = results.map((r) => {
+              const escaped = r.content.replace(/"/g, '""')
+              return `${r.id},${r.type},"${escaped}",${r.importance},${r.confidence},${r.source},${r.createdAt}`
+            })
+            const csv = header + rows.join("\n")
+            const blob = new Blob([csv], { type: "text/csv" })
+            const url = URL.createObjectURL(blob)
+            const a = document.createElement("a")
+            a.href = url
+            a.download = "memory-export.csv"
+            a.click()
+            URL.revokeObjectURL(url)
+          }}
           className="flex items-center gap-1.5 rounded-lg bg-slate-800 px-3 py-1.5 text-xs font-medium text-slate-400 transition-colors hover:bg-slate-700 hover:text-slate-300"
         >
           <span className="material-symbols-outlined text-sm">download</span>


### PR DESCRIPTION
## Summary

Implements Epic #213 (Memory Explorer) and fixes Bug #216 (UUID parse error on load).

### Bug #216 Fix — UUID Parse Error
**Root cause:** On mount, `useMemoryExplorer` sent `agentId: "*"` to `GET /memory/search`. The backend used `"*"` in a `WHERE agent_id = '*'` clause against a UUID column, causing a Postgres parse error.

- **Frontend:** Changed default to `"default"`, skip API call when query is empty
- **Backend:** Added UUID validation regex — non-UUID values skip the filter

### Memory Explorer Wiring
- **Search:** Fixed by #216 fix — queries no longer sent with empty/wildcard values
- **Sync:** Added post-sync `refetch()` to refresh results after syncing
- **Document Viewer:** Wired "Open" button to open content in new tab via Blob URL
- **Memory Editor:** Wired "Save & Sync" button with loading/saved/error states
- **Export CSV:** Wired dead "Export CSV" button to generate and download CSV

### Files Changed (6 files, +102/−43)
- `packages/control-plane/src/routes/dashboard.ts` — UUID validation guard
- `packages/dashboard/src/hooks/use-memory-explorer.ts` — default agent, empty query guard
- `packages/dashboard/src/components/memory/document-viewer.tsx` — Blob viewer
- `packages/dashboard/src/components/memory/memory-editor.tsx` — Save & Sync
- `packages/dashboard/src/components/memory/memory-results.tsx` — CSV export

### Verification
- 293/293 tests passing (45 memory tests)
- Format, lint, typecheck all clean

Closes #213, Closes #216