### PR TITLE
fix(dashboard): agent detail resource metrics overflow

### DIFF
--- a/packages/dashboard/src/app/agents/[agentId]/page.tsx
+++ b/packages/dashboard/src/app/agents/[agentId]/page.tsx
@@ -251,7 +251,7 @@ export default function AgentDetailPage({ params }: Props): React.JSX.Element {
       {/* Desktop: 3-column layout */}
       <div className="hidden flex-1 gap-6 lg:flex">
         {/* Left column: steering + lifecycle details */}
-        <div className="flex w-80 shrink-0 flex-col gap-6">
+        <div className="flex w-80 min-w-0 shrink-0 flex-col gap-6">
           <SteerInput agentId={agentId} />
           <LifecycleDetails transitions={transitions} currentState={currentState} />
         </div>
@@ -262,7 +262,7 @@ export default function AgentDetailPage({ params }: Props): React.JSX.Element {
         </div>
 
         {/* Right column: resources */}
-        <div className="flex w-72 shrink-0 flex-col gap-6">
+        <div className="flex w-80 min-w-0 shrink-0 flex-col gap-6">
           <ResourcePanel metrics={metrics} />
         </div>
       </div>

--- a/packages/dashboard/src/components/agents/resource-sparklines.tsx
+++ b/packages/dashboard/src/components/agents/resource-sparklines.tsx
@@ -104,7 +104,7 @@ const deltaColors: Record<string, string> = {
 
 export function ResourceSparklines({ metrics }: ResourceSparklinesProps): React.JSX.Element {
   return (
-    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+    <div className="grid grid-cols-2 gap-3">
       {metrics.map((metric) => (
         <div
           key={metric.label}
@@ -131,7 +131,7 @@ export function ResourceSparklines({ metrics }: ResourceSparklinesProps): React.
             <span className="text-xl font-bold text-text-main">{metric.value}</span>
             <span className="text-sm font-normal text-slate-400">{metric.unit}</span>
           </div>
-          <Sparkline samples={metric.samples} width={140} height={28} />
+          <Sparkline samples={metric.samples} width={100} height={28} />
         </div>
       ))}
     </div>


### PR DESCRIPTION
Resource Metrics panel was overflowing on desktop — grid was set to 4 columns inside a 288px sidebar. Changed to 2-column grid with smaller sparklines. Also added min-w-0 to prevent flex overflow.