### PR TITLE
fix(auth): include state in Anthropic OAuth token exchange

### DIFF
--- a/packages/control-plane/src/auth/oauth-service.ts
+++ b/packages/control-plane/src/auth/oauth-service.ts
@@ -223,13 +223,15 @@ export interface TokenExchangeParams {
   code: string
   callbackUrl: string
   codeVerifier?: string
+  /** OAuth state parameter — required by Anthropic in the token exchange body. */
+  state?: string
 }
 
 /**
  * Exchange an authorization code for tokens.
  */
 export async function exchangeCodeForTokens(params: TokenExchangeParams): Promise<TokenResponse> {
-  const { provider, config, code, callbackUrl, codeVerifier } = params
+  const { provider, config, code, callbackUrl, codeVerifier, state } = params
   const urls = getProviderUrls(provider, config)
 
   // Anthropic uses JSON body for token exchange
@@ -242,6 +244,7 @@ export async function exchangeCodeForTokens(params: TokenExchangeParams): Promis
     }
     if (config.clientSecret) jsonBody.client_secret = config.clientSecret
     if (codeVerifier) jsonBody.code_verifier = codeVerifier
+    if (state) jsonBody.state = state
 
     const res = await fetch(urls.tokenUrl, {
       method: "POST",

--- a/packages/control-plane/src/routes/auth.ts
+++ b/packages/control-plane/src/routes/auth.ts
@@ -411,7 +411,8 @@ export function authRoutes(deps: AuthRouteDeps) {
 
         const codeVerifier = generateCodeVerifier()
         const codeChallenge = generateCodeChallenge(codeVerifier)
-        const state = crypto.randomUUID()
+        // Anthropic uses the PKCE verifier as the state parameter (matches pi-ai SDK).
+        const state = provider === "anthropic" ? codeVerifier : crypto.randomUUID()
 
         const url = new URL(providerReg.authUrl)
         url.searchParams.set("client_id", providerReg.clientId)
@@ -510,6 +511,7 @@ export function authRoutes(deps: AuthRouteDeps) {
             code: parsed.code,
             callbackUrl: providerReg.redirectUri,
             codeVerifier,
+            state: parsed.state,
           })
 
           // Provider-specific post-exchange actions


### PR DESCRIPTION
## Problem

Anthropic OAuth token exchange fails with `400 Invalid request format`. The error occurs because:

1. **Missing `state` in token exchange body** — Anthropic requires the `state` parameter in the token exchange JSON body. Our code omitted it.
2. **State should equal PKCE verifier** — The pi-ai SDK (OpenClaw's reference implementation) uses the PKCE code verifier as the OAuth state parameter. Our code used a random UUID instead.

Error from Anthropic:
```
Token exchange failed for anthropic: 400 {"type":"error","error":{"type":"invalid_request_error","message":"Invalid request format"}}
```

## Root Cause

Compared our implementation against the pi-ai SDK (`@mariozechner/pi-ai`) at:
`node_modules/@mariozechner/pi-ai/dist/utils/oauth/anthropic.js`

Key differences:
- pi-ai sends `state` in the token exchange body — we didn't
- pi-ai uses the PKCE verifier as the state value — we used `crypto.randomUUID()`

## Changes

- **`oauth-service.ts`**: Added optional `state` field to `TokenExchangeParams`, included in Anthropic's JSON token exchange body
- **`auth.ts` (init)**: Use PKCE verifier as state for Anthropic provider (matching pi-ai convention)
- **`auth.ts` (exchange)**: Pass `parsed.state` through to token exchange

## Testing

- All 1,386 tests pass (608 control-plane + 291 dashboard + 411 shared + 52 adapter-discord + 24 agent-cdp)
- Typecheck clean across all packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth token exchange state handling for enhanced security and provider-specific authentication support.
  * Aligned Anthropic provider authentication with standard PKCE-based state management for consistent OAuth flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->