### PR TITLE
fix(dashboard): credentials + browser schema camelCase mismatch

### DIFF
--- a/packages/dashboard/src/__tests__/api-client.test.ts
+++ b/packages/dashboard/src/__tests__/api-client.test.ts
@@ -578,7 +578,7 @@ describe("API Client", () => {
     it("listProviders fetches GET /credentials/providers", async () => {
       const body = {
         providers: [
-          { id: "anthropic", name: "Anthropic", auth_type: "oauth", description: "Claude models" },
+          { id: "anthropic", name: "Anthropic", authType: "oauth", description: "Claude models" },
         ],
       }
       mockFetchResponse(body)
@@ -596,12 +596,12 @@ describe("API Client", () => {
           {
             id: "cred-1",
             provider: "anthropic",
-            credential_type: "oauth",
-            display_label: null,
-            masked_key: null,
+            credentialType: "oauth",
+            displayLabel: null,
+            maskedKey: null,
             status: "active",
-            last_used_at: null,
-            created_at: "2026-01-01T00:00:00Z",
+            lastUsedAt: null,
+            createdAt: "2026-01-01T00:00:00Z",
           },
         ],
       }

--- a/packages/dashboard/src/__tests__/browser.test.ts
+++ b/packages/dashboard/src/__tests__/browser.test.ts
@@ -92,10 +92,10 @@ describe("ConnectionStatus states", () => {
   })
 
   it("latency quality classifications", () => {
-    function qualityLabel(latency_ms: number): string {
-      if (latency_ms < 50) return "Excellent"
-      if (latency_ms < 100) return "Good"
-      if (latency_ms < 200) return "Fair"
+    function qualityLabel(latencyMs: number): string {
+      if (latencyMs < 50) return "Excellent"
+      if (latencyMs < 100) return "Good"
+      if (latencyMs < 200) return "Fair"
       return "Poor"
     }
 
@@ -211,26 +211,26 @@ describe("ScreenshotGallery rendering logic", () => {
   const mockScreenshots: Screenshot[] = [
     {
       id: "ss-001",
-      agent_id: "agt-123",
+      agentId: "agt-123",
       timestamp: new Date(Date.now() - 15_000).toISOString(),
-      thumbnail_url: "https://placeholder/thumb-1.png",
-      full_url: "https://placeholder/full-1.png",
+      thumbnailUrl: "https://placeholder/thumb-1.png",
+      fullUrl: "https://placeholder/full-1.png",
       dimensions: { width: 1920, height: 1080 },
     },
     {
       id: "ss-002",
-      agent_id: "agt-123",
+      agentId: "agt-123",
       timestamp: new Date(Date.now() - 60_000).toISOString(),
-      thumbnail_url: "https://placeholder/thumb-2.png",
-      full_url: "https://placeholder/full-2.png",
+      thumbnailUrl: "https://placeholder/thumb-2.png",
+      fullUrl: "https://placeholder/full-2.png",
       dimensions: { width: 1920, height: 1080 },
     },
     {
       id: "ss-003",
-      agent_id: "agt-123",
+      agentId: "agt-123",
       timestamp: new Date(Date.now() - 120_000).toISOString(),
-      thumbnail_url: "https://placeholder/thumb-3.png",
-      full_url: "https://placeholder/full-3.png",
+      thumbnailUrl: "https://placeholder/thumb-3.png",
+      fullUrl: "https://placeholder/full-3.png",
       dimensions: { width: 1280, height: 720 },
     },
   ]
@@ -248,10 +248,10 @@ describe("ScreenshotGallery rendering logic", () => {
   it("screenshots have required properties", () => {
     for (const ss of mockScreenshots) {
       expect(ss.id).toBeDefined()
-      expect(ss.agent_id).toBeDefined()
+      expect(ss.agentId).toBeDefined()
       expect(ss.timestamp).toBeDefined()
-      expect(ss.thumbnail_url).toBeDefined()
-      expect(ss.full_url).toBeDefined()
+      expect(ss.thumbnailUrl).toBeDefined()
+      expect(ss.fullUrl).toBeDefined()
       expect(ss.dimensions.width).toBeGreaterThan(0)
       expect(ss.dimensions.height).toBeGreaterThan(0)
     }
@@ -319,7 +319,7 @@ describe("TraceTimeline rendering logic", () => {
       type: "GET",
       timestamp: new Date(Date.now() - 295_000).toISOString(),
       url: "https://github.com/cortex-plane/dashboard",
-      duration_ms: 340,
+      durationMs: 340,
     },
     {
       id: "evt-003",
@@ -418,8 +418,8 @@ describe("TraceTimeline rendering logic", () => {
   })
 
   it("duration is only shown when present", () => {
-    const withDuration = mockEvents.filter((e) => e.duration_ms !== undefined)
-    const withoutDuration = mockEvents.filter((e) => e.duration_ms === undefined)
+    const withDuration = mockEvents.filter((e) => e.durationMs !== undefined)
+    const withoutDuration = mockEvents.filter((e) => e.durationMs === undefined)
 
     expect(withDuration.length).toBeGreaterThan(0)
     expect(withoutDuration.length).toBeGreaterThan(0)
@@ -441,8 +441,8 @@ describe("TraceTimeline rendering logic", () => {
 
 describe("BrowserViewport rendering logic", () => {
   // Helper that mirrors the component logic without TypeScript narrowing issues
-  function canShowVnc(vnc_url: string | null, status: BrowserSessionStatus): boolean {
-    return Boolean(vnc_url && (status === "connected" || status === "connecting"))
+  function canShowVnc(vncUrl: string | null, status: BrowserSessionStatus): boolean {
+    return Boolean(vncUrl && (status === "connected" || status === "connecting"))
   }
 
   it("shows VNC iframe when vncUrl is available and status is connected", () => {
@@ -482,8 +482,8 @@ describe("BrowserSession interface", () => {
   it("has all required fields", () => {
     const session: BrowserSession = {
       id: "bsess-123",
-      agent_id: "agt-456",
-      vnc_url: "wss://vnc.example.com/session-123",
+      agentId: "agt-456",
+      vncUrl: "wss://vnc.example.com/session-123",
       status: "connected",
       tabs: [
         {
@@ -493,28 +493,28 @@ describe("BrowserSession interface", () => {
           active: true,
         },
       ],
-      latency_ms: 42,
+      latencyMs: 42,
     }
 
     expect(session.id).toBe("bsess-123")
-    expect(session.agent_id).toBe("agt-456")
-    expect(session.vnc_url).toBe("wss://vnc.example.com/session-123")
+    expect(session.agentId).toBe("agt-456")
+    expect(session.vncUrl).toBe("wss://vnc.example.com/session-123")
     expect(session.status).toBe("connected")
     expect(session.tabs).toHaveLength(1)
-    expect(session.latency_ms).toBe(42)
+    expect(session.latencyMs).toBe(42)
   })
 
   it("vncUrl can be null", () => {
     const session: BrowserSession = {
       id: "bsess-123",
-      agent_id: "agt-456",
-      vnc_url: null,
+      agentId: "agt-456",
+      vncUrl: null,
       status: "disconnected",
       tabs: [],
-      latency_ms: 0,
+      latencyMs: 0,
     }
 
-    expect(session.vnc_url).toBeNull()
+    expect(session.vncUrl).toBeNull()
   })
 })
 
@@ -531,11 +531,11 @@ describe("getAgentBrowser API", () => {
   it("fetches browser session by agent ID", async () => {
     const mockSession: BrowserSession = {
       id: "bsess-123",
-      agent_id: "agt-456",
-      vnc_url: "wss://vnc.example.com/session-123",
+      agentId: "agt-456",
+      vncUrl: "wss://vnc.example.com/session-123",
       status: "connected",
       tabs: [],
-      latency_ms: 35,
+      latencyMs: 35,
     }
 
     mockFetchResponse(mockSession)
@@ -700,7 +700,7 @@ describe("getTraceState API", () => {
   it("returns recording state with startedAt", async () => {
     const mockState: TraceState = {
       status: "recording",
-      started_at: "2026-02-28T10:00:00Z",
+      startedAt: "2026-02-28T10:00:00Z",
       options: { snapshots: true, screenshots: true },
     }
 
@@ -708,7 +708,7 @@ describe("getTraceState API", () => {
     const result = await getTraceState("agt-456")
 
     expect(result.status).toBe("recording")
-    expect(result.started_at).toBe("2026-02-28T10:00:00Z")
+    expect(result.startedAt).toBe("2026-02-28T10:00:00Z")
     expect(result.options?.snapshots).toBe(true)
   })
 })
@@ -725,16 +725,16 @@ describe("TraceState interface", () => {
 
   it("idle state has no startedAt", () => {
     const state: TraceState = { status: "idle" }
-    expect(state.started_at).toBeUndefined()
+    expect(state.startedAt).toBeUndefined()
   })
 
   it("recording state has startedAt", () => {
     const state: TraceState = {
       status: "recording",
-      started_at: "2026-02-28T10:00:00Z",
+      startedAt: "2026-02-28T10:00:00Z",
     }
     expect(state.status).toBe("recording")
-    expect(state.started_at).toBeDefined()
+    expect(state.startedAt).toBeDefined()
   })
 })
 
@@ -749,7 +749,7 @@ describe("startTrace API", () => {
   })
 
   it("posts to observe/trace/start", async () => {
-    mockFetchResponse({ status: "recording", started_at: "2026-02-28T10:00:00Z" })
+    mockFetchResponse({ status: "recording", startedAt: "2026-02-28T10:00:00Z" })
     const result = await startTrace("agt-456")
 
     expect(result.status).toBe("recording")
@@ -785,12 +785,12 @@ describe("stopTrace API", () => {
   })
 
   it("posts to observe/trace/stop", async () => {
-    mockFetchResponse({ status: "idle", file_path: "/tmp/trace.zip", duration_ms: 5000 })
+    mockFetchResponse({ status: "idle", filePath: "/tmp/trace.zip", durationMs: 5000 })
     const result = await stopTrace("agt-456")
 
     expect(result.status).toBe("idle")
-    expect(result.file_path).toBe("/tmp/trace.zip")
-    expect(result.duration_ms).toBe(5000)
+    expect(result.filePath).toBe("/tmp/trace.zip")
+    expect(result.durationMs).toBe(5000)
     expect(fetch).toHaveBeenCalledWith(
       `${API_BASE}/agents/agt-456/observe/trace/stop`,
       expect.objectContaining({ method: "POST" }),

--- a/packages/dashboard/src/__tests__/schemas.test.ts
+++ b/packages/dashboard/src/__tests__/schemas.test.ts
@@ -343,11 +343,11 @@ describe("BrowserSessionSchema", () => {
   it("accepts valid session", () => {
     const session = {
       id: "bsess-001",
-      agent_id: "agt-001",
-      vnc_url: null,
+      agentId: "agt-001",
+      vncUrl: null,
       status: "connected",
       tabs: [{ id: "tab-1", title: "Google", url: "https://google.com", active: true }],
-      latency_ms: 42,
+      latencyMs: 42,
     }
     expect(BrowserSessionSchema.parse(session).status).toBe("connected")
   })
@@ -355,24 +355,24 @@ describe("BrowserSessionSchema", () => {
   it("accepts vncUrl as string", () => {
     const session = {
       id: "bsess-001",
-      agent_id: "agt-001",
-      vnc_url: "wss://vnc.example.com/session/123",
+      agentId: "agt-001",
+      vncUrl: "wss://vnc.example.com/session/123",
       status: "connected",
       tabs: [],
-      latency_ms: 30,
+      latencyMs: 30,
     }
-    expect(BrowserSessionSchema.parse(session).vnc_url).toBe("wss://vnc.example.com/session/123")
+    expect(BrowserSessionSchema.parse(session).vncUrl).toBe("wss://vnc.example.com/session/123")
   })
 
   it("rejects invalid status", () => {
     expect(() =>
       BrowserSessionSchema.parse({
         id: "b1",
-        agent_id: "a1",
-        vnc_url: null,
+        agentId: "a1",
+        vncUrl: null,
         status: "ACTIVE",
         tabs: [],
-        latency_ms: 0,
+        latencyMs: 0,
       }),
     ).toThrow()
   })
@@ -409,10 +409,10 @@ describe("ScreenshotSchema", () => {
   it("accepts valid screenshot", () => {
     const ss = {
       id: "ss-001",
-      agent_id: "agt-001",
+      agentId: "agt-001",
       timestamp: "2026-01-01T00:00:00Z",
-      thumbnail_url: "https://example.com/thumb.png",
-      full_url: "https://example.com/full.png",
+      thumbnailUrl: "https://example.com/thumb.png",
+      fullUrl: "https://example.com/full.png",
       dimensions: { width: 1920, height: 1080 },
     }
     expect(ScreenshotSchema.parse(ss).dimensions.width).toBe(1920)
@@ -422,10 +422,10 @@ describe("ScreenshotSchema", () => {
     expect(() =>
       ScreenshotSchema.parse({
         id: "ss-1",
-        agent_id: "a1",
+        agentId: "a1",
         timestamp: "t",
-        thumbnail_url: "u",
-        full_url: "u",
+        thumbnailUrl: "u",
+        fullUrl: "u",
       }),
     ).toThrow()
   })

--- a/packages/dashboard/src/app/agents/[agentId]/browser/page.tsx
+++ b/packages/dashboard/src/app/agents/[agentId]/browser/page.tsx
@@ -84,9 +84,9 @@ export default function BrowserPage({ params }: BrowserPageProps): React.JSX.Ele
             </h1>
             <p className="text-xs text-slate-500">
               {session.status === "connected"
-                ? `Live session · ${session.latency_ms}ms latency`
-                : session.last_heartbeat
-                  ? `Last active ${relativeTime(session.last_heartbeat)}`
+                ? `Live session · ${session.latencyMs}ms latency`
+                : session.lastHeartbeat
+                  ? `Last active ${relativeTime(session.lastHeartbeat)}`
                   : "No active session"}
             </p>
           </div>
@@ -127,9 +127,9 @@ export default function BrowserPage({ params }: BrowserPageProps): React.JSX.Ele
           <TabBar tabs={tabs} onSelectTab={handleSelectTab} onCloseTab={handleCloseTab} />
 
           <BrowserViewport
-            vncUrl={session.vnc_url}
+            vncUrl={session.vncUrl}
             status={session.status}
-            latencyMs={session.latency_ms}
+            latencyMs={session.latencyMs}
             latestScreenshot={latestScreenshot}
             onReconnect={handleReconnect}
           />
@@ -168,7 +168,7 @@ export default function BrowserPage({ params }: BrowserPageProps): React.JSX.Ele
             {/* Trace controls */}
             <TraceControls
               traceStatus={traceState.status}
-              startedAt={traceState.started_at}
+              startedAt={traceState.startedAt}
               onStartTrace={() => void handleStartTrace()}
               onStopTrace={() => void handleStopTrace()}
               isStarting={isStartingTrace}
@@ -195,11 +195,11 @@ export default function BrowserPage({ params }: BrowserPageProps): React.JSX.Ele
         {mobileTab === "Viewport" && (
           <div className="flex flex-col gap-4">
             {/* On mobile, show screenshots as primary if VNC unavailable */}
-            {session.vnc_url ? (
+            {session.vncUrl ? (
               <BrowserViewport
-                vncUrl={session.vnc_url}
+                vncUrl={session.vncUrl}
                 status={session.status}
-                latencyMs={session.latency_ms}
+                latencyMs={session.latencyMs}
                 latestScreenshot={latestScreenshot}
                 onReconnect={handleReconnect}
               />
@@ -216,7 +216,7 @@ export default function BrowserPage({ params }: BrowserPageProps): React.JSX.Ele
           <div className="flex flex-col gap-4">
             <TraceControls
               traceStatus={traceState.status}
-              startedAt={traceState.started_at}
+              startedAt={traceState.startedAt}
               onStartTrace={() => void handleStartTrace()}
               onStopTrace={() => void handleStopTrace()}
               isStarting={isStartingTrace}

--- a/packages/dashboard/src/app/settings/page.tsx
+++ b/packages/dashboard/src/app/settings/page.tsx
@@ -220,7 +220,7 @@ function SettingsInner() {
         <div className="mt-4 space-y-3">
           {providers.map((p) => {
             const cred = getCredentialForProvider(p.id)
-            const isOAuth = p.auth_type === "oauth"
+            const isOAuth = p.authType === "oauth"
             const isCodePaste = CODE_PASTE_PROVIDER_IDS.has(p.id)
 
             return (
@@ -250,8 +250,8 @@ function SettingsInner() {
                     )}
                   </div>
                   <p className="text-xs text-text-muted">{p.description}</p>
-                  {cred?.masked_key && (
-                    <p className="mt-1 font-mono text-xs text-text-muted">{cred.masked_key}</p>
+                  {cred?.maskedKey && (
+                    <p className="mt-1 font-mono text-xs text-text-muted">{cred.maskedKey}</p>
                   )}
                 </div>
 

--- a/packages/dashboard/src/components/browser/browser-viewport.tsx
+++ b/packages/dashboard/src/components/browser/browser-viewport.tsx
@@ -119,7 +119,7 @@ function ScreenshotFallback({ screenshot }: { screenshot: Screenshot }): React.J
     <div className="flex size-full flex-col items-center justify-center gap-3 p-4">
       <div className="relative overflow-hidden rounded-lg border border-chrome-border">
         <img
-          src={screenshot.full_url}
+          src={screenshot.fullUrl}
           alt={`Screenshot from ${new Date(screenshot.timestamp).toLocaleTimeString()}`}
           className="max-h-[60vh] w-auto object-contain"
         />

--- a/packages/dashboard/src/components/browser/screenshot-gallery.tsx
+++ b/packages/dashboard/src/components/browser/screenshot-gallery.tsx
@@ -62,7 +62,7 @@ export function ScreenshotGallery({ screenshots }: ScreenshotGalleryProps): Reac
           >
             <div className="aspect-video w-full bg-chrome-deep">
               <img
-                src={screenshot.thumbnail_url}
+                src={screenshot.thumbnailUrl}
                 alt={`Screenshot at ${new Date(screenshot.timestamp).toLocaleTimeString()}`}
                 className="size-full object-cover"
                 loading="lazy"
@@ -156,7 +156,7 @@ function Lightbox({
       {/* Image */}
       <div className="max-h-[85vh] max-w-[90vw]">
         <img
-          src={screenshot.full_url}
+          src={screenshot.fullUrl}
           alt={`Screenshot at ${new Date(screenshot.timestamp).toLocaleTimeString()}`}
           className="max-h-[85vh] w-auto rounded-lg object-contain"
         />

--- a/packages/dashboard/src/components/browser/trace-timeline.tsx
+++ b/packages/dashboard/src/components/browser/trace-timeline.tsx
@@ -171,9 +171,9 @@ function EventItem({ event, isLast }: { event: BrowserEvent; isLast: boolean }):
             {config.label}
           </span>
           <span className="font-mono text-[10px] text-slate-600">{time}</span>
-          {event.duration_ms !== undefined && (
+          {event.durationMs !== undefined && (
             <span className="font-mono text-[10px] text-slate-500">
-              {duration(event.duration_ms)}
+              {duration(event.durationMs)}
             </span>
           )}
         </div>

--- a/packages/dashboard/src/hooks/use-browser-observation.ts
+++ b/packages/dashboard/src/hooks/use-browser-observation.ts
@@ -84,11 +84,11 @@ export function useBrowserObservation(agentId: string) {
     return (
       sessionData ?? {
         id: `session-${agentId}`,
-        agent_id: agentId,
-        vnc_url: null,
+        agentId: agentId,
+        vncUrl: null,
         status: sessionError ? "error" : "connecting",
         tabs: [],
-        latency_ms: 0,
+        latencyMs: 0,
       }
     )
   }, [sessionData, sessionError, agentId])
@@ -162,7 +162,7 @@ export function useBrowserObservation(agentId: string) {
 
   useEffect(() => {
     // Only auto-refresh when there is no VNC and the session is not in error
-    if (session.vnc_url) return
+    if (session.vncUrl) return
     if (session.status === "error") return
 
     const id = setInterval(() => {
@@ -171,7 +171,7 @@ export function useBrowserObservation(agentId: string) {
     }, AUTO_REFRESH_INTERVAL_MS)
 
     return () => clearInterval(id)
-  }, [session.vnc_url, session.status, refetchScreenshots, refetchEvents])
+  }, [session.vncUrl, session.status, refetchScreenshots, refetchEvents])
 
   // -------------------------------------------------------------------------
   // Return

--- a/packages/dashboard/src/lib/schemas/browser.ts
+++ b/packages/dashboard/src/lib/schemas/browser.ts
@@ -28,12 +28,12 @@ export const BrowserTabSchema = z.object({
 
 export const BrowserSessionSchema = z.object({
   id: z.string(),
-  agent_id: z.string(),
-  vnc_url: z.string().nullable(),
+  agentId: z.string(),
+  vncUrl: z.string().nullable(),
   status: BrowserSessionStatusSchema,
   tabs: z.array(BrowserTabSchema),
-  latency_ms: z.number(),
-  last_heartbeat: z.string().optional(),
+  latencyMs: z.number(),
+  lastHeartbeat: z.string().optional(),
 })
 
 export const BrowserEventSchema = z.object({
@@ -43,16 +43,16 @@ export const BrowserEventSchema = z.object({
   url: z.string().optional(),
   selector: z.string().optional(),
   message: z.string().optional(),
-  duration_ms: z.number().optional(),
+  durationMs: z.number().optional(),
   severity: BrowserEventSeveritySchema.optional(),
 })
 
 export const ScreenshotSchema = z.object({
   id: z.string(),
-  agent_id: z.string(),
+  agentId: z.string(),
   timestamp: z.string(),
-  thumbnail_url: z.string(),
-  full_url: z.string(),
+  thumbnailUrl: z.string(),
+  fullUrl: z.string(),
   dimensions: z.object({
     width: z.number(),
     height: z.number(),
@@ -75,7 +75,7 @@ export const CaptureScreenshotResponseSchema = z.object({
   timestamp: z.string(),
   url: z.string().optional(),
   title: z.string().optional(),
-  file_path: z.string().optional(),
+  filePath: z.string().optional(),
 })
 
 // ---------------------------------------------------------------------------
@@ -86,7 +86,7 @@ export const TraceStatusSchema = z.enum(["idle", "recording"])
 
 export const TraceStateSchema = z.object({
   status: TraceStatusSchema,
-  started_at: z.string().optional(),
+  startedAt: z.string().optional(),
   options: z
     .object({
       snapshots: z.boolean().optional(),
@@ -99,13 +99,13 @@ export const TraceStateSchema = z.object({
 
 export const TraceStartResponseSchema = z.object({
   status: z.string(),
-  started_at: z.string().optional(),
+  startedAt: z.string().optional(),
 })
 
 export const TraceStopResponseSchema = z.object({
   status: z.string(),
-  file_path: z.string().optional(),
-  duration_ms: z.number().optional(),
+  filePath: z.string().optional(),
+  durationMs: z.number().optional(),
 })
 
 export type BrowserSessionStatus = z.infer<typeof BrowserSessionStatusSchema>

--- a/packages/dashboard/src/lib/schemas/credentials.ts
+++ b/packages/dashboard/src/lib/schemas/credentials.ts
@@ -3,19 +3,26 @@ import { z } from "zod"
 export const ProviderInfoSchema = z.object({
   id: z.string(),
   name: z.string(),
-  auth_type: z.enum(["oauth", "api_key"]),
+  authType: z.enum(["oauth", "api_key"]),
   description: z.string(),
 })
 
 export const CredentialSchema = z.object({
   id: z.string(),
   provider: z.string(),
-  credential_type: z.string(),
-  display_label: z.string().nullable(),
-  masked_key: z.string().nullable(),
+  credentialType: z.string(),
+  displayLabel: z.string().nullable(),
+  maskedKey: z.string().nullable(),
   status: z.string(),
-  last_used_at: z.string().nullable(),
-  created_at: z.string(),
+  accountId: z.string().nullable().optional(),
+  scopes: z.array(z.string()).nullable().optional(),
+  tokenExpiresAt: z.string().nullable().optional(),
+  lastUsedAt: z.string().nullable(),
+  lastRefreshAt: z.string().nullable().optional(),
+  errorCount: z.number().optional(),
+  lastError: z.string().nullable().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string().optional(),
 })
 
 export const ProviderListResponseSchema = z.object({


### PR DESCRIPTION
Same root cause as PR #227 — backend returns camelCase, dashboard schemas expected snake_case.

**Settings page** showed 'No providers configured' because `authType` → `auth_type` Zod parse failed silently.

**Browser tab** broke because `vncUrl`, `latencyMs`, `agentId` etc. all failed validation.

Fixes credentials.ts and browser.ts schemas + all component/hook references + tests. 306/306 tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized field naming conventions from snake_case to camelCase across API responses, data models, and schemas for improved consistency.
  * Updated all related components and utilities to use the new camelCase field names.

* **Tests**
  * Updated test fixtures and assertions to validate the new camelCase field naming convention.

* **Chores**
  * Adjusted schema definitions to reflect naming convention updates across credentials, providers, and browser-related data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->