### PR TITLE
feat(tools): built-in tools + webhook framework (#243)

### DIFF
--- a/packages/control-plane/src/__tests__/builtin-tools.test.ts
+++ b/packages/control-plane/src/__tests__/builtin-tools.test.ts
@@ -1,0 +1,774 @@
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest"
+
+import { createAgentToolRegistry, createDefaultToolRegistry } from "../backends/tool-executor.js"
+import { createHttpRequestTool } from "../backends/tools/http-request.js"
+import { createMemoryQueryTool } from "../backends/tools/memory-query.js"
+import { createMemoryStoreTool } from "../backends/tools/memory-store.js"
+import { createWebSearchTool } from "../backends/tools/web-search.js"
+import {
+  createWebhookTool,
+  parseWebhookTools,
+  type WebhookToolSpec,
+} from "../backends/tools/webhook.js"
+
+// ---------------------------------------------------------------------------
+// Mock fetch globally
+// ---------------------------------------------------------------------------
+
+let fetchMock: MockInstance
+
+beforeEach(() => {
+  fetchMock = vi.spyOn(globalThis, "fetch")
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function mockFetchResponse(body: unknown, status = 200, statusText = "OK"): void {
+  fetchMock.mockResolvedValueOnce(
+    new Response(JSON.stringify(body), {
+      status,
+      statusText,
+      headers: { "Content-Type": "application/json" },
+    }),
+  )
+}
+
+function mockFetchTextResponse(body: string, status = 200, statusText = "OK"): void {
+  fetchMock.mockResolvedValueOnce(
+    new Response(body, {
+      status,
+      statusText,
+      headers: { "Content-Type": "text/plain" },
+    }),
+  )
+}
+
+/** Parse JSON tool output with a typed result. */
+function parseResult(json: string): Record<string, unknown> {
+  return JSON.parse(json) as Record<string, unknown>
+}
+
+/** Parse a request body from fetch mock args. */
+function parseBody(opts: RequestInit): Record<string, unknown> {
+  return JSON.parse(opts.body as string) as Record<string, unknown>
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// web_search
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("web_search tool", () => {
+  it("has correct name and schema", () => {
+    const tool = createWebSearchTool({ apiKey: "test-key" })
+    expect(tool.name).toBe("web_search")
+    expect(tool.inputSchema.required).toContain("query")
+  })
+
+  it("returns error when no API key is configured", async () => {
+    const tool = createWebSearchTool({ apiKey: "" })
+    const result = await tool.execute({ query: "test" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("not configured")
+  })
+
+  it("makes a GET request to the search API", async () => {
+    mockFetchResponse({
+      web: {
+        results: [
+          { title: "Result 1", url: "https://example.com/1", description: "Desc 1" },
+          { title: "Result 2", url: "https://example.com/2", description: "Desc 2" },
+        ],
+      },
+    })
+
+    const tool = createWebSearchTool({ apiKey: "test-key" })
+    const result = await tool.execute({ query: "hello world" })
+    const parsed = parseResult(result)
+
+    expect(parsed.results).toHaveLength(2)
+    expect((parsed.results as Record<string, unknown>[])[0].title).toBe("Result 1")
+    expect(parsed.query).toBe("hello world")
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain("q=hello+world")
+    expect(opts.method).toBe("GET")
+    expect((opts.headers as Record<string, string>)["X-Subscription-Token"]).toBe("test-key")
+  })
+
+  it("respects count parameter", async () => {
+    mockFetchResponse({
+      web: {
+        results: [
+          { title: "R1", url: "https://a.com", description: "D1" },
+          { title: "R2", url: "https://b.com", description: "D2" },
+          { title: "R3", url: "https://c.com", description: "D3" },
+        ],
+      },
+    })
+
+    const tool = createWebSearchTool({ apiKey: "test-key" })
+    const result = await tool.execute({ query: "test", count: 2 })
+    const parsed = parseResult(result)
+
+    expect(parsed.results).toHaveLength(2)
+  })
+
+  it("caps count at 20", async () => {
+    mockFetchResponse({ web: { results: [] } })
+
+    const tool = createWebSearchTool({ apiKey: "test-key" })
+    await tool.execute({ query: "test", count: 100 })
+
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toContain("count=20")
+  })
+
+  it("handles API error responses", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("Forbidden", { status: 403, statusText: "Forbidden" }),
+    )
+
+    const tool = createWebSearchTool({ apiKey: "test-key" })
+    const result = await tool.execute({ query: "test" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("403")
+  })
+
+  it("handles missing web results gracefully", async () => {
+    mockFetchResponse({ query: { original: "test" } })
+
+    const tool = createWebSearchTool({ apiKey: "test-key" })
+    const result = await tool.execute({ query: "test" })
+    const parsed = parseResult(result)
+    expect(parsed.results).toEqual([])
+  })
+
+  it("uses custom API URL", async () => {
+    mockFetchResponse({ web: { results: [] } })
+
+    const tool = createWebSearchTool({
+      apiKey: "key",
+      apiUrl: "https://custom-search.example.com/search",
+    })
+    await tool.execute({ query: "test" })
+
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toContain("custom-search.example.com")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// memory_query
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("memory_query tool", () => {
+  it("has correct name and schema", () => {
+    const tool = createMemoryQueryTool()
+    expect(tool.name).toBe("memory_query")
+    expect(tool.inputSchema.required).toContain("query")
+  })
+
+  it("queries Qdrant scroll endpoint", async () => {
+    mockFetchResponse({
+      result: {
+        points: [
+          { id: "p1", payload: { content: "Memory 1", metadata: { topic: "arch" } } },
+          { id: "p2", payload: { content: "Memory 2", metadata: {} } },
+        ],
+      },
+    })
+
+    const tool = createMemoryQueryTool({ qdrantUrl: "http://qdrant:6333" })
+    const result = await tool.execute({ query: "architecture" })
+    const parsed = parseResult(result)
+
+    expect(parsed.memories).toHaveLength(2)
+    expect((parsed.memories as Record<string, unknown>[])[0].content).toBe("Memory 1")
+    expect(parsed.count).toBe(2)
+
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toContain("qdrant:6333/collections/agent_memories/points/scroll")
+  })
+
+  it("passes limit parameter", async () => {
+    mockFetchResponse({ result: { points: [] } })
+
+    const tool = createMemoryQueryTool()
+    await tool.execute({ query: "test", limit: 3 })
+
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = parseBody(opts)
+    expect(body.limit).toBe(3)
+  })
+
+  it("caps limit at 50", async () => {
+    mockFetchResponse({ result: { points: [] } })
+
+    const tool = createMemoryQueryTool()
+    await tool.execute({ query: "test", limit: 100 })
+
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = parseBody(opts)
+    expect(body.limit).toBe(50)
+  })
+
+  it("passes filter to Qdrant", async () => {
+    mockFetchResponse({ result: { points: [] } })
+
+    const tool = createMemoryQueryTool()
+    await tool.execute({ query: "test", filter: { agentId: "agent-1" } })
+
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = parseBody(opts)
+    const filter = body.filter as Record<string, unknown>
+    const must = filter.must as Record<string, unknown>[]
+    expect(must[0].key).toBe("agentId")
+    expect((must[0].match as Record<string, unknown>).value).toBe("agent-1")
+  })
+
+  it("handles API errors", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("Not Found", { status: 404, statusText: "Not Found" }),
+    )
+
+    const tool = createMemoryQueryTool()
+    const result = await tool.execute({ query: "test" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("404")
+  })
+
+  it("handles empty points array", async () => {
+    mockFetchResponse({ result: { points: [] } })
+
+    const tool = createMemoryQueryTool()
+    const result = await tool.execute({ query: "test" })
+    const parsed = parseResult(result)
+    expect(parsed.memories).toEqual([])
+    expect(parsed.count).toBe(0)
+  })
+
+  it("sends API key header when configured", async () => {
+    mockFetchResponse({ result: { points: [] } })
+
+    const tool = createMemoryQueryTool({ qdrantApiKey: "my-key" })
+    await tool.execute({ query: "test" })
+
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect((opts.headers as Record<string, string>)["api-key"]).toBe("my-key")
+  })
+
+  it("uses custom collection name", async () => {
+    mockFetchResponse({ result: { points: [] } })
+
+    const tool = createMemoryQueryTool({ collection: "custom_memories" })
+    await tool.execute({ query: "test" })
+
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toContain("custom_memories")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// memory_store
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("memory_store tool", () => {
+  it("has correct name and schema", () => {
+    const tool = createMemoryStoreTool()
+    expect(tool.name).toBe("memory_store")
+    expect(tool.inputSchema.required).toContain("content")
+  })
+
+  it("stores a memory point in Qdrant", async () => {
+    mockFetchResponse({ status: "ok" })
+
+    const tool = createMemoryStoreTool({ qdrantUrl: "http://qdrant:6333" })
+    const result = await tool.execute({ content: "Important fact about architecture" })
+    const parsed = parseResult(result)
+
+    expect(parsed.stored).toBe(true)
+    expect(parsed.id).toBeDefined()
+
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain("qdrant:6333/collections/agent_memories/points")
+    expect(opts.method).toBe("PUT")
+
+    const body = parseBody(opts)
+    const points = body.points as Record<string, unknown>[]
+    expect(points).toHaveLength(1)
+    expect((points[0].payload as Record<string, unknown>).content).toBe(
+      "Important fact about architecture",
+    )
+  })
+
+  it("includes metadata in stored point", async () => {
+    mockFetchResponse({ status: "ok" })
+
+    const tool = createMemoryStoreTool()
+    await tool.execute({
+      content: "Some fact",
+      metadata: { topic: "design", importance: "high" },
+    })
+
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = parseBody(opts)
+    const points = body.points as Record<string, unknown>[]
+    expect((points[0].payload as Record<string, unknown>).metadata).toEqual({
+      topic: "design",
+      importance: "high",
+    })
+  })
+
+  it("uses correct vector size", async () => {
+    mockFetchResponse({ status: "ok" })
+
+    const tool = createMemoryStoreTool({ vectorSize: 768 })
+    await tool.execute({ content: "test" })
+
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = parseBody(opts)
+    const points = body.points as Record<string, unknown>[]
+    expect(points[0].vector).toHaveLength(768)
+  })
+
+  it("truncates content in response for long inputs", async () => {
+    mockFetchResponse({ status: "ok" })
+
+    const longContent = "A".repeat(200)
+    const tool = createMemoryStoreTool()
+    const result = await tool.execute({ content: longContent })
+    const parsed = parseResult(result)
+
+    expect(parsed.content).toContain("...")
+    expect((parsed.content as string).length).toBeLessThan(200)
+  })
+
+  it("handles API errors", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("Error", { status: 500, statusText: "Internal Server Error" }),
+    )
+
+    const tool = createMemoryStoreTool()
+    const result = await tool.execute({ content: "test" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("500")
+  })
+
+  it("sends API key header when configured", async () => {
+    mockFetchResponse({ status: "ok" })
+
+    const tool = createMemoryStoreTool({ qdrantApiKey: "qdrant-key" })
+    await tool.execute({ content: "test" })
+
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect((opts.headers as Record<string, string>)["api-key"]).toBe("qdrant-key")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// http_request
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("http_request tool", () => {
+  it("has correct name and schema", () => {
+    const tool = createHttpRequestTool()
+    expect(tool.name).toBe("http_request")
+    expect(tool.inputSchema.required).toContain("url")
+  })
+
+  it("makes a GET request by default", async () => {
+    mockFetchTextResponse("Hello, World!")
+
+    const tool = createHttpRequestTool()
+    const result = await tool.execute({ url: "https://example.com/api" })
+    const parsed = parseResult(result)
+
+    expect(parsed.status).toBe(200)
+    expect(parsed.body).toBe("Hello, World!")
+
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("https://example.com/api")
+    expect(opts.method).toBe("GET")
+  })
+
+  it("makes a POST request with body", async () => {
+    mockFetchResponse({ success: true })
+
+    const tool = createHttpRequestTool()
+    const result = await tool.execute({
+      url: "https://example.com/api",
+      method: "POST",
+      body: '{"key": "value"}',
+      headers: { "Content-Type": "application/json" },
+    })
+
+    const parsed = parseResult(result)
+    expect(parsed.status).toBe(200)
+
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(opts.method).toBe("POST")
+    expect(opts.body).toBe('{"key": "value"}')
+  })
+
+  it("blocks requests to localhost", async () => {
+    const tool = createHttpRequestTool()
+    const result = await tool.execute({ url: "http://localhost:8080/secret" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("not allowed")
+  })
+
+  it("blocks requests to 127.0.0.1", async () => {
+    const tool = createHttpRequestTool()
+    const result = await tool.execute({ url: "http://127.0.0.1:8080/secret" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("not allowed")
+  })
+
+  it("blocks requests to ::1", async () => {
+    const tool = createHttpRequestTool()
+    const result = await tool.execute({ url: "http://[::1]:8080/secret" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("not allowed")
+  })
+
+  it("blocks requests to 0.0.0.0", async () => {
+    const tool = createHttpRequestTool()
+    const result = await tool.execute({ url: "http://0.0.0.0:8080/secret" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("not allowed")
+  })
+
+  it("blocks requests to .internal domains", async () => {
+    const tool = createHttpRequestTool()
+    const result = await tool.execute({ url: "http://service.internal:8080/api" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("not allowed")
+  })
+
+  it("rejects invalid URLs", async () => {
+    const tool = createHttpRequestTool()
+    const result = await tool.execute({ url: "not-a-url" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("Invalid URL")
+  })
+
+  it("rejects unsupported HTTP methods", async () => {
+    const tool = createHttpRequestTool()
+    const result = await tool.execute({ url: "https://example.com", method: "TRACE" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("Unsupported HTTP method")
+  })
+
+  it("respects URL allowlist", async () => {
+    const tool = createHttpRequestTool({
+      allowedUrlPrefixes: ["https://api.example.com/"],
+    })
+
+    const result = await tool.execute({ url: "https://evil.com/steal" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("not in the allowed list")
+  })
+
+  it("allows URLs matching the allowlist", async () => {
+    mockFetchTextResponse("OK")
+
+    const tool = createHttpRequestTool({
+      allowedUrlPrefixes: ["https://api.example.com/"],
+    })
+
+    const result = await tool.execute({ url: "https://api.example.com/data" })
+    const parsed = parseResult(result)
+    expect(parsed.status).toBe(200)
+  })
+
+  it("handles response size limit", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("x".repeat(100), {
+        status: 200,
+        headers: { "Content-Length": "2000000" },
+      }),
+    )
+
+    const tool = createHttpRequestTool({ maxResponseBytes: 1_048_576 })
+    const result = await tool.execute({ url: "https://example.com/large" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("too large")
+  })
+
+  it("supports all standard HTTP methods", async () => {
+    for (const method of ["GET", "POST", "PUT", "PATCH", "DELETE"]) {
+      fetchMock.mockResolvedValueOnce(new Response("ok", { status: 200 }))
+      const tool = createHttpRequestTool()
+      const result = await tool.execute({ url: "https://example.com", method })
+      const parsed = parseResult(result)
+      expect(parsed.status).toBe(200)
+    }
+  })
+
+  it("does not send body for GET requests", async () => {
+    mockFetchTextResponse("ok")
+
+    const tool = createHttpRequestTool()
+    await tool.execute({ url: "https://example.com", method: "GET", body: "ignored" })
+
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(opts.body).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// webhook tools
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("createWebhookTool", () => {
+  const spec: WebhookToolSpec = {
+    name: "my_webhook",
+    description: "Calls my webhook",
+    inputSchema: {
+      type: "object",
+      properties: { data: { type: "string" } },
+      required: ["data"],
+    },
+    webhook: {
+      url: "https://hooks.example.com/trigger",
+      method: "POST",
+      headers: { Authorization: "Bearer token123" },
+      timeout_ms: 5000,
+    },
+  }
+
+  it("creates a tool with the correct name and schema", () => {
+    const tool = createWebhookTool(spec)
+    expect(tool.name).toBe("my_webhook")
+    expect(tool.description).toBe("Calls my webhook")
+    expect(tool.inputSchema).toEqual(spec.inputSchema)
+  })
+
+  it("sends input as JSON body to the webhook URL", async () => {
+    mockFetchTextResponse('{"result": "ok"}')
+
+    const tool = createWebhookTool(spec)
+    const result = await tool.execute({ data: "hello" })
+
+    expect(result).toBe('{"result": "ok"}')
+
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("https://hooks.example.com/trigger")
+    expect(opts.method).toBe("POST")
+    expect((opts.headers as Record<string, string>).Authorization).toBe("Bearer token123")
+
+    const body = parseBody(opts)
+    expect(body.data).toBe("hello")
+  })
+
+  it("handles webhook error responses", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("Error", { status: 500, statusText: "Internal Server Error" }),
+    )
+
+    const tool = createWebhookTool(spec)
+    const result = await tool.execute({ data: "test" })
+    const parsed = parseResult(result)
+    expect(parsed.error).toContain("500")
+  })
+
+  it("defaults to POST method", () => {
+    const specNoMethod: WebhookToolSpec = {
+      ...spec,
+      webhook: { url: "https://hooks.example.com/trigger" },
+    }
+    const tool = createWebhookTool(specNoMethod)
+
+    expect(tool.name).toBe("my_webhook")
+  })
+
+  it("uses GET method when specified", async () => {
+    mockFetchTextResponse("result")
+
+    const getSpec: WebhookToolSpec = {
+      ...spec,
+      webhook: { ...spec.webhook, method: "GET" },
+    }
+    const tool = createWebhookTool(getSpec)
+    await tool.execute({ data: "test" })
+
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(opts.method).toBe("GET")
+    expect(opts.body).toBeUndefined()
+  })
+})
+
+describe("parseWebhookTools", () => {
+  it("returns empty array when no tools configured", () => {
+    expect(parseWebhookTools({})).toEqual([])
+    expect(parseWebhookTools({ tools: "not-an-array" })).toEqual([])
+  })
+
+  it("parses valid webhook tool specs", () => {
+    const config = {
+      tools: [
+        {
+          name: "tool_a",
+          description: "Tool A",
+          inputSchema: { type: "object", properties: {} },
+          webhook: { url: "https://a.example.com" },
+        },
+        {
+          name: "tool_b",
+          description: "Tool B",
+          inputSchema: { type: "object", properties: {} },
+          webhook: {
+            url: "https://b.example.com",
+            method: "PUT",
+            headers: { "X-Custom": "value" },
+            timeout_ms: 10_000,
+          },
+        },
+      ],
+    }
+
+    const specs = parseWebhookTools(config)
+    expect(specs).toHaveLength(2)
+    expect(specs[0].name).toBe("tool_a")
+    expect(specs[1].webhook.method).toBe("PUT")
+    expect(specs[1].webhook.headers).toEqual({ "X-Custom": "value" })
+  })
+
+  it("skips invalid entries", () => {
+    const config = {
+      tools: [
+        {
+          name: "valid",
+          description: "Valid",
+          inputSchema: {},
+          webhook: { url: "https://x.com" },
+        },
+        { name: "missing_webhook" },
+        { name: "bad_url", description: "Bad", inputSchema: {}, webhook: { url: 123 } },
+        null,
+        "not-an-object",
+        { description: "no name", inputSchema: {}, webhook: { url: "https://x.com" } },
+      ],
+    }
+
+    const specs = parseWebhookTools(config)
+    expect(specs).toHaveLength(1)
+    expect(specs[0].name).toBe("valid")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// createDefaultToolRegistry — now includes built-in tools
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("createDefaultToolRegistry — built-in tools", () => {
+  it("includes echo tool", () => {
+    const registry = createDefaultToolRegistry()
+    expect(registry.get("echo")).toBeDefined()
+  })
+
+  it("includes web_search tool", () => {
+    const registry = createDefaultToolRegistry()
+    expect(registry.get("web_search")).toBeDefined()
+  })
+
+  it("includes memory_query tool", () => {
+    const registry = createDefaultToolRegistry()
+    expect(registry.get("memory_query")).toBeDefined()
+  })
+
+  it("includes memory_store tool", () => {
+    const registry = createDefaultToolRegistry()
+    expect(registry.get("memory_store")).toBeDefined()
+  })
+
+  it("includes http_request tool", () => {
+    const registry = createDefaultToolRegistry()
+    expect(registry.get("http_request")).toBeDefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// createAgentToolRegistry
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("createAgentToolRegistry", () => {
+  it("includes all default tools when no custom tools configured", () => {
+    const registry = createAgentToolRegistry({})
+    expect(registry.get("echo")).toBeDefined()
+    expect(registry.get("web_search")).toBeDefined()
+    expect(registry.get("memory_query")).toBeDefined()
+    expect(registry.get("memory_store")).toBeDefined()
+    expect(registry.get("http_request")).toBeDefined()
+  })
+
+  it("registers custom webhook tools from agent config", () => {
+    const registry = createAgentToolRegistry({
+      tools: [
+        {
+          name: "custom_tool",
+          description: "Custom webhook tool",
+          inputSchema: { type: "object", properties: {} },
+          webhook: { url: "https://hooks.example.com/custom" },
+        },
+      ],
+    })
+
+    expect(registry.get("custom_tool")).toBeDefined()
+    expect(registry.get("custom_tool")!.description).toBe("Custom webhook tool")
+  })
+
+  it("includes both default and custom tools", () => {
+    const registry = createAgentToolRegistry({
+      tools: [
+        {
+          name: "agent_tool",
+          description: "Agent-specific tool",
+          inputSchema: { type: "object", properties: {} },
+          webhook: { url: "https://hooks.example.com" },
+        },
+      ],
+    })
+
+    expect(registry.get("echo")).toBeDefined()
+    expect(registry.get("web_search")).toBeDefined()
+    expect(registry.get("agent_tool")).toBeDefined()
+  })
+
+  it("resolves custom tools via allowed list", () => {
+    const registry = createAgentToolRegistry({
+      tools: [
+        {
+          name: "agent_tool",
+          description: "Agent-specific tool",
+          inputSchema: { type: "object", properties: {} },
+          webhook: { url: "https://hooks.example.com" },
+        },
+      ],
+    })
+
+    const resolved = registry.resolve(["echo", "agent_tool"], [])
+    expect(resolved).toHaveLength(2)
+    expect(resolved.map((t) => t.name)).toContain("agent_tool")
+  })
+
+  it("custom tools can be denied", () => {
+    const registry = createAgentToolRegistry({
+      tools: [
+        {
+          name: "agent_tool",
+          description: "Agent-specific tool",
+          inputSchema: { type: "object", properties: {} },
+          webhook: { url: "https://hooks.example.com" },
+        },
+      ],
+    })
+
+    const resolved = registry.resolve(["echo", "agent_tool"], ["agent_tool"])
+    expect(resolved).toHaveLength(1)
+    expect(resolved[0].name).toBe("echo")
+  })
+})

--- a/packages/control-plane/src/backends/index.ts
+++ b/packages/control-plane/src/backends/index.ts
@@ -15,11 +15,21 @@ export { ClaudeCodeBackend } from "./claude-code.js"
 export { EchoBackend } from "./echo-backend.js"
 export { HttpLlmBackend } from "./http-llm.js"
 export {
+  createAgentToolRegistry,
   createDefaultToolRegistry,
   echoTool,
   type ToolDefinition,
   ToolRegistry,
 } from "./tool-executor.js"
+export {
+  createHttpRequestTool,
+  createMemoryQueryTool,
+  createMemoryStoreTool,
+  createWebhookTool,
+  createWebSearchTool,
+  parseWebhookTools,
+  type WebhookToolSpec,
+} from "./tools/index.js"
 
 /** Default concurrency limits per backend type. */
 export const DEFAULT_CONCURRENCY: Record<string, number> = {

--- a/packages/control-plane/src/backends/tools/http-request.ts
+++ b/packages/control-plane/src/backends/tools/http-request.ts
@@ -1,0 +1,137 @@
+/**
+ * Built-in http_request tool — makes arbitrary HTTP requests.
+ *
+ * Supports GET, POST, PUT, PATCH, DELETE methods with configurable
+ * headers, body, and timeout. Useful for calling external APIs.
+ */
+
+import type { ToolDefinition } from "../tool-executor.js"
+
+export interface HttpRequestConfig {
+  /** Maximum allowed timeout per request (ms). */
+  maxTimeoutMs?: number
+  /** Maximum response body size (bytes). */
+  maxResponseBytes?: number
+  /** Optional URL allowlist. If set, only these URL prefixes are permitted. */
+  allowedUrlPrefixes?: string[]
+}
+
+const DEFAULT_MAX_TIMEOUT_MS = 30_000
+const DEFAULT_MAX_RESPONSE_BYTES = 1_048_576 // 1 MB
+const ALLOWED_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"])
+
+export function createHttpRequestTool(config?: HttpRequestConfig): ToolDefinition {
+  const maxTimeoutMs = config?.maxTimeoutMs ?? DEFAULT_MAX_TIMEOUT_MS
+  const maxResponseBytes = config?.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES
+  const allowedUrlPrefixes = config?.allowedUrlPrefixes
+
+  return {
+    name: "http_request",
+    description:
+      "Make an HTTP request to an external URL. Supports GET, POST, PUT, PATCH, DELETE methods.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        url: { type: "string", description: "The URL to request" },
+        method: {
+          type: "string",
+          description: "HTTP method (GET, POST, PUT, PATCH, DELETE). Defaults to GET.",
+          enum: ["GET", "POST", "PUT", "PATCH", "DELETE"],
+        },
+        headers: {
+          type: "object",
+          description: "Request headers as key-value pairs",
+        },
+        body: {
+          type: "string",
+          description: "Request body (for POST/PUT/PATCH). Sent as-is.",
+        },
+        timeout_ms: {
+          type: "number",
+          description: "Request timeout in milliseconds (default 30000)",
+        },
+      },
+      required: ["url"],
+    },
+    execute: async (input) => {
+      const url = typeof input.url === "string" ? input.url : String(input.url)
+      const method = typeof input.method === "string" ? input.method.toUpperCase() : "GET"
+      const headers =
+        typeof input.headers === "object" && input.headers !== null
+          ? (input.headers as Record<string, string>)
+          : {}
+      const body = typeof input.body === "string" ? input.body : undefined
+      const timeoutMs = Math.min(
+        typeof input.timeout_ms === "number" ? input.timeout_ms : maxTimeoutMs,
+        maxTimeoutMs,
+      )
+
+      // Validate method
+      if (!ALLOWED_METHODS.has(method)) {
+        return JSON.stringify({ error: `Unsupported HTTP method: ${method}` })
+      }
+
+      // Validate URL
+      let parsedUrl: URL
+      try {
+        parsedUrl = new URL(url)
+      } catch {
+        return JSON.stringify({ error: `Invalid URL: ${url}` })
+      }
+
+      // Block private/internal addresses
+      const hostname = parsedUrl.hostname.replace(/^\[|\]$/g, "")
+      if (
+        hostname === "localhost" ||
+        hostname === "127.0.0.1" ||
+        hostname === "::1" ||
+        hostname === "0.0.0.0" ||
+        hostname.endsWith(".internal")
+      ) {
+        return JSON.stringify({
+          error: "Requests to localhost and internal addresses are not allowed",
+        })
+      }
+
+      // Check URL allowlist
+      if (allowedUrlPrefixes && allowedUrlPrefixes.length > 0) {
+        const allowed = allowedUrlPrefixes.some((prefix) => url.startsWith(prefix))
+        if (!allowed) {
+          return JSON.stringify({ error: "URL is not in the allowed list" })
+        }
+      }
+
+      const response = await fetch(url, {
+        method,
+        headers,
+        body: body && method !== "GET" ? body : undefined,
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+
+      // Read response with size limit
+      const contentLength = response.headers.get("content-length")
+      if (contentLength && parseInt(contentLength, 10) > maxResponseBytes) {
+        return JSON.stringify({
+          error: `Response too large: ${contentLength} bytes (max ${maxResponseBytes})`,
+          status: response.status,
+        })
+      }
+
+      const responseBody = await response.text()
+      if (responseBody.length > maxResponseBytes) {
+        return JSON.stringify({
+          status: response.status,
+          headers: Object.fromEntries(response.headers.entries()),
+          body: responseBody.slice(0, maxResponseBytes),
+          truncated: true,
+        })
+      }
+
+      return JSON.stringify({
+        status: response.status,
+        headers: Object.fromEntries(response.headers.entries()),
+        body: responseBody,
+      })
+    },
+  }
+}

--- a/packages/control-plane/src/backends/tools/index.ts
+++ b/packages/control-plane/src/backends/tools/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Built-in Tools & Webhook Factory
+ *
+ * Re-exports all built-in tool factories and the webhook tool factory.
+ */
+
+export { createHttpRequestTool, type HttpRequestConfig } from "./http-request.js"
+export { createMemoryQueryTool, type MemoryQueryConfig } from "./memory-query.js"
+export { createMemoryStoreTool, type MemoryStoreConfig } from "./memory-store.js"
+export { createWebSearchTool, type WebSearchConfig } from "./web-search.js"
+export { createWebhookTool, parseWebhookTools, type WebhookToolSpec } from "./webhook.js"

--- a/packages/control-plane/src/backends/tools/memory-query.ts
+++ b/packages/control-plane/src/backends/tools/memory-query.ts
@@ -1,0 +1,116 @@
+/**
+ * Built-in memory_query tool — queries the agent's memory store.
+ *
+ * Searches vector memory (Qdrant) for semantically similar content.
+ * Requires a Qdrant client to be injected at creation time.
+ */
+
+import type { ToolDefinition } from "../tool-executor.js"
+
+export interface MemoryQueryConfig {
+  /** Qdrant HTTP endpoint. */
+  qdrantUrl?: string
+  /** Qdrant API key. */
+  qdrantApiKey?: string
+  /** Collection name to query. */
+  collection?: string
+  /** Maximum results to return. */
+  maxResults?: number
+}
+
+const DEFAULT_COLLECTION = "agent_memories"
+const DEFAULT_MAX_RESULTS = 10
+
+export function createMemoryQueryTool(config?: MemoryQueryConfig): ToolDefinition {
+  const qdrantUrl = config?.qdrantUrl ?? process.env.QDRANT_URL ?? "http://localhost:6333"
+  const qdrantApiKey = config?.qdrantApiKey ?? process.env.QDRANT_API_KEY
+  const collection = config?.collection ?? DEFAULT_COLLECTION
+  const maxResults = config?.maxResults ?? DEFAULT_MAX_RESULTS
+
+  return {
+    name: "memory_query",
+    description:
+      "Search the agent's memory store for relevant past interactions, knowledge, and context. Returns semantically similar memories.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Natural language search query" },
+        limit: {
+          type: "number",
+          description: "Maximum number of memories to return (default 10)",
+        },
+        filter: {
+          type: "object",
+          description: "Optional metadata filter (e.g. { agentId: '...' })",
+        },
+      },
+      required: ["query"],
+    },
+    execute: async (input) => {
+      const query = typeof input.query === "string" ? input.query : String(input.query)
+      const limit = Math.min(typeof input.limit === "number" ? input.limit : maxResults, 50)
+      const filter =
+        typeof input.filter === "object" && input.filter !== null
+          ? (input.filter as Record<string, unknown>)
+          : undefined
+
+      const scrollBody: Record<string, unknown> = {
+        limit,
+        with_payload: true,
+        filter: filter
+          ? {
+              must: Object.entries(filter).map(([key, value]) => ({
+                key,
+                match: { value },
+              })),
+            }
+          : undefined,
+      }
+
+      // Use scroll with filter if no embedding service is available,
+      // otherwise use search with query vector. For simplicity, we use
+      // the Qdrant scroll endpoint with payload filtering.
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      }
+      if (qdrantApiKey) {
+        headers["api-key"] = qdrantApiKey
+      }
+
+      const url = `${qdrantUrl}/collections/${encodeURIComponent(collection)}/points/scroll`
+
+      const response = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(scrollBody),
+        signal: AbortSignal.timeout(10_000),
+      })
+
+      if (!response.ok) {
+        return JSON.stringify({
+          error: `Memory query failed: ${response.status} ${response.statusText}`,
+          query,
+        })
+      }
+
+      const data = (await response.json()) as Record<string, unknown>
+      const result = data.result as Record<string, unknown> | undefined
+      const points = result?.points
+
+      if (!Array.isArray(points)) {
+        return JSON.stringify({ memories: [], query })
+      }
+
+      const memories = points.map((p: Record<string, unknown>) => {
+        const payload = p.payload as Record<string, unknown> | undefined
+        return {
+          id: p.id,
+          content: payload?.content ?? payload?.text ?? "",
+          metadata: payload?.metadata ?? {},
+        }
+      })
+
+      return JSON.stringify({ memories, query, count: memories.length })
+    },
+  }
+}

--- a/packages/control-plane/src/backends/tools/memory-store.ts
+++ b/packages/control-plane/src/backends/tools/memory-store.ts
@@ -1,0 +1,102 @@
+/**
+ * Built-in memory_store tool — stores content in the agent's memory.
+ *
+ * Writes a new memory point to Qdrant with payload metadata.
+ * The vector embedding is left as a zero vector (to be updated by the
+ * memory extraction pipeline or an embedding service).
+ */
+
+import { randomUUID } from "node:crypto"
+
+import type { ToolDefinition } from "../tool-executor.js"
+
+export interface MemoryStoreConfig {
+  /** Qdrant HTTP endpoint. */
+  qdrantUrl?: string
+  /** Qdrant API key. */
+  qdrantApiKey?: string
+  /** Collection name. */
+  collection?: string
+  /** Embedding vector dimension (must match collection config). */
+  vectorSize?: number
+}
+
+const DEFAULT_COLLECTION = "agent_memories"
+const DEFAULT_VECTOR_SIZE = 1536
+
+export function createMemoryStoreTool(config?: MemoryStoreConfig): ToolDefinition {
+  const qdrantUrl = config?.qdrantUrl ?? process.env.QDRANT_URL ?? "http://localhost:6333"
+  const qdrantApiKey = config?.qdrantApiKey ?? process.env.QDRANT_API_KEY
+  const collection = config?.collection ?? DEFAULT_COLLECTION
+  const vectorSize = config?.vectorSize ?? DEFAULT_VECTOR_SIZE
+
+  return {
+    name: "memory_store",
+    description:
+      "Store a piece of information in the agent's long-term memory for later retrieval. Use this to remember important facts, decisions, or context.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        content: { type: "string", description: "The text content to store in memory" },
+        metadata: {
+          type: "object",
+          description:
+            "Optional metadata tags (e.g. { topic: 'architecture', importance: 'high' })",
+        },
+      },
+      required: ["content"],
+    },
+    execute: async (input) => {
+      const content = typeof input.content === "string" ? input.content : String(input.content)
+      const metadata =
+        typeof input.metadata === "object" && input.metadata !== null
+          ? (input.metadata as Record<string, unknown>)
+          : {}
+
+      const pointId = randomUUID()
+      const now = new Date().toISOString()
+
+      const body = {
+        points: [
+          {
+            id: pointId,
+            vector: new Array(vectorSize).fill(0) as number[],
+            payload: {
+              content,
+              metadata,
+              created_at: now,
+            },
+          },
+        ],
+      }
+
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      }
+      if (qdrantApiKey) {
+        headers["api-key"] = qdrantApiKey
+      }
+
+      const url = `${qdrantUrl}/collections/${encodeURIComponent(collection)}/points?wait=true`
+
+      const response = await fetch(url, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(10_000),
+      })
+
+      if (!response.ok) {
+        return JSON.stringify({
+          error: `Memory store failed: ${response.status} ${response.statusText}`,
+        })
+      }
+
+      return JSON.stringify({
+        stored: true,
+        id: pointId,
+        content: content.slice(0, 100) + (content.length > 100 ? "..." : ""),
+      })
+    },
+  }
+}

--- a/packages/control-plane/src/backends/tools/web-search.ts
+++ b/packages/control-plane/src/backends/tools/web-search.ts
@@ -1,0 +1,88 @@
+/**
+ * Built-in web_search tool — performs web searches via HTTP.
+ *
+ * Delegates to a configurable search endpoint (defaults to Brave Search API).
+ * Requires SEARCH_API_KEY and optionally SEARCH_API_URL in the environment.
+ */
+
+import type { ToolDefinition } from "../tool-executor.js"
+
+export interface WebSearchConfig {
+  /** Base URL of the search API. Defaults to Brave Search. */
+  apiUrl?: string
+  /** API key for authentication. */
+  apiKey?: string
+  /** Maximum number of results to return. */
+  maxResults?: number
+}
+
+const DEFAULT_API_URL = "https://api.search.brave.com/res/v1/web/search"
+const DEFAULT_MAX_RESULTS = 5
+
+export function createWebSearchTool(config?: WebSearchConfig): ToolDefinition {
+  const apiUrl = config?.apiUrl ?? process.env.SEARCH_API_URL ?? DEFAULT_API_URL
+  const apiKey = config?.apiKey ?? process.env.SEARCH_API_KEY ?? ""
+  const maxResults = config?.maxResults ?? DEFAULT_MAX_RESULTS
+
+  return {
+    name: "web_search",
+    description:
+      "Search the web for information. Returns a list of relevant results with titles, URLs, and snippets.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "The search query" },
+        count: {
+          type: "number",
+          description: "Number of results to return (default 5, max 20)",
+        },
+      },
+      required: ["query"],
+    },
+    execute: async (input) => {
+      const query = typeof input.query === "string" ? input.query : String(input.query)
+      const count = Math.min(typeof input.count === "number" ? input.count : maxResults, 20)
+
+      if (!apiKey) {
+        return JSON.stringify({
+          error: "web_search is not configured: missing SEARCH_API_KEY",
+        })
+      }
+
+      const url = new URL(apiUrl)
+      url.searchParams.set("q", query)
+      url.searchParams.set("count", String(count))
+
+      const response = await fetch(url.toString(), {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          "X-Subscription-Token": apiKey,
+        },
+        signal: AbortSignal.timeout(15_000),
+      })
+
+      if (!response.ok) {
+        return JSON.stringify({
+          error: `Search API returned ${response.status}: ${response.statusText}`,
+        })
+      }
+
+      const data = (await response.json()) as Record<string, unknown>
+
+      // Extract web results from Brave Search format
+      const webResults = (data.web as Record<string, unknown> | undefined)?.results
+      if (!Array.isArray(webResults)) {
+        return JSON.stringify({ results: [], query })
+      }
+
+      const results = webResults.slice(0, count).map((r: Record<string, unknown>) => ({
+        title: r.title ?? "",
+        url: r.url ?? "",
+        description: r.description ?? "",
+      }))
+
+      return JSON.stringify({ results, query })
+    },
+  }
+}

--- a/packages/control-plane/src/backends/tools/webhook.ts
+++ b/packages/control-plane/src/backends/tools/webhook.ts
@@ -1,0 +1,121 @@
+/**
+ * Webhook Tool Factory
+ *
+ * Creates ToolDefinition instances from per-agent custom webhook
+ * configurations stored in agent.config.tools.
+ *
+ * Each webhook tool definition in the agent config has the shape:
+ *   {
+ *     name: string            — unique tool name
+ *     description: string     — description for the LLM
+ *     inputSchema: object     — JSON Schema for tool input
+ *     webhook: {
+ *       url: string           — HTTP endpoint to call
+ *       method?: string       — HTTP method (default POST)
+ *       headers?: object      — extra headers
+ *       timeout_ms?: number   — request timeout (default 30000)
+ *     }
+ *   }
+ */
+
+import type { ToolDefinition } from "../tool-executor.js"
+
+export interface WebhookToolSpec {
+  name: string
+  description: string
+  inputSchema: Record<string, unknown>
+  webhook: {
+    url: string
+    method?: string
+    headers?: Record<string, string>
+    timeout_ms?: number
+  }
+}
+
+const MAX_TIMEOUT_MS = 60_000
+const DEFAULT_TIMEOUT_MS = 30_000
+const MAX_RESPONSE_BYTES = 1_048_576 // 1 MB
+
+/**
+ * Create a ToolDefinition from a webhook tool spec.
+ * The tool sends the LLM-provided input as a JSON POST body to the
+ * configured URL and returns the response body as the tool output.
+ */
+export function createWebhookTool(spec: WebhookToolSpec): ToolDefinition {
+  const method = spec.webhook.method?.toUpperCase() ?? "POST"
+  const timeoutMs = Math.min(spec.webhook.timeout_ms ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS)
+
+  return {
+    name: spec.name,
+    description: spec.description,
+    inputSchema: spec.inputSchema,
+    execute: async (input) => {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        ...spec.webhook.headers,
+      }
+
+      const response = await fetch(spec.webhook.url, {
+        method,
+        headers,
+        body: method !== "GET" ? JSON.stringify(input) : undefined,
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+
+      if (!response.ok) {
+        return JSON.stringify({
+          error: `Webhook returned ${response.status}: ${response.statusText}`,
+          tool: spec.name,
+        })
+      }
+
+      const body = await response.text()
+      if (body.length > MAX_RESPONSE_BYTES) {
+        return body.slice(0, MAX_RESPONSE_BYTES)
+      }
+      return body
+    },
+  }
+}
+
+/**
+ * Parse the agent config and extract webhook tool specs.
+ * Expects agent.config.tools to be an array of WebhookToolSpec objects.
+ */
+export function parseWebhookTools(agentConfig: Record<string, unknown>): WebhookToolSpec[] {
+  const tools = agentConfig.tools
+  if (!Array.isArray(tools)) return []
+
+  const specs: WebhookToolSpec[] = []
+  for (const entry of tools) {
+    if (
+      typeof entry === "object" &&
+      entry !== null &&
+      typeof (entry as Record<string, unknown>).name === "string" &&
+      typeof (entry as Record<string, unknown>).description === "string" &&
+      typeof (entry as Record<string, unknown>).inputSchema === "object" &&
+      typeof (entry as Record<string, unknown>).webhook === "object" &&
+      (entry as Record<string, unknown>).webhook !== null
+    ) {
+      const e = entry as Record<string, unknown>
+      const webhook = e.webhook as Record<string, unknown>
+      if (typeof webhook.url !== "string") continue
+
+      specs.push({
+        name: e.name as string,
+        description: e.description as string,
+        inputSchema: e.inputSchema as Record<string, unknown>,
+        webhook: {
+          url: webhook.url,
+          method: typeof webhook.method === "string" ? webhook.method : undefined,
+          headers:
+            typeof webhook.headers === "object" && webhook.headers !== null
+              ? (webhook.headers as Record<string, string>)
+              : undefined,
+          timeout_ms: typeof webhook.timeout_ms === "number" ? webhook.timeout_ms : undefined,
+        },
+      })
+    }
+  }
+  return specs
+}


### PR DESCRIPTION
## Summary

Adds 4 built-in tools, a webhook tool factory, and per-agent tool registry composition. 1,420 lines added.

### Built-in Tools
- **web_search** — Brave Search API
- **memory_query** — Qdrant vector store queries
- **memory_store** — Qdrant vector store writes
- **http_request** — Arbitrary HTTP with SSRF protection (blocks localhost/internal, URL allowlists)

### Webhook Tools
- `createWebhookTool()` — creates ToolDefinition from agent config webhook spec
- `parseWebhookTools()` — parses `agent.config.tools` array

### Integration
- `createAgentToolRegistry()` — per-agent registry (built-in + webhook tools from config)
- `HttpLlmBackend.executeTask()` — accepts per-task tool registry
- `agent-execute.ts` — wired to create per-agent registries

### Tests (68 new)
All tools, webhook parsing, SSRF protection, registry composition, tool filtering

Closes #243. Depends on #242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-turn conversation history: agents now maintain context across messages with session tracking by channel.
  * Agent chat endpoint: new REST API for direct communication and message handling.
  * Agent tooling: built-in web search, HTTP requests, memory storage/query, and webhook integrations.
  * Agent configuration: customizable settings and tool definitions for agent behavior.
  * Configuration UI: dashboard components for viewing and editing agent configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->