### PR TITLE
feat(backends): agentic execution loop with tool iteration (#242)

### DIFF
--- a/packages/control-plane/src/__tests__/http-llm.test.ts
+++ b/packages/control-plane/src/__tests__/http-llm.test.ts
@@ -1,5 +1,5 @@
-import type { ExecutionTask } from "@cortex/shared/backends"
-import { describe, expect, it } from "vitest"
+import type { ExecutionTask, OutputEvent } from "@cortex/shared/backends"
+import { describe, expect, it, vi } from "vitest"
 
 import { HttpLlmBackend } from "../backends/http-llm.js"
 
@@ -176,5 +176,522 @@ describe("HttpLlmBackend — provider selection", () => {
     const handle = await backend.executeTask(makeTask())
     expect(handle.taskId).toBe("task-llm-001")
     await handle.cancel("cleanup")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Agentic loop helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a mock object that mimics Anthropic's MessageStream.
+ * It is async-iterable (yields content_block_delta events for text)
+ * and exposes a finalMessage() that returns the complete message.
+ */
+function createMockAnthropicStream(opts: {
+  textContent: string
+  toolUseBlocks?: Array<{ id: string; name: string; input: Record<string, unknown> }>
+  stopReason: string
+  inputTokens?: number
+  outputTokens?: number
+}) {
+  const { textContent, toolUseBlocks = [], stopReason, inputTokens = 10, outputTokens = 20 } = opts
+
+  // Build content blocks for finalMessage
+  const contentBlocks: unknown[] = []
+  if (textContent) {
+    contentBlocks.push({ type: "text", text: textContent })
+  }
+  for (const tu of toolUseBlocks) {
+    contentBlocks.push({ type: "tool_use", id: tu.id, name: tu.name, input: tu.input })
+  }
+
+  // Build streaming events (only text deltas)
+  const events: unknown[] = []
+  if (textContent) {
+    events.push({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: textContent },
+    })
+  }
+
+  const finalMsg = {
+    id: "msg_test",
+    type: "message",
+    role: "assistant",
+    content: contentBlocks,
+    model: "test",
+    stop_reason: stopReason,
+    usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+  }
+
+  let eventIndex = 0
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: () => {
+          if (eventIndex < events.length) {
+            return Promise.resolve({ value: events[eventIndex++], done: false as const })
+          }
+          return Promise.resolve({ value: undefined, done: true as const })
+        },
+      }
+    },
+    finalMessage: () => Promise.resolve(finalMsg),
+    abort: vi.fn(),
+  }
+}
+
+/** Collect all OutputEvents from a handle. */
+async function collectEvents(handle: { events(): AsyncIterable<OutputEvent> }) {
+  const events: OutputEvent[] = []
+  for await (const e of handle.events()) {
+    events.push(e)
+  }
+  return events
+}
+
+// ---------------------------------------------------------------------------
+// Agentic loop — Anthropic
+// ---------------------------------------------------------------------------
+
+describe("HttpLlmBackend — agentic loop (Anthropic)", () => {
+  it("executes a single tool call and returns the final text response", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "test-key" })
+
+    // Replace the internal Anthropic client's stream method
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const client = (backend as any).anthropicClient
+    let callCount = 0
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    vi.spyOn(client.messages, "stream").mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        // First call: LLM returns text + tool_use
+        return createMockAnthropicStream({
+          textContent: "Let me echo that.",
+          toolUseBlocks: [{ id: "toolu_001", name: "echo", input: { text: "hello" } }],
+          stopReason: "tool_use",
+          inputTokens: 50,
+          outputTokens: 30,
+        })
+      }
+      // Second call: LLM returns final text
+      return createMockAnthropicStream({
+        textContent: "The echo returned: hello",
+        stopReason: "end_turn",
+        inputTokens: 80,
+        outputTokens: 15,
+      })
+    })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        maxTurns: 5,
+        allowedTools: ["echo"],
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+    const events = await collectEvents(handle)
+
+    // Should have text events from both iterations
+    const textEvents = events.filter((e) => e.type === "text")
+    expect(textEvents).toHaveLength(2)
+
+    // Should have tool_use and tool_result events
+    const toolUseEvents = events.filter((e) => e.type === "tool_use")
+    expect(toolUseEvents).toHaveLength(1)
+    expect(toolUseEvents[0]).toMatchObject({
+      type: "tool_use",
+      toolName: "echo",
+      toolInput: { text: "hello" },
+    })
+
+    const toolResultEvents = events.filter((e) => e.type === "tool_result")
+    expect(toolResultEvents).toHaveLength(1)
+    expect(toolResultEvents[0]).toMatchObject({
+      type: "tool_result",
+      toolName: "echo",
+      output: "hello",
+      isError: false,
+    })
+
+    // Should have usage event with accumulated tokens
+    const usageEvents = events.filter((e) => e.type === "usage")
+    expect(usageEvents).toHaveLength(1)
+    expect(usageEvents[0]).toMatchObject({
+      type: "usage",
+      tokenUsage: {
+        inputTokens: 130, // 50 + 80
+        outputTokens: 45, // 30 + 15
+      },
+    })
+
+    // Final result should contain all text
+    const result = await handle.result()
+    expect(result.status).toBe("completed")
+    expect(result.stdout).toBe("Let me echo that.The echo returned: hello")
+
+    // The LLM was called exactly twice
+    expect(callCount).toBe(2)
+  })
+
+  it("stops at maxTurns even when LLM keeps requesting tools", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "test-key" })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const client = (backend as any).anthropicClient
+    let callCount = 0
+
+    // Always return tool_use — loop should be bounded by maxTurns
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    vi.spyOn(client.messages, "stream").mockImplementation(() => {
+      callCount++
+      return createMockAnthropicStream({
+        textContent: `Iteration ${callCount}. `,
+        toolUseBlocks: [{ id: `toolu_${callCount}`, name: "echo", input: { text: "loop" } }],
+        stopReason: "tool_use",
+      })
+    })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        maxTurns: 3,
+        allowedTools: ["echo"],
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+    const events = await collectEvents(handle)
+
+    // maxTurns=3 means at most 3 LLM calls; tool execution happens
+    // between calls, so we get 2 tool executions (after call 1 and 2).
+    // Call 3 also returns tool_use but we can't loop again.
+    expect(callCount).toBe(3)
+
+    // Tool events: 2 rounds of tool execution (between iterations 1→2 and 2→3)
+    const toolUseEvents = events.filter((e) => e.type === "tool_use")
+    expect(toolUseEvents).toHaveLength(2)
+
+    const result = await handle.result()
+    expect(result.status).toBe("completed")
+  })
+
+  it("does not send tools when allowedTools is empty", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "test-key" })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const client = (backend as any).anthropicClient
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const streamSpy = vi.spyOn(client.messages, "stream").mockImplementation(() => {
+      return createMockAnthropicStream({
+        textContent: "Just text, no tools.",
+        stopReason: "end_turn",
+      })
+    })
+
+    const task = makeTask() // allowedTools: [] by default
+    const handle = await backend.executeTask(task)
+    await collectEvents(handle)
+
+    // Verify no tools parameter was sent
+
+    const callArgs = streamSpy.mock.calls[0][0] as Record<string, unknown>
+    expect(callArgs).not.toHaveProperty("tools")
+
+    const result = await handle.result()
+    expect(result.status).toBe("completed")
+    expect(result.stdout).toBe("Just text, no tools.")
+  })
+
+  it("handles unknown tool gracefully", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "test-key" })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const client = (backend as any).anthropicClient
+    let callCount = 0
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    vi.spyOn(client.messages, "stream").mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        return createMockAnthropicStream({
+          textContent: "",
+          toolUseBlocks: [{ id: "toolu_x", name: "nonexistent", input: {} }],
+          stopReason: "tool_use",
+        })
+      }
+      return createMockAnthropicStream({
+        textContent: "OK, that tool failed.",
+        stopReason: "end_turn",
+      })
+    })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        maxTurns: 5,
+        allowedTools: ["echo"],
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+    const events = await collectEvents(handle)
+
+    const toolResultEvents = events.filter((e) => e.type === "tool_result")
+    expect(toolResultEvents).toHaveLength(1)
+    expect(toolResultEvents[0]).toMatchObject({
+      toolName: "nonexistent",
+      isError: true,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      output: expect.stringContaining("Unknown tool"),
+    })
+
+    const result = await handle.result()
+    expect(result.status).toBe("completed")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Agentic loop — OpenAI
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a mock async iterable for OpenAI chat completion streaming.
+ * Yields chunks with text content and/or tool call deltas.
+ */
+function createMockOpenAIStream(opts: {
+  textContent: string
+  toolCalls?: Array<{ id: string; name: string; arguments: string }>
+  finishReason: string
+  promptTokens?: number
+  completionTokens?: number
+}) {
+  const {
+    textContent,
+    toolCalls = [],
+    finishReason,
+    promptTokens = 10,
+    completionTokens = 20,
+  } = opts
+
+  const chunks: unknown[] = []
+
+  // Text content chunk
+  if (textContent) {
+    chunks.push({
+      choices: [{ index: 0, delta: { content: textContent }, finish_reason: null }],
+    })
+  }
+
+  // Tool call chunks (each tool in a single chunk for simplicity)
+  for (const tc of toolCalls) {
+    chunks.push({
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: toolCalls.indexOf(tc),
+                id: tc.id,
+                type: "function",
+                function: { name: tc.name, arguments: tc.arguments },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    })
+  }
+
+  // Final chunk with finish_reason and usage
+  chunks.push({
+    choices: [{ index: 0, delta: {}, finish_reason: finishReason }],
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens,
+    },
+  })
+
+  let chunkIndex = 0
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: () => {
+          if (chunkIndex < chunks.length) {
+            return Promise.resolve({ value: chunks[chunkIndex++], done: false as const })
+          }
+          return Promise.resolve({ value: undefined, done: true as const })
+        },
+      }
+    },
+  }
+}
+
+describe("HttpLlmBackend — agentic loop (OpenAI)", () => {
+  it("executes a tool call and returns final text response", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "openai", apiKey: "test-key", model: "gpt-4o" })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const client = (backend as any).openaiClient
+    let callCount = 0
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    vi.spyOn(client.chat.completions, "create").mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        return Promise.resolve(
+          createMockOpenAIStream({
+            textContent: "Calling echo. ",
+            toolCalls: [{ id: "call_001", name: "echo", arguments: '{"text":"world"}' }],
+            finishReason: "tool_calls",
+            promptTokens: 40,
+            completionTokens: 25,
+          }),
+        )
+      }
+      return Promise.resolve(
+        createMockOpenAIStream({
+          textContent: "Echo said: world",
+          finishReason: "stop",
+          promptTokens: 70,
+          completionTokens: 12,
+        }),
+      )
+    })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        maxTurns: 5,
+        allowedTools: ["echo"],
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+    const events = await collectEvents(handle)
+
+    // Tool events
+    const toolUseEvents = events.filter((e) => e.type === "tool_use")
+    expect(toolUseEvents).toHaveLength(1)
+    expect(toolUseEvents[0]).toMatchObject({
+      toolName: "echo",
+      toolInput: { text: "world" },
+    })
+
+    const toolResultEvents = events.filter((e) => e.type === "tool_result")
+    expect(toolResultEvents).toHaveLength(1)
+    expect(toolResultEvents[0]).toMatchObject({
+      toolName: "echo",
+      output: "world",
+      isError: false,
+    })
+
+    const result = await handle.result()
+    expect(result.status).toBe("completed")
+    expect(result.stdout).toBe("Calling echo. Echo said: world")
+    expect(callCount).toBe(2)
+  })
+
+  it("does not send tools when allowedTools is empty", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "openai", apiKey: "test-key", model: "gpt-4o" })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const client = (backend as any).openaiClient
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const createSpy = vi.spyOn(client.chat.completions, "create").mockImplementation(() => {
+      return Promise.resolve(
+        createMockOpenAIStream({
+          textContent: "Just text.",
+          finishReason: "stop",
+        }),
+      )
+    })
+
+    const task = makeTask() // allowedTools: []
+    const handle = await backend.executeTask(task)
+    await collectEvents(handle)
+
+    const callArgs = createSpy.mock.calls[0][0] as Record<string, unknown>
+    expect(callArgs).not.toHaveProperty("tools")
+
+    const result = await handle.result()
+    expect(result.stdout).toBe("Just text.")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// registerTool
+// ---------------------------------------------------------------------------
+
+describe("HttpLlmBackend — registerTool()", () => {
+  it("makes custom tools available for execution", async () => {
+    const backend = new HttpLlmBackend()
+    backend.registerTool({
+      name: "greet",
+      description: "Returns a greeting",
+      inputSchema: {
+        type: "object",
+        properties: { name: { type: "string" } },
+        required: ["name"],
+      },
+      execute: (input) => Promise.resolve(`Hello, ${String(input.name)}!`),
+    })
+    await backend.start({ provider: "anthropic", apiKey: "test-key" })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const client = (backend as any).anthropicClient
+    let callCount = 0
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    vi.spyOn(client.messages, "stream").mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        return createMockAnthropicStream({
+          textContent: "",
+          toolUseBlocks: [{ id: "toolu_g1", name: "greet", input: { name: "Alice" } }],
+          stopReason: "tool_use",
+        })
+      }
+      return createMockAnthropicStream({
+        textContent: "Greeting done.",
+        stopReason: "end_turn",
+      })
+    })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        maxTurns: 5,
+        allowedTools: ["greet"],
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+    const events = await collectEvents(handle)
+
+    const toolResultEvents = events.filter((e) => e.type === "tool_result")
+    expect(toolResultEvents).toHaveLength(1)
+    expect(toolResultEvents[0]).toMatchObject({
+      toolName: "greet",
+      output: "Hello, Alice!",
+      isError: false,
+    })
   })
 })

--- a/packages/control-plane/src/__tests__/tool-executor.test.ts
+++ b/packages/control-plane/src/__tests__/tool-executor.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest"
+
+import { createDefaultToolRegistry, echoTool, ToolRegistry } from "../backends/tool-executor.js"
+
+// ---------------------------------------------------------------------------
+// echoTool
+// ---------------------------------------------------------------------------
+
+describe("echoTool", () => {
+  it("echoes back the input text", async () => {
+    const result = await echoTool.execute({ text: "hello world" })
+    expect(result).toBe("hello world")
+  })
+
+  it("serialises non-string input as JSON", async () => {
+    const result = await echoTool.execute({ num: 42 })
+    expect(result).toBe('{"num":42}')
+  })
+
+  it("has a valid input schema", () => {
+    expect(echoTool.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        text: { type: "string", description: "The text to echo back" },
+      },
+      required: ["text"],
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ToolRegistry
+// ---------------------------------------------------------------------------
+
+describe("ToolRegistry", () => {
+  it("registers and retrieves a tool", () => {
+    const registry = new ToolRegistry()
+    registry.register(echoTool)
+    expect(registry.get("echo")).toBe(echoTool)
+  })
+
+  it("returns undefined for unknown tools", () => {
+    const registry = new ToolRegistry()
+    expect(registry.get("nonexistent")).toBeUndefined()
+  })
+
+  it("executes a registered tool", async () => {
+    const registry = new ToolRegistry()
+    registry.register(echoTool)
+    const { output, isError } = await registry.execute("echo", { text: "test" })
+    expect(output).toBe("test")
+    expect(isError).toBe(false)
+  })
+
+  it("returns error for unknown tool execution", async () => {
+    const registry = new ToolRegistry()
+    const { output, isError } = await registry.execute("missing", {})
+    expect(output).toContain("Unknown tool")
+    expect(isError).toBe(true)
+  })
+
+  it("catches tool execution errors", async () => {
+    const registry = new ToolRegistry()
+    registry.register({
+      name: "failing",
+      description: "Always fails",
+      inputSchema: { type: "object", properties: {} },
+      execute: () => Promise.reject(new Error("boom")),
+    })
+    const { output, isError } = await registry.execute("failing", {})
+    expect(output).toBe("boom")
+    expect(isError).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolve (allowedTools / deniedTools filtering)
+// ---------------------------------------------------------------------------
+
+describe("ToolRegistry.resolve", () => {
+  it("returns empty when allowedTools is empty", () => {
+    const registry = createDefaultToolRegistry()
+    expect(registry.resolve([], [])).toEqual([])
+  })
+
+  it("returns matching tools from allowedTools", () => {
+    const registry = createDefaultToolRegistry()
+    const tools = registry.resolve(["echo"], [])
+    expect(tools).toHaveLength(1)
+    expect(tools[0].name).toBe("echo")
+  })
+
+  it("excludes tools in deniedTools", () => {
+    const registry = createDefaultToolRegistry()
+    const tools = registry.resolve(["echo"], ["echo"])
+    expect(tools).toHaveLength(0)
+  })
+
+  it("ignores allowed tools that do not exist in registry", () => {
+    const registry = createDefaultToolRegistry()
+    const tools = registry.resolve(["echo", "nonexistent"], [])
+    expect(tools).toHaveLength(1)
+    expect(tools[0].name).toBe("echo")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createDefaultToolRegistry
+// ---------------------------------------------------------------------------
+
+describe("createDefaultToolRegistry", () => {
+  it("includes the echo tool", () => {
+    const registry = createDefaultToolRegistry()
+    expect(registry.get("echo")).toBeDefined()
+  })
+})

--- a/packages/control-plane/src/backends/index.ts
+++ b/packages/control-plane/src/backends/index.ts
@@ -14,6 +14,12 @@ import { HttpLlmBackend } from "./http-llm.js"
 export { ClaudeCodeBackend } from "./claude-code.js"
 export { EchoBackend } from "./echo-backend.js"
 export { HttpLlmBackend } from "./http-llm.js"
+export {
+  createDefaultToolRegistry,
+  echoTool,
+  type ToolDefinition,
+  ToolRegistry,
+} from "./tool-executor.js"
 
 /** Default concurrency limits per backend type. */
 export const DEFAULT_CONCURRENCY: Record<string, number> = {

--- a/packages/control-plane/src/backends/tool-executor.ts
+++ b/packages/control-plane/src/backends/tool-executor.ts
@@ -1,0 +1,90 @@
+/**
+ * Tool Executor
+ *
+ * Provides a simple tool execution framework for the agentic iteration loop.
+ * Tools are registered with a name, description, JSON Schema, and handler.
+ */
+
+export interface ToolDefinition {
+  /** Unique tool name (sent to the LLM). */
+  name: string
+  /** Human-readable description for the LLM. */
+  description: string
+  /** JSON Schema describing the tool's input parameters. */
+  inputSchema: Record<string, unknown>
+  /** Execute the tool and return output text. */
+  execute: (input: Record<string, unknown>) => Promise<string>
+}
+
+/**
+ * Registry of available tools keyed by name.
+ */
+export class ToolRegistry {
+  private tools = new Map<string, ToolDefinition>()
+
+  register(tool: ToolDefinition): void {
+    this.tools.set(tool.name, tool)
+  }
+
+  get(name: string): ToolDefinition | undefined {
+    return this.tools.get(name)
+  }
+
+  /**
+   * Return tool definitions filtered by the task's allowed/denied lists.
+   * Per the TaskConstraints contract, an empty allowedTools array means
+   * "no tools" — the caller must opt-in by listing tool names.
+   */
+  resolve(allowedTools: string[], deniedTools: string[]): ToolDefinition[] {
+    if (allowedTools.length === 0) return []
+
+    const allowed = new Set(allowedTools)
+    const denied = new Set(deniedTools)
+    return [...this.tools.values()].filter((t) => allowed.has(t.name) && !denied.has(t.name))
+  }
+
+  /** Execute a tool call by name. */
+  async execute(
+    name: string,
+    input: Record<string, unknown>,
+  ): Promise<{ output: string; isError: boolean }> {
+    const tool = this.tools.get(name)
+    if (!tool) {
+      return { output: `Unknown tool: ${name}`, isError: true }
+    }
+    try {
+      const result = await tool.execute(input)
+      return { output: result, isError: false }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Tool execution failed"
+      return { output: message, isError: true }
+    }
+  }
+}
+
+/**
+ * Built-in echo tool — returns the input text unchanged.
+ * Useful for testing the agentic iteration loop.
+ */
+export const echoTool: ToolDefinition = {
+  name: "echo",
+  description: "Echoes back the provided text unchanged. Useful for testing.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      text: { type: "string", description: "The text to echo back" },
+    },
+    required: ["text"],
+  },
+  execute: (input) => {
+    const text = typeof input.text === "string" ? input.text : JSON.stringify(input)
+    return Promise.resolve(text)
+  },
+}
+
+/** Create a default registry with built-in tools. */
+export function createDefaultToolRegistry(): ToolRegistry {
+  const registry = new ToolRegistry()
+  registry.register(echoTool)
+  return registry
+}


### PR DESCRIPTION
## Summary

Adds an iteration loop to HttpLlmBackend: call LLM → parse tool_use → execute tools → call again → repeat until text response or max iterations.

## Changes

### New: Tool Executor
- `ToolDefinition` interface, `ToolRegistry` class
- Built-in `echo` tool for testing
- `createDefaultToolRegistry()` factory

### Modified: HttpLlmBackend
- Agentic loop in both `AnthropicHandle` and `OpenAIHandle`
- Streams text events, detects tool_use blocks, executes via ToolRegistry
- Emits `OutputToolUseEvent` + `OutputToolResultEvent`
- Bounded by `maxTurns` from TaskConstraints (prevents infinite loops)
- Tools only sent when `allowedTools` is non-empty (backward compatible)
- `registerTool()` for custom tool registration

### Tests (25 new)
- 13 tool executor tests
- 12 HTTP LLM loop tests (Anthropic + OpenAI paths, maxTurns, unknown tools, backward compat)

1489 total tests passing. Closes #242

Depends on #240, #241, #244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tool execution framework enabling custom tool registration and invocation.
  * Implemented agentic iteration loop that automatically executes tools and feeds results back to the LLM during conversations.
  * Supports tool use with both Anthropic and OpenAI providers.
  * Includes built-in echo tool and default tool registry.

* **Tests**
  * Added comprehensive test coverage for tool execution and LLM backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->