### PR TITLE
feat(control-plane): agent-channel binding and message dispatch (#232)

### DIFF
--- a/packages/control-plane/migrations/012_create_agent_channel_binding.down.sql
+++ b/packages/control-plane/migrations/012_create_agent_channel_binding.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS agent_channel_binding;

--- a/packages/control-plane/migrations/012_create_agent_channel_binding.up.sql
+++ b/packages/control-plane/migrations/012_create_agent_channel_binding.up.sql
@@ -1,0 +1,15 @@
+-- 012: Agent ↔ channel binding — maps chat channels to specific agents
+
+CREATE TABLE agent_channel_binding (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
+  channel_type TEXT NOT NULL,
+  chat_id TEXT NOT NULL,
+  is_default BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(channel_type, chat_id)
+);
+
+CREATE INDEX idx_agent_channel_binding_agent ON agent_channel_binding (agent_id);
+CREATE INDEX idx_agent_channel_binding_default ON agent_channel_binding (channel_type, is_default)
+  WHERE is_default = true;

--- a/packages/control-plane/src/__tests__/agent-channel-routes.test.ts
+++ b/packages/control-plane/src/__tests__/agent-channel-routes.test.ts
@@ -1,0 +1,188 @@
+import Fastify from "fastify"
+import { describe, expect, it, vi } from "vitest"
+
+import type { AgentChannelService } from "../channels/agent-channel-service.js"
+import type { AuthConfig } from "../middleware/types.js"
+import { agentChannelRoutes } from "../routes/agent-channels.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEV_AUTH_CONFIG: AuthConfig = {
+  requireAuth: false,
+  apiKeys: [],
+}
+
+function makeBinding(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "bbbbbbbb-1111-2222-3333-444444444444",
+    agent_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    channel_type: "telegram",
+    chat_id: "12345",
+    is_default: false,
+    created_at: new Date(),
+    ...overrides,
+  }
+}
+
+function mockService(overrides: Partial<AgentChannelService> = {}): AgentChannelService {
+  return {
+    resolveAgent: vi.fn().mockResolvedValue("agent-id"),
+    bindChannel: vi.fn().mockResolvedValue(undefined),
+    unbindChannel: vi.fn().mockResolvedValue(undefined),
+    unbindById: vi.fn().mockResolvedValue(true),
+    listBindings: vi.fn().mockResolvedValue([makeBinding()]),
+    setDefault: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as AgentChannelService
+}
+
+async function buildTestApp(serviceOverrides: Partial<AgentChannelService> = {}) {
+  const app = Fastify({ logger: false })
+  const service = mockService(serviceOverrides)
+
+  await app.register(agentChannelRoutes({ service, authConfig: DEV_AUTH_CONFIG }))
+
+  return { app, service }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GET /agents/:agentId/channels
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/:agentId/channels", () => {
+  it("returns list of bindings", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/agents/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/channels",
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.bindings).toBeDefined()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.bindings).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/channels
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/channels", () => {
+  it("binds a channel", async () => {
+    const { app, service } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/channels",
+      payload: {
+        channel_type: "telegram",
+        chat_id: "12345",
+      },
+    })
+
+    expect(res.statusCode).toBe(201)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(service.bindChannel).toHaveBeenCalledWith(
+      "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "telegram",
+      "12345",
+    )
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.status).toBe("bound")
+  })
+
+  it("validates required fields", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/channels",
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: DELETE /agents/:agentId/channels/:bindingId
+// ---------------------------------------------------------------------------
+
+describe("DELETE /agents/:agentId/channels/:bindingId", () => {
+  it("unbinds a channel", async () => {
+    const { app, service } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/agents/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/channels/bbbbbbbb-1111-2222-3333-444444444444",
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(service.unbindById).toHaveBeenCalledWith(
+      "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "bbbbbbbb-1111-2222-3333-444444444444",
+    )
+  })
+
+  it("returns 404 when binding not found", async () => {
+    const { app } = await buildTestApp({
+      unbindById: vi.fn().mockResolvedValue(false),
+    })
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/agents/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/channels/nonexistent",
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/channels/default
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/channels/default", () => {
+  it("sets default agent for channel type", async () => {
+    const { app, service } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/channels/default",
+      payload: { channel_type: "telegram" },
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(service.setDefault).toHaveBeenCalledWith(
+      "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "telegram",
+    )
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.is_default).toBe(true)
+  })
+
+  it("validates required channel_type", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/channels/default",
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+})

--- a/packages/control-plane/src/__tests__/agent-channel-service.test.ts
+++ b/packages/control-plane/src/__tests__/agent-channel-service.test.ts
@@ -1,0 +1,234 @@
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import { AgentChannelService } from "../channels/agent-channel-service.js"
+import type { Database } from "../db/types.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBinding(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "bbbbbbbb-1111-2222-3333-444444444444",
+    agent_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    channel_type: "telegram",
+    chat_id: "12345",
+    is_default: false,
+    created_at: new Date(),
+    ...overrides,
+  }
+}
+
+function selectChain(rows: Record<string, unknown>[]) {
+  const executeTakeFirst = vi.fn().mockResolvedValue(rows[0] ?? null)
+  const execute = vi.fn().mockResolvedValue(rows)
+  const terminal = { execute, executeTakeFirst }
+  const orderBy = vi.fn().mockReturnValue(terminal)
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  whereFn.mockReturnValue({
+    where: whereFn,
+    orderBy,
+    ...terminal,
+  })
+  const selectAll = vi.fn().mockReturnValue({ where: whereFn, orderBy, ...terminal })
+  const select = vi.fn().mockReturnValue({ where: whereFn, ...terminal })
+  return { selectAll, select, _where: whereFn, _executeTakeFirst: executeTakeFirst }
+}
+
+function insertChain() {
+  const execute = vi.fn().mockResolvedValue(undefined)
+  const doUpdateSet = vi.fn().mockReturnValue({ execute })
+  const columns = vi.fn().mockReturnValue({ doUpdateSet })
+  const onConflict = vi
+    .fn()
+    .mockImplementation((cb: (oc: { columns: typeof columns }) => unknown) => {
+      cb({ columns })
+      return { execute }
+    })
+  const values = vi.fn().mockReturnValue({ onConflict, execute })
+  return { values, _execute: execute }
+}
+
+function deleteChain(numDeletedRows = 1) {
+  const executeTakeFirst = vi.fn().mockResolvedValue({ numDeletedRows: BigInt(numDeletedRows) })
+  const execute = vi.fn().mockResolvedValue(undefined)
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  whereFn.mockReturnValue({ where: whereFn, executeTakeFirst, execute })
+  return { where: whereFn, _executeTakeFirst: executeTakeFirst }
+}
+
+function updateChain() {
+  const execute = vi.fn().mockResolvedValue(undefined)
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  whereFn.mockReturnValue({ where: whereFn, execute })
+  const set = vi.fn().mockReturnValue({ where: whereFn, execute })
+  return { set }
+}
+
+interface MockDbOptions {
+  bindings?: Record<string, unknown>[]
+  defaultBinding?: Record<string, unknown> | null
+}
+
+function mockDb(opts: MockDbOptions = {}) {
+  const { bindings = [makeBinding()], defaultBinding = null } = opts
+
+  // Track call count to selectFrom to differentiate direct vs default lookups
+  let selectCallCount = 0
+
+  return {
+    selectFrom: vi.fn().mockImplementation(() => {
+      selectCallCount++
+      if (selectCallCount === 1) {
+        return selectChain(bindings)
+      }
+      // Second call is for default lookup
+      return selectChain(defaultBinding ? [defaultBinding] : [])
+    }),
+    insertInto: vi.fn().mockImplementation(() => insertChain()),
+    deleteFrom: vi.fn().mockImplementation(() => deleteChain()),
+    updateTable: vi.fn().mockImplementation(() => updateChain()),
+  } as unknown as Kysely<Database>
+}
+
+// ---------------------------------------------------------------------------
+// Tests: resolveAgent
+// ---------------------------------------------------------------------------
+
+describe("AgentChannelService", () => {
+  describe("resolveAgent", () => {
+    it("returns agent_id for direct binding", async () => {
+      const db = mockDb({ bindings: [makeBinding()] })
+      const service = new AgentChannelService(db)
+
+      const result = await service.resolveAgent("telegram", "12345")
+
+      expect(result).toBe("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+    })
+
+    it("falls back to default agent when no direct binding", async () => {
+      const db = mockDb({
+        bindings: [],
+        defaultBinding: makeBinding({ is_default: true, agent_id: "default-agent-id" }),
+      })
+      const service = new AgentChannelService(db)
+
+      const result = await service.resolveAgent("telegram", "99999")
+
+      expect(result).toBe("default-agent-id")
+    })
+
+    it("returns null when no binding and no default", async () => {
+      const db = mockDb({ bindings: [], defaultBinding: null })
+      const service = new AgentChannelService(db)
+
+      const result = await service.resolveAgent("telegram", "99999")
+
+      expect(result).toBeNull()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Tests: bindChannel
+  // ---------------------------------------------------------------------------
+
+  describe("bindChannel", () => {
+    it("inserts a binding with upsert", async () => {
+      const db = mockDb()
+      const service = new AgentChannelService(db)
+
+      await service.bindChannel("agent-1", "telegram", "12345")
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(db.insertInto).toHaveBeenCalledWith("agent_channel_binding")
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Tests: unbindChannel
+  // ---------------------------------------------------------------------------
+
+  describe("unbindChannel", () => {
+    it("deletes the binding", async () => {
+      const db = mockDb()
+      const service = new AgentChannelService(db)
+
+      await service.unbindChannel("agent-1", "telegram", "12345")
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(db.deleteFrom).toHaveBeenCalledWith("agent_channel_binding")
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Tests: unbindById
+  // ---------------------------------------------------------------------------
+
+  describe("unbindById", () => {
+    it("returns true when binding is deleted", async () => {
+      const db = mockDb()
+      const service = new AgentChannelService(db)
+
+      const result = await service.unbindById("agent-1", "binding-1")
+
+      expect(result).toBe(true)
+    })
+
+    it("returns false when binding not found", async () => {
+      const db = {
+        ...mockDb(),
+        deleteFrom: vi.fn().mockImplementation(() => deleteChain(0)),
+      } as unknown as Kysely<Database>
+      const service = new AgentChannelService(db)
+
+      const result = await service.unbindById("agent-1", "nonexistent")
+
+      expect(result).toBe(false)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Tests: listBindings
+  // ---------------------------------------------------------------------------
+
+  describe("listBindings", () => {
+    it("returns bindings for the agent", async () => {
+      const db = mockDb({ bindings: [makeBinding(), makeBinding({ id: "other" })] })
+      const service = new AgentChannelService(db)
+
+      const result = await service.listBindings("agent-1")
+
+      expect(result).toHaveLength(2)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Tests: setDefault
+  // ---------------------------------------------------------------------------
+
+  describe("setDefault", () => {
+    it("clears existing defaults and sets new one", async () => {
+      // When an existing binding exists for this agent + channel_type
+      let selectCallCount = 0
+      const db = {
+        updateTable: vi.fn().mockImplementation(() => updateChain()),
+        selectFrom: vi.fn().mockImplementation(() => {
+          selectCallCount++
+          if (selectCallCount === 1) {
+            return selectChain([makeBinding()])
+          }
+          return selectChain([])
+        }),
+        insertInto: vi.fn().mockImplementation(() => insertChain()),
+      } as unknown as Kysely<Database>
+
+      const service = new AgentChannelService(db)
+
+      await service.setDefault("agent-1", "telegram")
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(db.updateTable).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/control-plane/src/__tests__/message-dispatch.test.ts
+++ b/packages/control-plane/src/__tests__/message-dispatch.test.ts
@@ -1,0 +1,155 @@
+import type { RoutedMessage } from "@cortex/shared/channels"
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import type { AgentChannelService } from "../channels/agent-channel-service.js"
+import { createMessageDispatch } from "../channels/message-dispatch.js"
+import type { Database } from "../db/types.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRoutedMessage(overrides: Partial<RoutedMessage> = {}): RoutedMessage {
+  return {
+    userAccountId: "user-111",
+    channelMappingId: "mapping-222",
+    message: {
+      channelType: "telegram",
+      channelUserId: "tg-user-1",
+      chatId: "chat-42",
+      messageId: "msg-1",
+      text: "Hello agent",
+      timestamp: new Date(),
+      metadata: {},
+    },
+    ...overrides,
+  }
+}
+
+function mockAgentChannelService(agentId: string | null = "agent-aaa") {
+  return {
+    resolveAgent: vi.fn().mockResolvedValue(agentId),
+    bindChannel: vi.fn(),
+    unbindChannel: vi.fn(),
+    unbindById: vi.fn(),
+    listBindings: vi.fn(),
+    setDefault: vi.fn(),
+  } as unknown as AgentChannelService
+}
+
+function mockRouter() {
+  return {
+    send: vi.fn().mockResolvedValue("sent-msg-id"),
+  }
+}
+
+function selectChain(rows: Record<string, unknown>[]) {
+  const executeTakeFirst = vi.fn().mockResolvedValue(rows[0] ?? null)
+  const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(rows[0])
+  const terminal = { executeTakeFirst, executeTakeFirstOrThrow }
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  whereFn.mockReturnValue({ where: whereFn, ...terminal })
+  const selectAll = vi.fn().mockReturnValue({ where: whereFn, ...terminal })
+  const select = vi.fn().mockReturnValue({ where: whereFn, ...terminal })
+  const returning = vi.fn().mockReturnValue({ executeTakeFirstOrThrow })
+  return { selectAll, select, returning }
+}
+
+function insertChain(row: Record<string, unknown>) {
+  const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(row)
+  const returning = vi.fn().mockReturnValue({ executeTakeFirstOrThrow })
+  const values = vi.fn().mockReturnValue({ returning })
+  return { values }
+}
+
+function mockDb(opts: { existingSession?: Record<string, unknown> | null } = {}) {
+  const { existingSession = null } = opts
+  return {
+    selectFrom: vi
+      .fn()
+      .mockImplementation(() => selectChain(existingSession ? [existingSession] : [])),
+    insertInto: vi.fn().mockImplementation(() => insertChain({ id: "new-session-id" })),
+  } as unknown as Kysely<Database>
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createMessageDispatch", () => {
+  it("dispatches message to agent with existing session", async () => {
+    const agentChannelService = mockAgentChannelService("agent-aaa")
+    const router = mockRouter()
+    const logger = { info: vi.fn(), warn: vi.fn() }
+    const db = mockDb({ existingSession: { id: "existing-session-id" } })
+
+    const dispatch = createMessageDispatch({
+      db,
+      agentChannelService,
+      router: router as never,
+      logger,
+    })
+
+    await dispatch(makeRoutedMessage())
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(agentChannelService.resolveAgent).toHaveBeenCalledWith("telegram", "chat-42")
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "agent-aaa",
+        sessionId: "existing-session-id",
+      }),
+      "Message dispatched to agent session",
+    )
+    expect(router.send).not.toHaveBeenCalled()
+  })
+
+  it("creates a new session when none exists", async () => {
+    const agentChannelService = mockAgentChannelService("agent-aaa")
+    const router = mockRouter()
+    const logger = { info: vi.fn(), warn: vi.fn() }
+    const db = mockDb({ existingSession: null })
+
+    const dispatch = createMessageDispatch({
+      db,
+      agentChannelService,
+      router: router as never,
+      logger,
+    })
+
+    await dispatch(makeRoutedMessage())
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(db.insertInto).toHaveBeenCalledWith("session")
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "agent-aaa",
+        sessionId: "new-session-id",
+      }),
+      "Message dispatched to agent session",
+    )
+  })
+
+  it("sends no-agent message when no binding found", async () => {
+    const agentChannelService = mockAgentChannelService(null)
+    const router = mockRouter()
+    const logger = { info: vi.fn(), warn: vi.fn() }
+    const db = mockDb()
+
+    const dispatch = createMessageDispatch({
+      db,
+      agentChannelService,
+      router: router as never,
+      logger,
+    })
+
+    await dispatch(makeRoutedMessage())
+
+    expect(router.send).toHaveBeenCalledWith("telegram", "chat-42", {
+      text: "No agent is assigned to this chat. Use the dashboard to connect an agent.",
+    })
+    expect(logger.warn).toHaveBeenCalled()
+    expect(logger.info).not.toHaveBeenCalled()
+  })
+})

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -15,12 +15,14 @@ import { HttpLlmBackend } from "./backends/http-llm.js"
 import { AuthHandoffService } from "./browser/auth-handoff.js"
 import { ScreenshotModeService } from "./browser/screenshot-mode.js"
 import { TraceCaptureService } from "./browser/trace-capture.js"
+import { AgentChannelService } from "./channels/agent-channel-service.js"
 import type { Config } from "./config.js"
 import type { Database } from "./db/types.js"
 import { FeedbackService } from "./feedback/service.js"
 import type { AgentLifecycleManager } from "./lifecycle/manager.js"
 import { loadAuthConfig } from "./middleware/api-keys.js"
 import { BrowserObservationService } from "./observation/service.js"
+import { agentChannelRoutes } from "./routes/agent-channels.js"
 import { agentRoutes } from "./routes/agents.js"
 import { approvalRoutes } from "./routes/approval.js"
 import { authRoutes } from "./routes/auth.js"
@@ -163,6 +165,16 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
       enqueueJob: async (jobId: string) => {
         await workerUtils.addJob("agent_execute", { jobId }, { jobKey: `exec:${jobId}` })
       },
+    }),
+  )
+
+  // Register agent channel binding routes
+  const agentChannelService = new AgentChannelService(db)
+  await app.register(
+    agentChannelRoutes({
+      service: agentChannelService,
+      authConfig,
+      sessionService,
     }),
   )
 

--- a/packages/control-plane/src/channels/agent-channel-service.ts
+++ b/packages/control-plane/src/channels/agent-channel-service.ts
@@ -1,0 +1,133 @@
+/**
+ * Agent Channel Service
+ *
+ * Maps chat channels (Telegram, Discord, etc.) to specific agents.
+ * Provides lookup, bind, unbind, and default-agent operations.
+ */
+
+import type { Kysely } from "kysely"
+
+import type { AgentChannelBinding, Database } from "../db/types.js"
+
+export class AgentChannelService {
+  constructor(private readonly db: Kysely<Database>) {}
+
+  /**
+   * Find which agent handles messages from this chat.
+   * Returns the agent ID or null if no binding exists.
+   * Falls back to the default agent for the channel type.
+   */
+  async resolveAgent(channelType: string, chatId: string): Promise<string | null> {
+    // Direct binding first
+    const binding = await this.db
+      .selectFrom("agent_channel_binding")
+      .select("agent_id")
+      .where("channel_type", "=", channelType)
+      .where("chat_id", "=", chatId)
+      .executeTakeFirst()
+
+    if (binding) return binding.agent_id
+
+    // Fall back to default agent for this channel type
+    const defaultBinding = await this.db
+      .selectFrom("agent_channel_binding")
+      .select("agent_id")
+      .where("channel_type", "=", channelType)
+      .where("is_default", "=", true)
+      .executeTakeFirst()
+
+    return defaultBinding?.agent_id ?? null
+  }
+
+  /**
+   * Bind a chat to an agent.
+   * Upserts — if the (channel_type, chat_id) pair already exists, it updates the agent_id.
+   */
+  async bindChannel(agentId: string, channelType: string, chatId: string): Promise<void> {
+    await this.db
+      .insertInto("agent_channel_binding")
+      .values({ agent_id: agentId, channel_type: channelType, chat_id: chatId })
+      .onConflict((oc) =>
+        oc.columns(["channel_type", "chat_id"]).doUpdateSet({ agent_id: agentId }),
+      )
+      .execute()
+  }
+
+  /**
+   * Unbind a chat from an agent.
+   */
+  async unbindChannel(agentId: string, channelType: string, chatId: string): Promise<void> {
+    await this.db
+      .deleteFrom("agent_channel_binding")
+      .where("agent_id", "=", agentId)
+      .where("channel_type", "=", channelType)
+      .where("chat_id", "=", chatId)
+      .execute()
+  }
+
+  /**
+   * Remove a binding by its ID.
+   */
+  async unbindById(agentId: string, bindingId: string): Promise<boolean> {
+    const result = await this.db
+      .deleteFrom("agent_channel_binding")
+      .where("id", "=", bindingId)
+      .where("agent_id", "=", agentId)
+      .executeTakeFirst()
+
+    return Number(result.numDeletedRows) > 0
+  }
+
+  /**
+   * List all channel bindings for an agent.
+   */
+  async listBindings(agentId: string): Promise<AgentChannelBinding[]> {
+    return this.db
+      .selectFrom("agent_channel_binding")
+      .selectAll()
+      .where("agent_id", "=", agentId)
+      .orderBy("created_at", "desc")
+      .execute()
+  }
+
+  /**
+   * Set this agent as the default for a channel type.
+   * Clears any existing default for that channel type first.
+   */
+  async setDefault(agentId: string, channelType: string): Promise<void> {
+    // Clear existing defaults for this channel type
+    await this.db
+      .updateTable("agent_channel_binding")
+      .set({ is_default: false })
+      .where("channel_type", "=", channelType)
+      .where("is_default", "=", true)
+      .execute()
+
+    // Set this agent as default — requires an existing binding
+    // If no binding exists for this agent + channel_type, create one with a sentinel chat_id
+    const existing = await this.db
+      .selectFrom("agent_channel_binding")
+      .select("id")
+      .where("agent_id", "=", agentId)
+      .where("channel_type", "=", channelType)
+      .executeTakeFirst()
+
+    if (existing) {
+      await this.db
+        .updateTable("agent_channel_binding")
+        .set({ is_default: true })
+        .where("id", "=", existing.id)
+        .execute()
+    } else {
+      await this.db
+        .insertInto("agent_channel_binding")
+        .values({
+          agent_id: agentId,
+          channel_type: channelType,
+          chat_id: `__default__${channelType}`,
+          is_default: true,
+        })
+        .execute()
+    }
+  }
+}

--- a/packages/control-plane/src/channels/message-dispatch.ts
+++ b/packages/control-plane/src/channels/message-dispatch.ts
@@ -1,0 +1,98 @@
+/**
+ * Message Dispatch Handler
+ *
+ * The message handler that MessageRouter.onMessage() calls:
+ * 1. Receive RoutedMessage (user resolved)
+ * 2. Look up agent binding for (channelType, chatId) via AgentChannelService
+ * 3. If no binding, check for default agent for this channel type
+ * 4. If still no agent, send a reply: "No agent is assigned to this chat."
+ * 5. If agent found, find or create a session for (agent_id, user_account_id)
+ * 6. Log the message + session info (execution backend comes in #233)
+ */
+
+import type { MessageRouter, RoutedMessage } from "@cortex/shared/channels"
+import type { Kysely } from "kysely"
+
+import type { Database } from "../db/types.js"
+import type { AgentChannelService } from "./agent-channel-service.js"
+
+export interface MessageDispatchDeps {
+  db: Kysely<Database>
+  agentChannelService: AgentChannelService
+  router: MessageRouter
+  logger?: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void }
+}
+
+const NO_AGENT_MESSAGE = "No agent is assigned to this chat. Use the dashboard to connect an agent."
+
+/**
+ * Create a message handler that dispatches routed messages to the correct agent session.
+ */
+export function createMessageDispatch(
+  deps: MessageDispatchDeps,
+): (msg: RoutedMessage) => Promise<void> {
+  const { db, agentChannelService, router, logger = console } = deps
+
+  return async function dispatch(routed: RoutedMessage): Promise<void> {
+    const { channelType, chatId } = routed.message
+
+    // Resolve the agent for this channel + chat
+    const agentId = await agentChannelService.resolveAgent(channelType, chatId)
+
+    if (!agentId) {
+      // No agent bound — notify the user
+      logger.warn(
+        { channelType, chatId, userAccountId: routed.userAccountId },
+        "No agent binding found for chat",
+      )
+      await router.send(channelType, chatId, { text: NO_AGENT_MESSAGE })
+      return
+    }
+
+    // Find or create a session for (agent_id, user_account_id)
+    const session = await findOrCreateSession(db, agentId, routed.userAccountId)
+
+    // Log the dispatch (execution backend comes in #233)
+    logger.info(
+      {
+        agentId,
+        sessionId: session.id,
+        userAccountId: routed.userAccountId,
+        channelType,
+        chatId,
+        messageId: routed.message.messageId,
+      },
+      "Message dispatched to agent session",
+    )
+  }
+}
+
+async function findOrCreateSession(
+  db: Kysely<Database>,
+  agentId: string,
+  userAccountId: string,
+): Promise<{ id: string }> {
+  // Try to find existing active session
+  const existing = await db
+    .selectFrom("session")
+    .select("id")
+    .where("agent_id", "=", agentId)
+    .where("user_account_id", "=", userAccountId)
+    .where("status", "=", "active")
+    .executeTakeFirst()
+
+  if (existing) return existing
+
+  // Create a new session
+  const created = await db
+    .insertInto("session")
+    .values({
+      agent_id: agentId,
+      user_account_id: userAccountId,
+      status: "active",
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow()
+
+  return created
+}

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -348,6 +348,21 @@ export type NewProviderCredential = Insertable<ProviderCredentialTable>
 export type ProviderCredentialUpdate = Updateable<ProviderCredentialTable>
 
 // ---------------------------------------------------------------------------
+// Table: agent_channel_binding
+// ---------------------------------------------------------------------------
+export interface AgentChannelBindingTable {
+  id: Generated<string>
+  agent_id: string
+  channel_type: string
+  chat_id: string
+  is_default: ColumnType<boolean, boolean | undefined, boolean>
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
+export type AgentChannelBinding = Selectable<AgentChannelBindingTable>
+export type NewAgentChannelBinding = Insertable<AgentChannelBindingTable>
+
+// ---------------------------------------------------------------------------
 // Table: credential_audit_log
 // ---------------------------------------------------------------------------
 export interface CredentialAuditLogTable {
@@ -386,4 +401,5 @@ export interface Database {
   dashboard_session: DashboardSessionTable
   provider_credential: ProviderCredentialTable
   credential_audit_log: CredentialAuditLogTable
+  agent_channel_binding: AgentChannelBindingTable
 }

--- a/packages/control-plane/src/routes/agent-channels.ts
+++ b/packages/control-plane/src/routes/agent-channels.ts
@@ -1,0 +1,201 @@
+/**
+ * Agent Channel Binding Routes
+ *
+ * GET    /agents/:agentId/channels            — List channel bindings for an agent
+ * POST   /agents/:agentId/channels            — Bind a channel to an agent
+ * DELETE /agents/:agentId/channels/:bindingId — Unbind a channel
+ * POST   /agents/:agentId/channels/default    — Set as default for a channel type
+ */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
+
+import type { SessionService } from "../auth/session-service.js"
+import type { AgentChannelService } from "../channels/agent-channel-service.js"
+import {
+  type AuthMiddlewareOptions,
+  createRequireAuth,
+  createRequireRole,
+  type PreHandler,
+} from "../middleware/auth.js"
+import type { AuthConfig } from "../middleware/types.js"
+
+// ---------------------------------------------------------------------------
+// Route types
+// ---------------------------------------------------------------------------
+
+interface AgentChannelParams {
+  agentId: string
+}
+
+interface BindChannelBody {
+  channel_type: string
+  chat_id: string
+}
+
+interface UnbindChannelParams {
+  agentId: string
+  bindingId: string
+}
+
+interface SetDefaultBody {
+  channel_type: string
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+export interface AgentChannelRouteDeps {
+  service: AgentChannelService
+  authConfig: AuthConfig
+  sessionService?: SessionService
+}
+
+export function agentChannelRoutes(deps: AgentChannelRouteDeps) {
+  const { service, authConfig, sessionService } = deps
+
+  const authOpts: AuthMiddlewareOptions = { config: authConfig, sessionService }
+  const requireAuth: PreHandler = createRequireAuth(authOpts)
+  const requireOperator: PreHandler = createRequireRole("operator")
+
+  return function register(app: FastifyInstance): void {
+    // -----------------------------------------------------------------
+    // GET /agents/:agentId/channels — List bindings
+    // -----------------------------------------------------------------
+    app.get<{ Params: AgentChannelParams }>(
+      "/agents/:agentId/channels",
+      {
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string" },
+            },
+            required: ["agentId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: AgentChannelParams }>, reply: FastifyReply) => {
+        const bindings = await service.listBindings(request.params.agentId)
+        return reply.status(200).send({ bindings })
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // POST /agents/:agentId/channels — Bind a channel
+    // Requires: auth + operator role
+    // -----------------------------------------------------------------
+    app.post<{ Params: AgentChannelParams; Body: BindChannelBody }>(
+      "/agents/:agentId/channels",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string" },
+            },
+            required: ["agentId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              channel_type: { type: "string", minLength: 1 },
+              chat_id: { type: "string", minLength: 1 },
+            },
+            required: ["channel_type", "chat_id"],
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: AgentChannelParams; Body: BindChannelBody }>,
+        reply: FastifyReply,
+      ) => {
+        const { agentId } = request.params
+        const { channel_type, chat_id } = request.body
+
+        await service.bindChannel(agentId, channel_type, chat_id)
+
+        return reply.status(201).send({
+          agent_id: agentId,
+          channel_type,
+          chat_id,
+          status: "bound",
+        })
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // DELETE /agents/:agentId/channels/:bindingId — Unbind a channel
+    // Requires: auth + operator role
+    // -----------------------------------------------------------------
+    app.delete<{ Params: UnbindChannelParams }>(
+      "/agents/:agentId/channels/:bindingId",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string" },
+              bindingId: { type: "string" },
+            },
+            required: ["agentId", "bindingId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: UnbindChannelParams }>, reply: FastifyReply) => {
+        const { agentId, bindingId } = request.params
+        const deleted = await service.unbindById(agentId, bindingId)
+
+        if (!deleted) {
+          return reply.status(404).send({ error: "not_found", message: "Binding not found" })
+        }
+
+        return reply.status(200).send({ status: "unbound" })
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // POST /agents/:agentId/channels/default — Set default for channel type
+    // Requires: auth + operator role
+    // -----------------------------------------------------------------
+    app.post<{ Params: AgentChannelParams; Body: SetDefaultBody }>(
+      "/agents/:agentId/channels/default",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string" },
+            },
+            required: ["agentId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              channel_type: { type: "string", minLength: 1 },
+            },
+            required: ["channel_type"],
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: AgentChannelParams; Body: SetDefaultBody }>,
+        reply: FastifyReply,
+      ) => {
+        const { agentId } = request.params
+        const { channel_type } = request.body
+
+        await service.setDefault(agentId, channel_type)
+
+        return reply.status(200).send({
+          agent_id: agentId,
+          channel_type,
+          is_default: true,
+        })
+      },
+    )
+  }
+}

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -34,6 +34,7 @@ import {
   TraceStateSchema,
   TraceStopResponseSchema,
 } from "./schemas/browser"
+import { AgentChannelBindingListResponseSchema } from "./schemas/channels"
 import { ContentListResponseSchema } from "./schemas/content"
 import {
   CredentialListResponseSchema,
@@ -693,4 +694,37 @@ export async function saveProviderApiKey(body: {
 
 export async function deleteCredential(id: string): Promise<unknown> {
   return apiFetch(`/credentials/${id}`, { method: "DELETE", schema: z.unknown() })
+}
+
+// ---------------------------------------------------------------------------
+// Agent channel binding endpoint functions
+// ---------------------------------------------------------------------------
+
+export type { AgentChannelBinding } from "./schemas/channels"
+
+export async function listAgentChannels(agentId: string): Promise<{
+  bindings: import("./schemas/channels").AgentChannelBinding[]
+}> {
+  return apiFetch(`/agents/${agentId}/channels`, {
+    schema: AgentChannelBindingListResponseSchema,
+  })
+}
+
+export async function bindAgentChannel(
+  agentId: string,
+  channelType: string,
+  chatId: string,
+): Promise<unknown> {
+  return apiFetch(`/agents/${agentId}/channels`, {
+    method: "POST",
+    body: { channel_type: channelType, chat_id: chatId },
+    schema: z.unknown(),
+  })
+}
+
+export async function unbindAgentChannel(agentId: string, bindingId: string): Promise<unknown> {
+  return apiFetch(`/agents/${agentId}/channels/${bindingId}`, {
+    method: "DELETE",
+    schema: z.unknown(),
+  })
 }

--- a/packages/dashboard/src/lib/schemas/channels.ts
+++ b/packages/dashboard/src/lib/schemas/channels.ts
@@ -1,0 +1,16 @@
+import { z } from "zod"
+
+export const AgentChannelBindingSchema = z.object({
+  id: z.string(),
+  agent_id: z.string(),
+  channel_type: z.string(),
+  chat_id: z.string(),
+  is_default: z.boolean(),
+  created_at: z.string(),
+})
+
+export const AgentChannelBindingListResponseSchema = z.object({
+  bindings: z.array(AgentChannelBindingSchema),
+})
+
+export type AgentChannelBinding = z.infer<typeof AgentChannelBindingSchema>


### PR DESCRIPTION
## Summary

Implements #232: Agent-Channel Binding — allows binding agents to specific messaging channels and dispatching inbound messages to the correct agent/session.

### New Files (8)

**Migration:**
- `012_create_agent_channel_binding.up.sql` — `agent_channel_binding` table with `UNIQUE(channel_type, chat_id)` and `ON DELETE CASCADE`
- `012_create_agent_channel_binding.down.sql`

**Service:**
- `channels/agent-channel-service.ts` — `resolveAgent`, `bindChannel`, `unbindChannel`, `unbindById`, `listBindings`, `setDefault`
- `channels/message-dispatch.ts` — `createMessageDispatch()` handler: resolves agent bindings, finds/creates sessions, logs dispatched messages

**Routes:**
- `routes/agent-channels.ts` — REST API: `GET/POST/DELETE /agents/:agentId/channels`, `POST /agents/:agentId/channels/default`

**Dashboard:**
- `schemas/channels.ts` — Zod schema for `AgentChannelBinding`
- `api-client.ts` — `listAgentChannels`, `bindAgentChannel`, `unbindAgentChannel`

### Modified Files (3)
- `db/types.ts` — Added `AgentChannelBindingTable` type
- `app.ts` — Registered `agentChannelRoutes` plugin
- `api-client.ts` — Added channel binding API functions

### Tests (19 new)
- `agent-channel-service.test.ts` — 9 tests
- `agent-channel-routes.test.ts` — 7 tests
- `message-dispatch.test.ts` — 3 tests

### Verification
- 629 control-plane tests + 306 dashboard tests passing
- Format, lint, typecheck all clean

### Stats
12 files, +1103 lines

Closes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent-channel binding management capabilities, enabling agents to be assigned to specific chat channels.
  * New API endpoints for listing, binding, and unbinding channels to agents with default channel support.
  * Integrated message routing to dispatch messages to the correct agent session based on channel configuration.

* **Tests**
  * Added comprehensive test coverage for agent-channel binding operations and message dispatch workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->