### PR TITLE
fix(auth): support session cookie auth in SSE stream endpoints (#246)

### DIFF
--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -200,7 +200,9 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
 
   // Always register streaming + observation routes
   // (lifecycleManager is optional — routes handle its absence gracefully)
-  await app.register(streamRoutes({ sseManager, lifecycleManager: options.lifecycleManager }))
+  await app.register(
+    streamRoutes({ sseManager, lifecycleManager: options.lifecycleManager, sessionService }),
+  )
   await app.register(
     voiceRoutes({
       db,

--- a/packages/control-plane/src/routes/stream.ts
+++ b/packages/control-plane/src/routes/stream.ts
@@ -12,6 +12,7 @@ import { randomUUID } from "node:crypto"
 
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
 
+import type { SessionService } from "../auth/session-service.js"
 import type { AgentLifecycleManager } from "../lifecycle/manager.js"
 import {
   type AuthenticatedRequest,
@@ -39,13 +40,14 @@ interface SteerBody {
 export interface StreamRouteDeps {
   sseManager: SSEConnectionManager
   lifecycleManager?: AgentLifecycleManager
+  sessionService?: SessionService
 }
 
 export function streamRoutes(deps: StreamRouteDeps) {
-  const { sseManager, lifecycleManager } = deps
+  const { sseManager, lifecycleManager, sessionService } = deps
 
   return function register(app: FastifyInstance): void {
-    const authHook = createStreamAuth(app.db)
+    const authHook = createStreamAuth({ db: app.db, sessionService })
 
     // -----------------------------------------------------------------
     // GET /agents/:agentId/stream — SSE live output

--- a/packages/control-plane/src/streaming/auth.ts
+++ b/packages/control-plane/src/streaming/auth.ts
@@ -1,18 +1,24 @@
 /**
  * Per-session token authentication for SSE streaming endpoints.
  *
- * Tokens are validated against the session table. Each session has
- * an agent_id, so the middleware also verifies that the token grants
- * access to the requested agent.
+ * Supports two authentication methods (checked in order):
+ *   1. Session cookie (httpOnly, set by OAuth login flow) — used by browser
+ *      EventSource which cannot send custom headers.
+ *   2. Authorization: Bearer <session-id> — used by programmatic clients.
  *
- * Token format: Bearer <session-id>
- * In production this would be a signed JWT or opaque token; for now
- * we use the session ID directly with a DB lookup.
+ * Bearer tokens are validated against the agent session table. Each session has
+ * an agent_id, so the middleware also verifies that the token grants access to
+ * the requested agent.
+ *
+ * Cookie-based sessions are validated via the dashboard SessionService. Dashboard
+ * users are granted access to any agent's stream.
  */
 
 import type { FastifyReply, FastifyRequest } from "fastify"
 import type { Kysely } from "kysely"
 
+import type { SessionService } from "../auth/session-service.js"
+import { SESSION_COOKIE_NAME } from "../auth/session-service.js"
 import type { Database } from "../db/types.js"
 
 export interface AuthContext {
@@ -21,16 +27,47 @@ export interface AuthContext {
   userAccountId: string
 }
 
+export interface StreamAuthOptions {
+  db: Kysely<Database>
+  sessionService?: SessionService
+}
+
 /**
  * Create an authentication hook for agent streaming routes.
- * Extracts Bearer token, validates against the session table,
- * and verifies the session grants access to the requested agent.
+ *
+ * When a SessionService is provided, dashboard session cookies are checked
+ * first (required for browser EventSource which cannot set headers).
+ * Falls back to Bearer token validation against the agent session table.
  */
-export function createStreamAuth(db: Kysely<Database>) {
+export function createStreamAuth(dbOrOptions: Kysely<Database> | StreamAuthOptions) {
+  const options: StreamAuthOptions = "selectFrom" in dbOrOptions ? { db: dbOrOptions } : dbOrOptions
+  const { db, sessionService } = options
+
   return async function streamAuth(
     request: FastifyRequest<{ Params: { agentId: string } }>,
     reply: FastifyReply,
   ): Promise<FastifyReply | void> {
+    const agentId = request.params.agentId
+
+    // 1. Try session cookie (dashboard sessions — EventSource cannot send headers)
+    if (sessionService) {
+      const cookieHeader = request.headers.cookie
+      const sessionId = parseCookieValue(cookieHeader, SESSION_COOKIE_NAME)
+
+      if (sessionId) {
+        const sessionData = await sessionService.validateSession(sessionId)
+        if (sessionData) {
+          ;(request as AuthenticatedRequest).authContext = {
+            sessionId,
+            agentId,
+            userAccountId: sessionData.user.userId,
+          }
+          return
+        }
+      }
+    }
+
+    // 2. Try Bearer token (agent execution sessions)
     const authHeader = request.headers.authorization
     if (!authHeader?.startsWith("Bearer ")) {
       return reply.status(401).send({
@@ -46,8 +83,6 @@ export function createStreamAuth(db: Kysely<Database>) {
         message: "Empty bearer token",
       })
     }
-
-    const agentId = request.params.agentId
 
     try {
       const session = await db
@@ -85,6 +120,18 @@ export function createStreamAuth(db: Kysely<Database>) {
       })
     }
   }
+}
+
+function parseCookieValue(cookieHeader: string | undefined, name: string): string | undefined {
+  if (!cookieHeader) return undefined
+  const prefix = `${name}=`
+  for (const part of cookieHeader.split(";")) {
+    const trimmed = part.trim()
+    if (trimmed.startsWith(prefix)) {
+      return trimmed.slice(prefix.length)
+    }
+  }
+  return undefined
 }
 
 export interface AuthenticatedRequest extends FastifyRequest {

--- a/packages/control-plane/src/streaming/index.ts
+++ b/packages/control-plane/src/streaming/index.ts
@@ -1,4 +1,9 @@
-export { type AuthContext, type AuthenticatedRequest, createStreamAuth } from "./auth.js"
+export {
+  type AuthContext,
+  type AuthenticatedRequest,
+  createStreamAuth,
+  type StreamAuthOptions,
+} from "./auth.js"
 export { SSEConnection } from "./connection.js"
 export { SSEConnectionManager } from "./manager.js"
 export type {


### PR DESCRIPTION
## Root Cause

`createStreamAuth` in `streaming/auth.ts` only accepted `Authorization: Bearer` tokens. Browser `EventSource` API cannot send custom headers — only cookies for same-origin requests. Dashboard SSE connections through the Next.js proxy forwarded cookies correctly, but the middleware ignored them → 401.

## Fix

Added session cookie (`cortex_session`) validation as primary auth in `createStreamAuth`:
1. Check session cookie → validate via `SessionService` (dashboard users)
2. Fall back to `Authorization: Bearer` → validate against agent session table (programmatic clients)

## Files Changed
- `packages/control-plane/src/streaming/auth.ts` — cookie + bearer dual auth
- `packages/control-plane/src/routes/stream.ts` — pass sessionService
- `packages/control-plane/src/app.ts` — wire sessionService to stream routes
- `packages/control-plane/src/streaming/index.ts` — export types
- Tests: 4 new tests covering cookie auth, bearer fallback, invalid session

Closes #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming endpoints now support cookie-based authentication, with automatic fallback to Bearer token validation if cookie authentication is unavailable.

* **Tests**
  * Added comprehensive test coverage for cookie-based and Bearer token authentication flows on streaming endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->