### PR TITLE
feat(routes): add MCP server CRUD API endpoints (#282)

### DIFF
--- a/packages/control-plane/src/__tests__/mcp-server-routes.test.ts
+++ b/packages/control-plane/src/__tests__/mcp-server-routes.test.ts
@@ -1,0 +1,648 @@
+import Fastify from "fastify"
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import type { Database, McpServerStatus } from "../db/types.js"
+import type { AuthConfig } from "../middleware/types.js"
+import { mcpServerRoutes } from "../routes/mcp-servers.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEV_AUTH_CONFIG: AuthConfig = {
+  requireAuth: false,
+  apiKeys: [],
+}
+
+const TEST_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+function makeMcpServer(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TEST_UUID,
+    name: "My MCP Server",
+    slug: "my-mcp-server",
+    transport: "streamable-http",
+    connection: { url: "https://example.com/mcp", headers: { Authorization: "Bearer tok" } },
+    agent_scope: [],
+    description: "A test MCP server",
+    status: "ACTIVE" as McpServerStatus,
+    protocol_version: null,
+    server_info: null,
+    capabilities: null,
+    health_probe_interval_ms: 30000,
+    last_healthy_at: null,
+    error_message: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  }
+}
+
+function makeMcpTool(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "11111111-2222-3333-4444-555555555555",
+    mcp_server_id: TEST_UUID,
+    name: "read_file",
+    qualified_name: "my-mcp-server:read_file",
+    description: "Read a file",
+    input_schema: { type: "object", properties: { path: { type: "string" } } },
+    annotations: null,
+    status: "available",
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  }
+}
+
+/** Build a chainable mock that simulates Kysely's fluent query API. */
+function mockDb(
+  opts: {
+    servers?: Record<string, unknown>[]
+    tools?: Record<string, unknown>[]
+    insertedServer?: Record<string, unknown>
+    updatedServer?: Record<string, unknown> | null
+    insertError?: Error
+  } = {},
+) {
+  const {
+    servers = [makeMcpServer()],
+    tools = [],
+    insertedServer = makeMcpServer(),
+    updatedServer = makeMcpServer(),
+    insertError,
+  } = opts
+
+  function selectChain(rows: Record<string, unknown>[]) {
+    const executeTakeFirst = vi.fn().mockResolvedValue(rows[0] ?? null)
+    const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(rows[0] ?? {})
+    const execute = vi.fn().mockResolvedValue(rows)
+    const terminal = { execute, executeTakeFirst, executeTakeFirstOrThrow }
+    const offset = vi.fn().mockReturnValue(terminal)
+    const limit = vi.fn().mockReturnValue({ ...terminal, offset })
+    const orderBy = vi.fn().mockReturnValue({ ...terminal, limit, offset })
+    const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+    whereFn.mockReturnValue({
+      where: whereFn,
+      orderBy,
+      limit,
+      offset,
+      ...terminal,
+    })
+    const selectAll = vi
+      .fn()
+      .mockReturnValue({ where: whereFn, orderBy, limit, offset, ...terminal })
+    const countResult = { total: rows.length }
+    const selectTerminal = {
+      executeTakeFirst,
+      executeTakeFirstOrThrow: vi.fn().mockResolvedValue(countResult),
+      execute,
+    }
+    const selectWhereFn: ReturnType<typeof vi.fn> = vi.fn()
+    selectWhereFn.mockReturnValue({
+      where: selectWhereFn,
+      ...selectTerminal,
+    })
+    const select = vi.fn().mockReturnValue({ where: selectWhereFn, ...selectTerminal })
+    return { selectAll, select }
+  }
+
+  function insertChain(row: Record<string, unknown>, error?: Error) {
+    const executeTakeFirstOrThrow = error
+      ? vi.fn().mockRejectedValue(error)
+      : vi.fn().mockResolvedValue(row)
+    const returningAll = vi.fn().mockReturnValue({ executeTakeFirstOrThrow })
+    const values = vi.fn().mockReturnValue({ returningAll })
+    return { values }
+  }
+
+  function updateChain(row: Record<string, unknown> | null) {
+    const executeTakeFirst = vi.fn().mockResolvedValue(row)
+    const execute = vi.fn().mockResolvedValue(row ? [row] : [])
+    const returningAll = vi.fn().mockReturnValue({ executeTakeFirst })
+    const where = vi.fn().mockReturnValue({
+      returningAll,
+      execute,
+      where: vi.fn().mockReturnValue({ returningAll, execute }),
+    })
+    const set = vi.fn().mockReturnValue({ where })
+    return { set }
+  }
+
+  function deleteChain(row: Record<string, unknown> | null) {
+    const executeTakeFirst = vi.fn().mockResolvedValue(row)
+    const returningAll = vi.fn().mockReturnValue({ executeTakeFirst })
+    const where = vi.fn().mockReturnValue({ returningAll })
+    return { where }
+  }
+
+  return {
+    selectFrom: vi.fn().mockImplementation((table: string) => {
+      if (table === "mcp_server") return selectChain(servers)
+      if (table === "mcp_server_tool") return selectChain(tools)
+      return selectChain([])
+    }),
+    insertInto: vi.fn().mockImplementation((table: string) => {
+      if (table === "mcp_server") return insertChain(insertedServer, insertError)
+      return insertChain({})
+    }),
+    updateTable: vi.fn().mockImplementation((table: string) => {
+      if (table === "mcp_server") return updateChain(updatedServer)
+      return updateChain(null)
+    }),
+    deleteFrom: vi.fn().mockImplementation((table: string) => {
+      if (table === "mcp_server") return deleteChain(servers[0] ?? null)
+      return deleteChain(null)
+    }),
+    fn: {
+      countAll: () => ({
+        as: () => "count(*) as total",
+      }),
+    },
+  } as unknown as Kysely<Database>
+}
+
+async function buildTestApp(dbOpts: Parameters<typeof mockDb>[0] = {}) {
+  const app = Fastify({ logger: false })
+  const db = mockDb(dbOpts)
+
+  await app.register(mcpServerRoutes({ db, authConfig: DEV_AUTH_CONFIG }))
+
+  return { app, db }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /mcp-servers
+// ---------------------------------------------------------------------------
+
+describe("POST /mcp-servers", () => {
+  it("creates an MCP server", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/mcp-servers",
+      payload: {
+        name: "My MCP Server",
+        transport: "streamable-http",
+        connection: { url: "https://example.com/mcp" },
+      },
+    })
+
+    expect(res.statusCode).toBe(201)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.name).toBe("My MCP Server")
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.slug).toBe("my-mcp-server")
+  })
+
+  it("auto-generates slug from name (kebab-case)", async () => {
+    const { app, db } = await buildTestApp()
+
+    await app.inject({
+      method: "POST",
+      url: "/mcp-servers",
+      payload: {
+        name: "My Cool MCP Server!",
+        transport: "streamable-http",
+        connection: { url: "https://example.com" },
+      },
+    })
+
+    // Verify the slug passed to the insert
+    const insertCall = (db.insertInto as ReturnType<typeof vi.fn>).mock.results[0]
+    expect(insertCall).toBeDefined()
+  })
+
+  it("validates required fields", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/mcp-servers",
+      payload: { description: "Missing name and transport" },
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+
+  it("validates transport enum", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/mcp-servers",
+      payload: {
+        name: "Bad Transport",
+        transport: "invalid-transport",
+        connection: { url: "https://example.com" },
+      },
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+
+  it("returns 409 on duplicate slug", async () => {
+    const { app } = await buildTestApp({
+      insertError: new Error(
+        'duplicate key value violates unique constraint "mcp_server_slug_key"',
+      ),
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/mcp-servers",
+      payload: {
+        name: "My MCP Server",
+        transport: "streamable-http",
+        connection: { url: "https://example.com" },
+      },
+    })
+
+    expect(res.statusCode).toBe(409)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.error).toBe("conflict")
+  })
+
+  it("accepts optional slug override", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/mcp-servers",
+      payload: {
+        name: "My Server",
+        slug: "custom-slug",
+        transport: "stdio",
+        connection: { command: "node", args: ["server.js"] },
+      },
+    })
+
+    expect(res.statusCode).toBe(201)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: GET /mcp-servers
+// ---------------------------------------------------------------------------
+
+describe("GET /mcp-servers", () => {
+  it("returns list of MCP servers", async () => {
+    const { app } = await buildTestApp({
+      servers: [makeMcpServer(), makeMcpServer({ id: "other-id", name: "Other" })],
+    })
+
+    const res = await app.inject({ method: "GET", url: "/mcp-servers" })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.servers).toBeDefined()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.count).toBeGreaterThanOrEqual(1)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.pagination).toBeDefined()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.pagination.total).toBeGreaterThanOrEqual(1)
+  })
+
+  it("accepts status filter", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({ method: "GET", url: "/mcp-servers?status=ACTIVE" })
+
+    expect(res.statusCode).toBe(200)
+  })
+
+  it("accepts pagination params", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/mcp-servers?limit=10&offset=5",
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.pagination.limit).toBe(10)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.pagination.offset).toBe(5)
+  })
+
+  it("rejects invalid status filter", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({ method: "GET", url: "/mcp-servers?status=INVALID" })
+
+    expect(res.statusCode).toBe(400)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: GET /mcp-servers/:id
+// ---------------------------------------------------------------------------
+
+describe("GET /mcp-servers/:id", () => {
+  it("returns MCP server with tools", async () => {
+    const { app } = await buildTestApp({
+      tools: [makeMcpTool()],
+    })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/mcp-servers/${TEST_UUID}`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.name).toBe("My MCP Server")
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.tools).toBeDefined()
+  })
+
+  it("returns 404 for nonexistent server", async () => {
+    const { app } = await buildTestApp({ servers: [] })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/mcp-servers/${TEST_UUID}`,
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: PUT /mcp-servers/:id
+// ---------------------------------------------------------------------------
+
+describe("PUT /mcp-servers/:id", () => {
+  it("updates an MCP server", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/mcp-servers/${TEST_UUID}`,
+      payload: { name: "Updated Server" },
+    })
+
+    expect(res.statusCode).toBe(200)
+  })
+
+  it("returns 400 with empty body", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/mcp-servers/${TEST_UUID}`,
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+
+  it("returns 404 for nonexistent server", async () => {
+    const { app } = await buildTestApp({ updatedServer: null })
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/mcp-servers/${TEST_UUID}`,
+      payload: { name: "Updated" },
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+
+  it("validates status enum on update", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/mcp-servers/${TEST_UUID}`,
+      payload: { status: "INVALID_STATUS" },
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+
+  it("allows updating connection", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/mcp-servers/${TEST_UUID}`,
+      payload: { connection: { url: "https://new-url.com/mcp" } },
+    })
+
+    expect(res.statusCode).toBe(200)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: DELETE /mcp-servers/:id
+// ---------------------------------------------------------------------------
+
+describe("DELETE /mcp-servers/:id", () => {
+  it("deletes an MCP server", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/mcp-servers/${TEST_UUID}`,
+    })
+
+    expect(res.statusCode).toBe(200)
+  })
+
+  it("returns 404 for nonexistent server", async () => {
+    const { app } = await buildTestApp({ servers: [] })
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/mcp-servers/${TEST_UUID}`,
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+
+  it("sets status to DISABLED before deleting", async () => {
+    const { app, db } = await buildTestApp()
+
+    await app.inject({
+      method: "DELETE",
+      url: `/mcp-servers/${TEST_UUID}`,
+    })
+
+    // updateTable should have been called (for the DISABLED status set)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(db.updateTable).toHaveBeenCalledWith("mcp_server")
+    // deleteFrom should have been called
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(db.deleteFrom).toHaveBeenCalledWith("mcp_server")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: POST /mcp-servers/:id/refresh
+// ---------------------------------------------------------------------------
+
+describe("POST /mcp-servers/:id/refresh", () => {
+  it("resets server status to PENDING", async () => {
+    const updatedServer = makeMcpServer({ status: "PENDING", error_message: null })
+    const { app } = await buildTestApp({ updatedServer })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/mcp-servers/${TEST_UUID}/refresh`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.status).toBe("PENDING")
+  })
+
+  it("returns 404 for nonexistent server", async () => {
+    const { app } = await buildTestApp({ updatedServer: null })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/mcp-servers/${TEST_UUID}/refresh`,
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: Encryption of connection headers
+// ---------------------------------------------------------------------------
+
+describe("connection header encryption", () => {
+  async function buildEncryptedApp(dbOpts: Parameters<typeof mockDb>[0] = {}) {
+    const app = Fastify({ logger: false })
+    const db = mockDb(dbOpts)
+
+    await app.register(
+      mcpServerRoutes({
+        db,
+        authConfig: DEV_AUTH_CONFIG,
+        connectionEncryptionKey: "test-encryption-passphrase",
+      }),
+    )
+
+    return { app, db }
+  }
+
+  it("encrypts headers on create and returns decrypted in response", async () => {
+    // The mock returns whatever insertedServer we provide, so the encryption
+    // flow is tested through the route logic processing the body
+    const serverWithEncHeaders = makeMcpServer({
+      connection: {
+        url: "https://example.com/mcp",
+        // Simulate encrypted form (in reality the route would have encrypted)
+        headers: { Authorization: "Bearer secret" },
+      },
+    })
+    const { app } = await buildEncryptedApp({ insertedServer: serverWithEncHeaders })
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/mcp-servers",
+      payload: {
+        name: "Encrypted Server",
+        transport: "streamable-http",
+        connection: { url: "https://example.com/mcp", headers: { Authorization: "Bearer secret" } },
+      },
+    })
+
+    expect(res.statusCode).toBe(201)
+  })
+
+  it("works without encryption key configured", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/mcp-servers",
+      payload: {
+        name: "Unencrypted Server",
+        transport: "streamable-http",
+        connection: { url: "https://example.com/mcp", headers: { Authorization: "Bearer tok" } },
+      },
+    })
+
+    expect(res.statusCode).toBe(201)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: Auth middleware (requireAuth + requireOperator)
+// ---------------------------------------------------------------------------
+
+describe("auth middleware", () => {
+  async function buildAuthApp() {
+    const app = Fastify({ logger: false })
+    const db = mockDb()
+    const authConfig: AuthConfig = {
+      requireAuth: true,
+      apiKeys: [
+        {
+          keyHash: "", // Not used for plain-text match
+          userId: "user-1",
+          roles: ["operator"],
+          label: "operator-key",
+        },
+        {
+          keyHash: "",
+          userId: "user-2",
+          roles: ["viewer"],
+          label: "viewer-key",
+        },
+      ],
+    }
+
+    await app.register(mcpServerRoutes({ db, authConfig }))
+
+    return { app }
+  }
+
+  it("returns 401 on mutating endpoints without auth", async () => {
+    const { app } = await buildAuthApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/mcp-servers",
+      payload: {
+        name: "No Auth",
+        transport: "streamable-http",
+        connection: { url: "https://example.com" },
+      },
+    })
+
+    expect(res.statusCode).toBe(401)
+  })
+
+  it("allows unauthenticated read on GET /mcp-servers", async () => {
+    const { app } = await buildAuthApp()
+
+    // GET endpoints do not require auth
+    const res = await app.inject({
+      method: "GET",
+      url: "/mcp-servers",
+    })
+
+    // Even with requireAuth=true, GET does not have preHandler so it should work
+    expect(res.statusCode).toBe(200)
+  })
+})

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -31,6 +31,7 @@ import { credentialRoutes } from "./routes/credentials.js"
 import { dashboardRoutes } from "./routes/dashboard.js"
 import { feedbackRoutes } from "./routes/feedback.js"
 import { healthRoutes } from "./routes/health.js"
+import { mcpServerRoutes } from "./routes/mcp-servers.js"
 import { observationRoutes } from "./routes/observation.js"
 import { sessionRoutes } from "./routes/sessions.js"
 import { streamRoutes } from "./routes/stream.js"
@@ -178,6 +179,16 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
       service: agentChannelService,
       authConfig,
       sessionService,
+    }),
+  )
+
+  // Register MCP server CRUD routes
+  await app.register(
+    mcpServerRoutes({
+      db,
+      authConfig,
+      sessionService,
+      connectionEncryptionKey: process.env.CREDENTIAL_MASTER_KEY,
     }),
   )
 

--- a/packages/control-plane/src/routes/mcp-servers.ts
+++ b/packages/control-plane/src/routes/mcp-servers.ts
@@ -1,0 +1,455 @@
+/**
+ * MCP Server CRUD Routes
+ *
+ * POST   /mcp-servers              — Create MCP server
+ * GET    /mcp-servers              — List MCP servers (supports ?status filter + pagination)
+ * GET    /mcp-servers/:id          — Get MCP server by ID (includes tools)
+ * PUT    /mcp-servers/:id          — Update MCP server
+ * DELETE /mcp-servers/:id          — Delete MCP server (hard delete, cascades tools)
+ * POST   /mcp-servers/:id/refresh  — Trigger re-probe (reset to PENDING)
+ */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
+import type { Kysely } from "kysely"
+
+import {
+  decrypt,
+  deriveMasterKey,
+  deserializeEncrypted,
+  encrypt,
+  serializeEncrypted,
+} from "../auth/credential-encryption.js"
+import type { SessionService } from "../auth/session-service.js"
+import type { Database, McpServerStatus, McpTransport } from "../db/types.js"
+import {
+  type AuthMiddlewareOptions,
+  createRequireAuth,
+  createRequireRole,
+  type PreHandler,
+} from "../middleware/auth.js"
+import type { AuthConfig } from "../middleware/types.js"
+
+// ---------------------------------------------------------------------------
+// Route types
+// ---------------------------------------------------------------------------
+
+interface McpServerParams {
+  id: string
+}
+
+interface CreateMcpServerBody {
+  name: string
+  slug?: string
+  transport: McpTransport
+  connection: Record<string, unknown>
+  agent_scope?: string[]
+  description?: string
+  health_probe_interval_ms?: number
+}
+
+interface UpdateMcpServerBody {
+  name?: string
+  transport?: McpTransport
+  connection?: Record<string, unknown>
+  agent_scope?: string[]
+  description?: string | null
+  status?: McpServerStatus
+  health_probe_interval_ms?: number
+}
+
+interface ListMcpServersQuery {
+  status?: McpServerStatus
+  limit?: number
+  offset?: number
+}
+
+// ---------------------------------------------------------------------------
+// Connection header encryption helpers
+// ---------------------------------------------------------------------------
+
+function encryptConnectionHeaders(
+  connection: Record<string, unknown>,
+  key: Buffer,
+): Record<string, unknown> {
+  const stored = { ...connection }
+  if (stored.headers && typeof stored.headers === "object") {
+    const encrypted = encrypt(JSON.stringify(stored.headers), key)
+    stored.headers_enc = serializeEncrypted(encrypted)
+    delete stored.headers
+  }
+  return stored
+}
+
+function decryptConnectionHeaders(
+  connection: Record<string, unknown>,
+  key: Buffer,
+): Record<string, unknown> {
+  const out = { ...connection }
+  if (typeof out.headers_enc === "string") {
+    const payload = deserializeEncrypted(out.headers_enc)
+    out.headers = JSON.parse(decrypt(payload, key)) as Record<string, unknown>
+    delete out.headers_enc
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+export interface McpServerRouteDeps {
+  db: Kysely<Database>
+  authConfig: AuthConfig
+  sessionService?: SessionService
+  /** Passphrase used to derive the encryption key for connection headers. */
+  connectionEncryptionKey?: string
+}
+
+export function mcpServerRoutes(deps: McpServerRouteDeps) {
+  const { db, authConfig, sessionService, connectionEncryptionKey } = deps
+
+  const encryptionKey = connectionEncryptionKey
+    ? deriveMasterKey(connectionEncryptionKey)
+    : undefined
+
+  const authOpts: AuthMiddlewareOptions = { config: authConfig, sessionService }
+  const requireAuth: PreHandler = createRequireAuth(authOpts)
+  const requireOperator: PreHandler = createRequireRole("operator")
+
+  return function register(app: FastifyInstance): void {
+    // -----------------------------------------------------------------
+    // POST /mcp-servers — Create MCP server
+    // -----------------------------------------------------------------
+    app.post<{ Body: CreateMcpServerBody }>(
+      "/mcp-servers",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          body: {
+            type: "object",
+            properties: {
+              name: { type: "string", minLength: 1, maxLength: 255 },
+              slug: { type: "string", minLength: 1, maxLength: 255, pattern: "^[a-z0-9-]+$" },
+              transport: { type: "string", enum: ["streamable-http", "stdio"] },
+              connection: { type: "object" },
+              agent_scope: { type: "array", items: { type: "string" } },
+              description: { type: "string", maxLength: 2000 },
+              health_probe_interval_ms: { type: "number", minimum: 1000, maximum: 3600000 },
+            },
+            required: ["name", "transport", "connection"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Body: CreateMcpServerBody }>, reply: FastifyReply) => {
+        const body = request.body
+        const slug =
+          body.slug ??
+          body.name
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/(^-|-$)/g, "")
+
+        const connectionToStore = encryptionKey
+          ? encryptConnectionHeaders(body.connection, encryptionKey)
+          : body.connection
+
+        try {
+          const server = await db
+            .insertInto("mcp_server")
+            .values({
+              name: body.name,
+              slug,
+              transport: body.transport,
+              connection: connectionToStore,
+              agent_scope: body.agent_scope ?? [],
+              description: body.description ?? null,
+              health_probe_interval_ms: body.health_probe_interval_ms ?? 30000,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+          const result = encryptionKey
+            ? { ...server, connection: decryptConnectionHeaders(server.connection, encryptionKey) }
+            : server
+
+          return reply.status(201).send(result)
+        } catch (err: unknown) {
+          if (
+            err instanceof Error &&
+            err.message.includes("unique") &&
+            err.message.includes("slug")
+          ) {
+            return reply.status(409).send({
+              error: "conflict",
+              message: `Slug '${slug}' is already in use`,
+            })
+          }
+          throw err
+        }
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // GET /mcp-servers — List MCP servers
+    // -----------------------------------------------------------------
+    app.get<{ Querystring: ListMcpServersQuery }>(
+      "/mcp-servers",
+      {
+        schema: {
+          querystring: {
+            type: "object",
+            properties: {
+              status: {
+                type: "string",
+                enum: ["PENDING", "ACTIVE", "DEGRADED", "ERROR", "DISABLED"],
+              },
+              limit: { type: "number", minimum: 1, maximum: 100 },
+              offset: { type: "number", minimum: 0 },
+            },
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Querystring: ListMcpServersQuery }>,
+        reply: FastifyReply,
+      ) => {
+        const { status, limit = 50, offset = 0 } = request.query
+
+        let query = db.selectFrom("mcp_server").selectAll()
+        let countQuery = db.selectFrom("mcp_server").select(db.fn.countAll<number>().as("total"))
+
+        if (status) {
+          query = query.where("status", "=", status)
+          countQuery = countQuery.where("status", "=", status)
+        }
+
+        const [servers, countResult] = await Promise.all([
+          query.orderBy("created_at", "desc").limit(limit).offset(offset).execute(),
+          countQuery.executeTakeFirstOrThrow(),
+        ])
+
+        const total = Number(countResult.total)
+
+        const items = encryptionKey
+          ? servers.map((s) => ({
+              ...s,
+              connection: decryptConnectionHeaders(s.connection, encryptionKey),
+            }))
+          : servers
+
+        return reply.status(200).send({
+          servers: items,
+          count: items.length,
+          pagination: {
+            total,
+            limit,
+            offset,
+            hasMore: offset + items.length < total,
+          },
+        })
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // GET /mcp-servers/:id — Get MCP server by ID (with tools)
+    // -----------------------------------------------------------------
+    app.get<{ Params: McpServerParams }>(
+      "/mcp-servers/:id",
+      {
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              id: { type: "string", format: "uuid" },
+            },
+            required: ["id"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: McpServerParams }>, reply: FastifyReply) => {
+        const server = await db
+          .selectFrom("mcp_server")
+          .selectAll()
+          .where("id", "=", request.params.id)
+          .executeTakeFirst()
+
+        if (!server) {
+          return reply.status(404).send({ error: "not_found", message: "MCP server not found" })
+        }
+
+        const tools = await db
+          .selectFrom("mcp_server_tool")
+          .selectAll()
+          .where("mcp_server_id", "=", server.id)
+          .orderBy("name", "asc")
+          .execute()
+
+        const connection = encryptionKey
+          ? decryptConnectionHeaders(server.connection, encryptionKey)
+          : server.connection
+
+        return reply.status(200).send({ ...server, connection, tools })
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // PUT /mcp-servers/:id — Update MCP server
+    // -----------------------------------------------------------------
+    app.put<{ Params: McpServerParams; Body: UpdateMcpServerBody }>(
+      "/mcp-servers/:id",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              id: { type: "string", format: "uuid" },
+            },
+            required: ["id"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              name: { type: "string", minLength: 1, maxLength: 255 },
+              transport: { type: "string", enum: ["streamable-http", "stdio"] },
+              connection: { type: "object" },
+              agent_scope: { type: "array", items: { type: "string" } },
+              description: { type: ["string", "null"], maxLength: 2000 },
+              status: {
+                type: "string",
+                enum: ["PENDING", "ACTIVE", "DEGRADED", "ERROR", "DISABLED"],
+              },
+              health_probe_interval_ms: { type: "number", minimum: 1000, maximum: 3600000 },
+            },
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: McpServerParams; Body: UpdateMcpServerBody }>,
+        reply: FastifyReply,
+      ) => {
+        const { id } = request.params
+        const body = request.body
+
+        const updateValues: Record<string, unknown> = {}
+        if (body.name !== undefined) updateValues.name = body.name
+        if (body.transport !== undefined) updateValues.transport = body.transport
+        if (body.connection !== undefined) {
+          updateValues.connection = encryptionKey
+            ? encryptConnectionHeaders(body.connection, encryptionKey)
+            : body.connection
+        }
+        if (body.agent_scope !== undefined) updateValues.agent_scope = body.agent_scope
+        if (body.description !== undefined) updateValues.description = body.description
+        if (body.status !== undefined) updateValues.status = body.status
+        if (body.health_probe_interval_ms !== undefined)
+          updateValues.health_probe_interval_ms = body.health_probe_interval_ms
+
+        if (Object.keys(updateValues).length === 0) {
+          return reply.status(400).send({ error: "bad_request", message: "No fields to update" })
+        }
+
+        updateValues.updated_at = new Date()
+
+        const updated = await db
+          .updateTable("mcp_server")
+          .set(updateValues)
+          .where("id", "=", id)
+          .returningAll()
+          .executeTakeFirst()
+
+        if (!updated) {
+          return reply.status(404).send({ error: "not_found", message: "MCP server not found" })
+        }
+
+        const result = encryptionKey
+          ? { ...updated, connection: decryptConnectionHeaders(updated.connection, encryptionKey) }
+          : updated
+
+        return reply.status(200).send(result)
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // DELETE /mcp-servers/:id — Delete MCP server
+    // Sets status to DISABLED first for graceful client disconnect,
+    // then hard-deletes (cascades to mcp_server_tool).
+    // -----------------------------------------------------------------
+    app.delete<{ Params: McpServerParams }>(
+      "/mcp-servers/:id",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              id: { type: "string", format: "uuid" },
+            },
+            required: ["id"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: McpServerParams }>, reply: FastifyReply) => {
+        const { id } = request.params
+
+        // Set DISABLED first so any live clients can detect the status change
+        await db
+          .updateTable("mcp_server")
+          .set({ status: "DISABLED" as McpServerStatus, updated_at: new Date() })
+          .where("id", "=", id)
+          .execute()
+
+        const deleted = await db
+          .deleteFrom("mcp_server")
+          .where("id", "=", id)
+          .returningAll()
+          .executeTakeFirst()
+
+        if (!deleted) {
+          return reply.status(404).send({ error: "not_found", message: "MCP server not found" })
+        }
+
+        return reply.status(200).send(deleted)
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // POST /mcp-servers/:id/refresh — Trigger re-probe
+    // Resets status to PENDING and clears error state so the
+    // health probe picks it up on its next cycle.
+    // -----------------------------------------------------------------
+    app.post<{ Params: McpServerParams }>(
+      "/mcp-servers/:id/refresh",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              id: { type: "string", format: "uuid" },
+            },
+            required: ["id"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: McpServerParams }>, reply: FastifyReply) => {
+        const updated = await db
+          .updateTable("mcp_server")
+          .set({
+            status: "PENDING" as McpServerStatus,
+            error_message: null,
+            updated_at: new Date(),
+          })
+          .where("id", "=", request.params.id)
+          .returningAll()
+          .executeTakeFirst()
+
+        if (!updated) {
+          return reply.status(404).send({ error: "not_found", message: "MCP server not found" })
+        }
+
+        return reply.status(200).send(updated)
+      },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add MCP server CRUD route plugin (mcp-servers.ts) with 6 endpoints
- register plugin in app.ts
- add 26 unit tests for validation/auth/pagination/CRUD behavior
- implement slug generation + duplicate handling
- add optional header encryption for connection headers using credential key

## Verification
- tests: 777 passing (51 files)
- lint: clean

Closes #282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP server management endpoints: create, list, retrieve, update, delete, and refresh operations
  * Pagination and status filtering for server listings
  * Automatic slug generation and connection header encryption
  * Health probe interval configuration and re-probe triggering

* **Tests**
  * Comprehensive test suite covering MCP server route operations and authorization flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->