### PR TITLE
fix(dashboard): per-instance dedup key for stat cards (#245)

### DIFF
--- a/packages/dashboard/src/__tests__/hooks.test.ts
+++ b/packages/dashboard/src/__tests__/hooks.test.ts
@@ -138,6 +138,25 @@ describe("useApi deduplication logic", () => {
   })
 })
 
+describe("useApi instance key isolation", () => {
+  it("anonymous arrow functions have empty name (root cause of #245)", () => {
+    // When useApiQuery wraps calls like () => listAgents({limit: 100}),
+    // the arrow function has .name === "". Before the fix, all three
+    // dashboard queries shared the dedup key "useApi::[]", causing the
+    // first resolved response (agents) to be used for jobs and approvals.
+    const anon1 = (
+      () => () =>
+        Promise.resolve({ total: 10 })
+    )()
+    const anon2 = (
+      () => () =>
+        Promise.resolve({ total: 20 })
+    )()
+    expect(anon1.name).toBe("")
+    expect(anon2.name).toBe("")
+  })
+})
+
 // ---------------------------------------------------------------------------
 // ApiError integration with hooks
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/__tests__/schema-contract.test.ts
+++ b/packages/dashboard/src/__tests__/schema-contract.test.ts
@@ -292,6 +292,48 @@ describe("API-Dashboard contract tests", () => {
   })
 
   // ---------------------------------------------------------------------------
+  // Dashboard stat cards — zero-result responses
+  // ---------------------------------------------------------------------------
+
+  describe("dashboard stat cards: zero-result API responses", () => {
+    it("JobListResponseSchema parses empty jobs with pagination.total = 0", () => {
+      const emptyResponse = {
+        jobs: [],
+        pagination: { total: 0, limit: 5, offset: 0, hasMore: false },
+      }
+      const result = JobListResponseSchema.parse(emptyResponse)
+      expect(result.jobs).toHaveLength(0)
+      expect(result.pagination.total).toBe(0)
+    })
+
+    it("ApprovalListResponseSchema parses empty approvals with pagination.total = 0", () => {
+      const emptyResponse = {
+        approvals: [],
+        pagination: { total: 0, limit: 1, offset: 0, hasMore: false },
+      }
+      const result = ApprovalListResponseSchema.parse(emptyResponse)
+      expect(result.approvals).toHaveLength(0)
+      expect(result.pagination?.total).toBe(0)
+    })
+
+    it("AgentListResponseSchema parses empty agents with pagination.total = 0", () => {
+      const emptyResponse = {
+        agents: [],
+        pagination: { total: 0, limit: 100, offset: 0, hasMore: false },
+      }
+      const result = AgentListResponseSchema.parse(emptyResponse)
+      expect(result.agents).toHaveLength(0)
+      expect(result.pagination.total).toBe(0)
+    })
+
+    it("AgentListResponseSchema normalizes count-only response to pagination", () => {
+      const countOnlyResponse = { agents: [], count: 0 }
+      const result = AgentListResponseSchema.parse(countOnlyResponse)
+      expect(result.pagination.total).toBe(0)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
   // Negative test — deliberately broken field name detected
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Root Cause

`useApi` hook generated dedup cache keys using `apiFnRef.current.name`. When `useDashboard` calls `useApiQuery` with anonymous arrow functions (`() => listAgents(...)`), all functions have `.name === ""`. Combined with identical args (`[]`), all queries shared key `"useApi::[]"`.

First response to resolve (agents, total=2) was cached and returned for all stat cards → Jobs and Approvals both showed 2 instead of 0.

## Fix

Replaced function-name-based key with a per-instance counter (`nextInstanceId`), assigned via `useRef` on first render. Each `useApi` instance now gets its own dedup namespace.

## Tests Added
- 4 contract tests for zero-result API responses
- 1 test documenting the anonymous function name collision

Closes #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deduplication key isolation so distinct dashboard queries no longer share dedup keys, preventing incorrect query merging.

* **Tests**
  * Added test coverage for query isolation to verify independent dashboard queries maintain separate identities.
  * Extended schema contract tests to validate zero-result API responses for job lists, approval lists, and agent lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->