### PR TITLE
fix(dashboard): remove broken memory search + optional approval pagination

### DIFF
--- a/packages/dashboard/src/hooks/use-dashboard.ts
+++ b/packages/dashboard/src/hooks/use-dashboard.ts
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from "react"
 
 import { useApiQuery } from "@/hooks/use-api"
 import type { ApiErrorCode, JobStatus } from "@/lib/api-client"
-import { listAgents, listApprovals, listJobs, searchMemory } from "@/lib/api-client"
+import { listAgents, listApprovals, listJobs } from "@/lib/api-client"
 
 export interface DashboardStats {
   totalAgents: number
@@ -55,27 +55,18 @@ export function useDashboard(): DashboardData {
     refetch: refetchApprovals,
   } = useApiQuery(() => listApprovals({ status: "PENDING", limit: 1 }), [])
 
-  const {
-    data: memoryData,
-    isLoading: memoryLoading,
-    error: memoryError,
-    errorCode: memoryErrorCode,
-    refetch: refetchMemory,
-  } = useApiQuery(() => searchMemory({ agent_id: "*", query: "all", limit: 1 }), [])
-
-  const isLoading = agentsLoading || jobsLoading || approvalsLoading || memoryLoading
-  const error = agentsError || jobsError || approvalsError || memoryError
-  const errorCode =
-    agentsErrorCode || jobsErrorCode || approvalsErrorCode || memoryErrorCode || null
+  const isLoading = agentsLoading || jobsLoading || approvalsLoading
+  const error = agentsError || jobsError || approvalsError
+  const errorCode = agentsErrorCode || jobsErrorCode || approvalsErrorCode || null
 
   const stats = useMemo<DashboardStats>(() => {
     return {
       totalAgents: agentData?.pagination?.total ?? 0,
       activeJobs: jobData?.pagination?.total ?? 0,
       pendingApprovals: approvalData?.pagination?.total ?? 0,
-      memoryRecords: memoryData?.results?.length ?? 0,
+      memoryRecords: 0,
     }
-  }, [agentData, jobData, approvalData, memoryData])
+  }, [agentData, jobData, approvalData])
 
   const recentJobs = useMemo<RecentJob[]>(() => {
     if (!jobData?.jobs || jobData.jobs.length === 0) return []
@@ -92,8 +83,7 @@ export function useDashboard(): DashboardData {
     void refetchAgents()
     void refetchJobs()
     void refetchApprovals()
-    void refetchMemory()
-  }, [refetchAgents, refetchJobs, refetchApprovals, refetchMemory])
+  }, [refetchAgents, refetchJobs, refetchApprovals])
 
   return { stats, recentJobs, isLoading, error, errorCode, refetch }
 }

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -455,7 +455,7 @@ export async function listApprovals(params?: {
   offset?: number
 }): Promise<{
   approvals: import("./schemas/approvals").ApprovalRequest[]
-  pagination: import("./schemas/common").Pagination
+  pagination?: import("./schemas/common").Pagination
 }> {
   const search = new URLSearchParams()
   if (params?.status) search.set("status", params.status)

--- a/packages/dashboard/src/lib/schemas/approvals.ts
+++ b/packages/dashboard/src/lib/schemas/approvals.ts
@@ -23,7 +23,7 @@ export const ApprovalRequestSchema = z.object({
 
 export const ApprovalListResponseSchema = z.object({
   approvals: z.array(ApprovalRequestSchema),
-  pagination: PaginationSchema,
+  pagination: PaginationSchema.optional(),
 })
 
 export const ApprovalAuditEntrySchema = z.object({


### PR DESCRIPTION
Two bugs causing 'Unexpected API response' banner on every page:

1. **Memory search wildcard**: `useDashboard()` called `searchMemory({ agent_id: '*' })` — backend requires valid UUID → 400. Removed the call (memory count shows 0 until we have an agent-context-aware endpoint).

2. **Approval pagination required**: `ApprovalListResponseSchema` required `pagination` but API returns `{approvals: []}` without it when empty. Made optional.