### PR TITLE
feat(mcp): tool router — MCP tool resolution and conflict handling

### DIFF
--- a/packages/control-plane/src/__tests__/builtin-tools.test.ts
+++ b/packages/control-plane/src/__tests__/builtin-tools.test.ts
@@ -696,8 +696,8 @@ describe("createDefaultToolRegistry — built-in tools", () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe("createAgentToolRegistry", () => {
-  it("includes all default tools when no custom tools configured", () => {
-    const registry = createAgentToolRegistry({})
+  it("includes all default tools when no custom tools configured", async () => {
+    const registry = await createAgentToolRegistry({})
     expect(registry.get("echo")).toBeDefined()
     expect(registry.get("web_search")).toBeDefined()
     expect(registry.get("memory_query")).toBeDefined()
@@ -705,8 +705,8 @@ describe("createAgentToolRegistry", () => {
     expect(registry.get("http_request")).toBeDefined()
   })
 
-  it("registers custom webhook tools from agent config", () => {
-    const registry = createAgentToolRegistry({
+  it("registers custom webhook tools from agent config", async () => {
+    const registry = await createAgentToolRegistry({
       tools: [
         {
           name: "custom_tool",
@@ -721,8 +721,8 @@ describe("createAgentToolRegistry", () => {
     expect(registry.get("custom_tool")!.description).toBe("Custom webhook tool")
   })
 
-  it("includes both default and custom tools", () => {
-    const registry = createAgentToolRegistry({
+  it("includes both default and custom tools", async () => {
+    const registry = await createAgentToolRegistry({
       tools: [
         {
           name: "agent_tool",
@@ -738,8 +738,8 @@ describe("createAgentToolRegistry", () => {
     expect(registry.get("agent_tool")).toBeDefined()
   })
 
-  it("resolves custom tools via allowed list", () => {
-    const registry = createAgentToolRegistry({
+  it("resolves custom tools via allowed list", async () => {
+    const registry = await createAgentToolRegistry({
       tools: [
         {
           name: "agent_tool",
@@ -755,8 +755,8 @@ describe("createAgentToolRegistry", () => {
     expect(resolved.map((t) => t.name)).toContain("agent_tool")
   })
 
-  it("custom tools can be denied", () => {
-    const registry = createAgentToolRegistry({
+  it("custom tools can be denied", async () => {
+    const registry = await createAgentToolRegistry({
       tools: [
         {
           name: "agent_tool",
@@ -770,5 +770,53 @@ describe("createAgentToolRegistry", () => {
     const resolved = registry.resolve(["echo", "agent_tool"], ["agent_tool"])
     expect(resolved).toHaveLength(1)
     expect(resolved[0].name).toBe("echo")
+  })
+
+  it("merges MCP tools when mcpRouter is provided", async () => {
+    const mockMcpRouter = {
+      resolveAll: vi.fn().mockResolvedValue([
+        {
+          name: "mcp:srv:read_file",
+          description: "Read a file",
+          inputSchema: { type: "object", properties: {} },
+          execute: vi.fn().mockResolvedValue("file-contents"),
+        },
+      ]),
+      resolve: vi.fn(),
+      invalidateCache: vi.fn(),
+    }
+
+    const registry = await createAgentToolRegistry(
+      {},
+      {
+        agentId: "agent-1",
+        mcpRouter: mockMcpRouter as never,
+        allowedTools: ["mcp:srv:read_file"],
+        deniedTools: [],
+      },
+    )
+
+    expect(registry.get("mcp:srv:read_file")).toBeDefined()
+    expect(mockMcpRouter.resolveAll).toHaveBeenCalledWith("agent-1", ["mcp:srv:read_file"], [])
+  })
+
+  it("skips MCP resolution when no agentId provided", async () => {
+    const mockMcpRouter = {
+      resolveAll: vi.fn(),
+      resolve: vi.fn(),
+      invalidateCache: vi.fn(),
+    }
+
+    const registry = await createAgentToolRegistry({}, { mcpRouter: mockMcpRouter as never })
+
+    expect(mockMcpRouter.resolveAll).not.toHaveBeenCalled()
+    expect(registry.get("echo")).toBeDefined()
+  })
+
+  it("skips MCP resolution when no mcpRouter provided", async () => {
+    const registry = await createAgentToolRegistry({}, { agentId: "agent-1" })
+
+    // Should still work, just no MCP tools
+    expect(registry.get("echo")).toBeDefined()
   })
 })

--- a/packages/control-plane/src/__tests__/mcp-tool-bridge.test.ts
+++ b/packages/control-plane/src/__tests__/mcp-tool-bridge.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { McpServer, McpServerTool } from "../db/types.js"
+import type { McpClientPool } from "../mcp/tool-bridge.js"
+import { createMcpToolDefinition, parseQualifiedName, qualifiedName } from "../mcp/tool-bridge.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeServer(overrides: Partial<McpServer> = {}): McpServer {
+  return {
+    id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    name: "Test Server",
+    slug: "test-server",
+    transport: "streamable-http",
+    connection: { url: "https://example.com/mcp" },
+    agent_scope: [],
+    description: "A test MCP server",
+    status: "ACTIVE",
+    protocol_version: null,
+    server_info: null,
+    capabilities: null,
+    health_probe_interval_ms: 30000,
+    last_healthy_at: null,
+    error_message: null,
+    created_at: new Date("2025-01-01"),
+    updated_at: new Date("2025-01-01"),
+    ...overrides,
+  } as McpServer
+}
+
+function makeTool(overrides: Partial<McpServerTool> = {}): McpServerTool {
+  return {
+    id: "11111111-2222-3333-4444-555555555555",
+    mcp_server_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    name: "read_file",
+    qualified_name: "mcp:test-server:read_file",
+    description: "Read a file from the filesystem",
+    input_schema: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    },
+    annotations: null,
+    status: "available",
+    created_at: new Date("2025-01-01"),
+    updated_at: new Date("2025-01-01"),
+    ...overrides,
+  } as McpServerTool
+}
+
+function mockPool(): McpClientPool {
+  return {
+    callTool: vi.fn().mockResolvedValue("tool-result"),
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// qualifiedName
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("qualifiedName", () => {
+  it("builds mcp:<slug>:<name> format", () => {
+    expect(qualifiedName("my-server", "read_file")).toBe("mcp:my-server:read_file")
+  })
+
+  it("handles slugs with hyphens", () => {
+    expect(qualifiedName("my-cool-server", "do_stuff")).toBe("mcp:my-cool-server:do_stuff")
+  })
+
+  it("handles underscored tool names", () => {
+    expect(qualifiedName("s", "my_long_tool_name")).toBe("mcp:s:my_long_tool_name")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// parseQualifiedName
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("parseQualifiedName", () => {
+  it("parses a valid qualified name", () => {
+    const result = parseQualifiedName("mcp:my-server:read_file")
+    expect(result).toEqual({ serverSlug: "my-server", toolName: "read_file" })
+  })
+
+  it("returns null for non-mcp prefixed names", () => {
+    expect(parseQualifiedName("echo")).toBeNull()
+    expect(parseQualifiedName("web_search")).toBeNull()
+    expect(parseQualifiedName("custom_tool")).toBeNull()
+  })
+
+  it("returns null for names with too few parts", () => {
+    expect(parseQualifiedName("mcp:only-one")).toBeNull()
+  })
+
+  it("returns null for names with too many parts", () => {
+    expect(parseQualifiedName("mcp:server:tool:extra")).toBeNull()
+  })
+
+  it("returns null for empty slug or tool name", () => {
+    expect(parseQualifiedName("mcp::read_file")).toBeNull()
+    expect(parseQualifiedName("mcp:server:")).toBeNull()
+  })
+
+  it("returns null for prefix-only", () => {
+    expect(parseQualifiedName("mcp:")).toBeNull()
+  })
+
+  it("is case-sensitive", () => {
+    expect(parseQualifiedName("MCP:server:tool")).toBeNull()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// createMcpToolDefinition
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("createMcpToolDefinition", () => {
+  it("creates a ToolDefinition with qualified name", () => {
+    const pool = mockPool()
+    const server = makeServer({ slug: "my-srv" })
+    const tool = makeTool({ name: "read_file" })
+
+    const def = createMcpToolDefinition(pool, server, tool)
+
+    expect(def.name).toBe("mcp:my-srv:read_file")
+  })
+
+  it("uses tool description when available", () => {
+    const pool = mockPool()
+    const server = makeServer()
+    const tool = makeTool({ description: "Custom description" })
+
+    const def = createMcpToolDefinition(pool, server, tool)
+
+    expect(def.description).toBe("Custom description")
+  })
+
+  it("falls back to auto-generated description when null", () => {
+    const pool = mockPool()
+    const server = makeServer({ name: "Cool Server" })
+    const tool = makeTool({ name: "write_file", description: null })
+
+    const def = createMcpToolDefinition(pool, server, tool)
+
+    expect(def.description).toBe("MCP tool write_file from Cool Server")
+  })
+
+  it("uses the tool input_schema", () => {
+    const pool = mockPool()
+    const schema = {
+      type: "object",
+      properties: { path: { type: "string" }, content: { type: "string" } },
+      required: ["path"],
+    }
+    const tool = makeTool({ input_schema: schema })
+
+    const def = createMcpToolDefinition(pool, makeServer(), tool)
+
+    expect(def.inputSchema).toEqual(schema)
+  })
+
+  it("delegates execution to client pool with correct args", async () => {
+    const callTool = vi.fn().mockResolvedValue("tool-result")
+    const pool: McpClientPool = { callTool }
+    const server = makeServer({ slug: "srv-1" })
+    const tool = makeTool({ name: "search" })
+
+    const def = createMcpToolDefinition(pool, server, tool)
+    const result = await def.execute({ query: "hello" })
+
+    expect(callTool).toHaveBeenCalledWith("srv-1", "search", { query: "hello" })
+    expect(result).toBe("tool-result")
+  })
+
+  it("propagates errors from pool.callTool", async () => {
+    const pool: McpClientPool = {
+      callTool: vi.fn().mockRejectedValue(new Error("connection refused")),
+    }
+    const def = createMcpToolDefinition(pool, makeServer(), makeTool())
+
+    await expect(def.execute({})).rejects.toThrow("connection refused")
+  })
+})

--- a/packages/control-plane/src/__tests__/mcp-tool-router.test.ts
+++ b/packages/control-plane/src/__tests__/mcp-tool-router.test.ts
@@ -1,0 +1,749 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { McpClientPool } from "../mcp/tool-bridge.js"
+import { McpToolRouter, type McpToolRouterDeps } from "../mcp/tool-router.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const AGENT_ID = "agent-111"
+
+/** Minimal mock of a McpClientPool. Returns the pool and its mock fn. */
+function mockPool(): McpClientPool & { _callTool: ReturnType<typeof vi.fn> } {
+  const callTool = vi.fn().mockResolvedValue("mcp-result")
+  return { callTool, _callTool: callTool }
+}
+
+/** Build a fake joined row as returned by the Kysely queries in McpToolRouter. */
+function makeRow(
+  overrides: {
+    toolName?: string
+    serverSlug?: string
+    serverId?: string
+    serverCreatedAt?: Date
+    agentScope?: string[]
+    serverStatus?: string
+    toolStatus?: string
+    description?: string | null
+    inputSchema?: Record<string, unknown>
+  } = {},
+) {
+  const {
+    toolName = "read_file",
+    serverSlug = "server-a",
+    serverId = "aaaaaaaa-0000-0000-0000-000000000001",
+    serverCreatedAt = new Date("2025-01-01T00:00:00Z"),
+    agentScope = [],
+    serverStatus = "ACTIVE",
+    toolStatus = "available",
+    description = "A tool",
+    inputSchema = { type: "object", properties: {} },
+  } = overrides
+
+  return {
+    // mcp_server_tool columns
+    id: `tool-${serverId}-${toolName}`,
+    mcp_server_id: serverId,
+    name: toolName,
+    qualified_name: `mcp:${serverSlug}:${toolName}`,
+    description,
+    input_schema: inputSchema,
+    annotations: null,
+    status: toolStatus,
+    created_at: serverCreatedAt,
+    updated_at: serverCreatedAt,
+    // mcp_server columns (prefixed)
+    server_id: serverId,
+    server_name: `Server ${serverSlug}`,
+    server_slug: serverSlug,
+    server_transport: "streamable-http",
+    server_connection: { url: "https://example.com/mcp" },
+    server_agent_scope: agentScope,
+    server_status: serverStatus,
+    server_description: null,
+    server_protocol_version: null,
+    server_server_info: null,
+    server_capabilities: null,
+    server_health_probe_interval_ms: 30000,
+    server_last_healthy_at: null,
+    server_error_message: null,
+    server_created_at: serverCreatedAt,
+    server_updated_at: serverCreatedAt,
+  }
+}
+
+/**
+ * Create a mock Kysely db that returns specified rows for any query.
+ *
+ * The mock builds a fluent chain: selectFrom → innerJoin → selectAll → select
+ * → where → orderBy → execute / executeTakeFirst
+ */
+function mockDb(rows: ReturnType<typeof makeRow>[]) {
+  const execute = vi.fn().mockResolvedValue(rows)
+  const executeTakeFirst = vi.fn().mockResolvedValue(rows[0] ?? undefined)
+
+  const orderBy = vi.fn().mockReturnValue({ execute, executeTakeFirst })
+  const where = vi.fn()
+
+  // Each .where() call chains to another .where() or terminal
+  where.mockReturnValue({
+    where,
+    orderBy,
+    execute,
+    executeTakeFirst,
+  })
+
+  const selectFn = vi.fn().mockReturnValue({
+    where,
+    orderBy,
+    execute,
+    executeTakeFirst,
+  })
+  const selectAll = vi.fn().mockReturnValue({
+    select: selectFn,
+    where,
+    orderBy,
+    execute,
+    executeTakeFirst,
+  })
+  const innerJoin = vi.fn().mockReturnValue({
+    selectAll,
+    select: selectFn,
+    where,
+    orderBy,
+    execute,
+    executeTakeFirst,
+  })
+  const selectFrom = vi.fn().mockReturnValue({
+    innerJoin,
+    selectAll,
+    select: selectFn,
+    where,
+    orderBy,
+    execute,
+    executeTakeFirst,
+  })
+
+  return { selectFrom, _execute: execute, _where: where } as unknown as McpToolRouterDeps["db"]
+}
+
+function makeDeps(rows: ReturnType<typeof makeRow>[]): McpToolRouterDeps & { pool: McpClientPool } {
+  const pool = mockPool()
+  return { db: mockDb(rows), clientPool: pool, pool }
+}
+
+// ---------------------------------------------------------------------------
+// Clock setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// resolve — qualified names
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("McpToolRouter.resolve — qualified names", () => {
+  it("resolves a qualified name to a ToolDefinition", async () => {
+    const row = makeRow({ toolName: "read_file", serverSlug: "srv" })
+    const deps = makeDeps([row])
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolve("mcp:srv:read_file", AGENT_ID)
+
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe("mcp:srv:read_file")
+  })
+
+  it("returns null when no match for qualified name", async () => {
+    const deps = makeDeps([])
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolve("mcp:missing:tool", AGENT_ID)
+
+    expect(result).toBeNull()
+  })
+
+  it("delegates execution to the client pool", async () => {
+    const row = makeRow({ toolName: "search", serverSlug: "search-srv" })
+    const deps = makeDeps([row])
+    const router = new McpToolRouter(deps)
+
+    const def = await router.resolve("mcp:search-srv:search", AGENT_ID)
+    const output = await def!.execute({ query: "test" })
+
+    expect(deps.pool._callTool).toHaveBeenCalledWith("search-srv", "search", { query: "test" })
+    expect(output).toBe("mcp-result")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// resolve — unqualified names (single match)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("McpToolRouter.resolve — unqualified names", () => {
+  it("resolves when exactly one server provides the tool", async () => {
+    const row = makeRow({ toolName: "read_file", serverSlug: "srv-a" })
+    const deps = makeDeps([row])
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolve("read_file", AGENT_ID)
+
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe("mcp:srv-a:read_file")
+  })
+
+  it("returns null when no server provides the tool", async () => {
+    const deps = makeDeps([])
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolve("nonexistent", AGENT_ID)
+
+    expect(result).toBeNull()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// resolve — conflict resolution
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("McpToolRouter.resolve — conflict resolution", () => {
+  it("prefers server with agent in scope", async () => {
+    const rowA = makeRow({
+      toolName: "search",
+      serverSlug: "srv-a",
+      serverId: "id-a",
+      agentScope: [],
+      serverCreatedAt: new Date("2025-01-01"),
+    })
+    const rowB = makeRow({
+      toolName: "search",
+      serverSlug: "srv-b",
+      serverId: "id-b",
+      agentScope: [AGENT_ID],
+      serverCreatedAt: new Date("2025-01-02"),
+    })
+    const deps = makeDeps([rowA, rowB])
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolve("search", AGENT_ID)
+
+    expect(result!.name).toBe("mcp:srv-b:search")
+  })
+
+  it("uses agent preference when multiple scope matches", async () => {
+    const rowA = makeRow({
+      toolName: "deploy",
+      serverSlug: "srv-a",
+      serverId: "id-a",
+      agentScope: [AGENT_ID],
+      serverCreatedAt: new Date("2025-01-01"),
+    })
+    const rowB = makeRow({
+      toolName: "deploy",
+      serverSlug: "srv-b",
+      serverId: "id-b",
+      agentScope: [AGENT_ID],
+      serverCreatedAt: new Date("2025-01-01"),
+    })
+    const deps = makeDeps([rowA, rowB])
+    const router = new McpToolRouter(deps)
+
+    const agentConfig = {
+      mcp_preferences: { server_priority: ["srv-b", "srv-a"] },
+    }
+
+    const result = await router.resolve("deploy", AGENT_ID, agentConfig)
+
+    expect(result!.name).toBe("mcp:srv-b:deploy")
+  })
+
+  it("falls back to first registered when no scope or preference match", async () => {
+    const rowA = makeRow({
+      toolName: "query",
+      serverSlug: "srv-a",
+      serverId: "id-a",
+      agentScope: [],
+      serverCreatedAt: new Date("2025-01-01"),
+    })
+    const rowB = makeRow({
+      toolName: "query",
+      serverSlug: "srv-b",
+      serverId: "id-b",
+      agentScope: [],
+      serverCreatedAt: new Date("2025-06-01"),
+    })
+    const deps = makeDeps([rowA, rowB])
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolve("query", AGENT_ID)
+
+    expect(result!.name).toBe("mcp:srv-a:query")
+  })
+
+  it("throws ambiguity error when timestamps match", async () => {
+    const sameTime = new Date("2025-01-01T00:00:00Z")
+    const rowA = makeRow({
+      toolName: "run",
+      serverSlug: "srv-a",
+      serverId: "id-a",
+      agentScope: [],
+      serverCreatedAt: sameTime,
+    })
+    const rowB = makeRow({
+      toolName: "run",
+      serverSlug: "srv-b",
+      serverId: "id-b",
+      agentScope: [],
+      serverCreatedAt: sameTime,
+    })
+    const deps = makeDeps([rowA, rowB])
+    const router = new McpToolRouter(deps)
+
+    await expect(router.resolve("run", AGENT_ID)).rejects.toThrow(/Ambiguous tool name "run"/)
+  })
+
+  it("ambiguity error includes qualified name suggestions", async () => {
+    const sameTime = new Date("2025-01-01T00:00:00Z")
+    const rowA = makeRow({
+      toolName: "run",
+      serverSlug: "alpha",
+      serverId: "id-a",
+      agentScope: [],
+      serverCreatedAt: sameTime,
+    })
+    const rowB = makeRow({
+      toolName: "run",
+      serverSlug: "beta",
+      serverId: "id-b",
+      agentScope: [],
+      serverCreatedAt: sameTime,
+    })
+    const deps = makeDeps([rowA, rowB])
+    const router = new McpToolRouter(deps)
+
+    await expect(router.resolve("run", AGENT_ID)).rejects.toThrow(/mcp:alpha:run.*mcp:beta:run/)
+  })
+
+  it("uses agent preference to resolve conflicts without scope", async () => {
+    const sameTime = new Date("2025-01-01T00:00:00Z")
+    const rowA = makeRow({
+      toolName: "exec",
+      serverSlug: "srv-a",
+      serverId: "id-a",
+      agentScope: [],
+      serverCreatedAt: sameTime,
+    })
+    const rowB = makeRow({
+      toolName: "exec",
+      serverSlug: "srv-b",
+      serverId: "id-b",
+      agentScope: [],
+      serverCreatedAt: sameTime,
+    })
+    const deps = makeDeps([rowA, rowB])
+    const router = new McpToolRouter(deps)
+
+    const agentConfig = {
+      mcp_preferences: { server_priority: ["srv-b"] },
+    }
+
+    const result = await router.resolve("exec", AGENT_ID, agentConfig)
+
+    expect(result!.name).toBe("mcp:srv-b:exec")
+  })
+
+  it("ignores server_priority entries that are not candidates", async () => {
+    const sameTime = new Date("2025-01-01T00:00:00Z")
+    const rowA = makeRow({
+      toolName: "op",
+      serverSlug: "srv-a",
+      serverId: "id-a",
+      agentScope: [],
+      serverCreatedAt: sameTime,
+    })
+    const rowB = makeRow({
+      toolName: "op",
+      serverSlug: "srv-b",
+      serverId: "id-b",
+      agentScope: [],
+      serverCreatedAt: sameTime,
+    })
+    const deps = makeDeps([rowA, rowB])
+    const router = new McpToolRouter(deps)
+
+    // Priority lists a slug not among the candidates
+    const agentConfig = {
+      mcp_preferences: { server_priority: ["srv-nonexistent"] },
+    }
+
+    // Should fall through to timestamps → ambiguity error
+    await expect(router.resolve("op", AGENT_ID, agentConfig)).rejects.toThrow(
+      /Ambiguous tool name "op"/,
+    )
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// resolveAll
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("McpToolRouter.resolveAll", () => {
+  it("returns all active tools when allowed list is empty", async () => {
+    const rows = [
+      makeRow({ toolName: "tool_a", serverSlug: "srv" }),
+      makeRow({ toolName: "tool_b", serverSlug: "srv" }),
+    ]
+    const deps = makeDeps(rows)
+    const router = new McpToolRouter(deps)
+
+    // Empty allowedTools = no filter (all MCP tools returned)
+    // NOTE: Per the resolveAll implementation, if allowedTools.length > 0
+    // tools must match. If length === 0, all tools pass the allow filter.
+    const result = await router.resolveAll(AGENT_ID, [], [])
+
+    expect(result).toHaveLength(2)
+  })
+
+  it("filters by allowedTools exact match", async () => {
+    const rows = [
+      makeRow({ toolName: "tool_a", serverSlug: "srv" }),
+      makeRow({ toolName: "tool_b", serverSlug: "srv" }),
+    ]
+    const deps = makeDeps(rows)
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolveAll(AGENT_ID, ["mcp:srv:tool_a"], [])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe("mcp:srv:tool_a")
+  })
+
+  it("filters by deniedTools — denied takes precedence", async () => {
+    const rows = [
+      makeRow({ toolName: "safe", serverSlug: "srv" }),
+      makeRow({ toolName: "dangerous", serverSlug: "srv" }),
+    ]
+    const deps = makeDeps(rows)
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolveAll(AGENT_ID, [], ["mcp:srv:dangerous"])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe("mcp:srv:safe")
+  })
+
+  it("denied overrides allowed", async () => {
+    const rows = [makeRow({ toolName: "tool_a", serverSlug: "srv" })]
+    const deps = makeDeps(rows)
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolveAll(AGENT_ID, ["mcp:srv:tool_a"], ["mcp:srv:tool_a"])
+
+    expect(result).toHaveLength(0)
+  })
+
+  it("filters by agent_scope — excludes tools from scoped servers", async () => {
+    const rows = [
+      makeRow({ toolName: "tool_a", serverSlug: "srv-a", agentScope: [AGENT_ID] }),
+      makeRow({
+        toolName: "tool_b",
+        serverSlug: "srv-b",
+        agentScope: ["other-agent"],
+      }),
+    ]
+    const deps = makeDeps(rows)
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolveAll(AGENT_ID, [], [])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe("mcp:srv-a:tool_a")
+  })
+
+  it("includes tools from servers with empty agent_scope (all agents)", async () => {
+    const rows = [
+      makeRow({ toolName: "tool_a", serverSlug: "srv-a", agentScope: [] }),
+      makeRow({ toolName: "tool_b", serverSlug: "srv-b", agentScope: [AGENT_ID] }),
+    ]
+    const deps = makeDeps(rows)
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolveAll(AGENT_ID, [], [])
+
+    expect(result).toHaveLength(2)
+  })
+
+  it("returns empty when no tools match", async () => {
+    const deps = makeDeps([])
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolveAll(AGENT_ID, [], [])
+
+    expect(result).toHaveLength(0)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// resolveAll — glob patterns
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("McpToolRouter.resolveAll — glob patterns", () => {
+  it("matches tools with wildcard in tool name", async () => {
+    const rows = [
+      makeRow({ toolName: "read_file", serverSlug: "fs" }),
+      makeRow({ toolName: "write_file", serverSlug: "fs" }),
+      makeRow({ toolName: "delete_file", serverSlug: "fs" }),
+    ]
+    const deps = makeDeps(rows)
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolveAll(AGENT_ID, ["mcp:fs:*_file"], [])
+
+    expect(result).toHaveLength(3)
+  })
+
+  it("matches tools with wildcard in server slug", async () => {
+    const rows = [
+      makeRow({ toolName: "search", serverSlug: "google-search" }),
+      makeRow({ toolName: "search", serverSlug: "bing-search" }),
+      makeRow({ toolName: "fetch", serverSlug: "http-client" }),
+    ]
+    const deps = makeDeps(rows)
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolveAll(AGENT_ID, ["mcp:*-search:*"], [])
+
+    expect(result).toHaveLength(2)
+  })
+
+  it("supports full wildcard pattern", async () => {
+    const rows = [
+      makeRow({ toolName: "tool_a", serverSlug: "srv-1" }),
+      makeRow({ toolName: "tool_b", serverSlug: "srv-2" }),
+    ]
+    const deps = makeDeps(rows)
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolveAll(AGENT_ID, ["mcp:*:*"], [])
+
+    expect(result).toHaveLength(2)
+  })
+
+  it("denies with glob pattern", async () => {
+    const rows = [
+      makeRow({ toolName: "read_file", serverSlug: "fs" }),
+      makeRow({ toolName: "write_file", serverSlug: "fs" }),
+      makeRow({ toolName: "search", serverSlug: "web" }),
+    ]
+    const deps = makeDeps(rows)
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolveAll(AGENT_ID, [], ["mcp:fs:*"])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe("mcp:web:search")
+  })
+
+  it("glob deny takes precedence over glob allow", async () => {
+    const rows = [
+      makeRow({ toolName: "read_file", serverSlug: "fs" }),
+      makeRow({ toolName: "write_file", serverSlug: "fs" }),
+    ]
+    const deps = makeDeps(rows)
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolveAll(AGENT_ID, ["mcp:fs:*"], ["mcp:fs:write_file"])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe("mcp:fs:read_file")
+  })
+
+  it("non-matching glob returns empty", async () => {
+    const rows = [makeRow({ toolName: "tool_a", serverSlug: "srv" })]
+    const deps = makeDeps(rows)
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolveAll(AGENT_ID, ["mcp:other:*"], [])
+
+    expect(result).toHaveLength(0)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Caching
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("McpToolRouter — caching", () => {
+  it("caches resolveAll results within TTL", async () => {
+    const rows = [makeRow({ toolName: "tool_a", serverSlug: "srv" })]
+    const deps = makeDeps(rows)
+    const db = deps.db as unknown as { selectFrom: ReturnType<typeof vi.fn> }
+    const router = new McpToolRouter(deps)
+
+    await router.resolveAll(AGENT_ID, [], [])
+    await router.resolveAll(AGENT_ID, [], [])
+
+    // DB should only be queried once
+    expect(db.selectFrom).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-queries after TTL expires", async () => {
+    const rows = [makeRow({ toolName: "tool_a", serverSlug: "srv" })]
+    const deps = makeDeps(rows)
+    const db = deps.db as unknown as { selectFrom: ReturnType<typeof vi.fn> }
+    const router = new McpToolRouter(deps)
+
+    await router.resolveAll(AGENT_ID, [], [])
+
+    // Advance time past the 60s TTL
+    vi.advanceTimersByTime(61_000)
+
+    await router.resolveAll(AGENT_ID, [], [])
+
+    expect(db.selectFrom).toHaveBeenCalledTimes(2)
+  })
+
+  it("uses separate cache entries for different args", async () => {
+    const rows = [makeRow({ toolName: "tool_a", serverSlug: "srv" })]
+    const deps = makeDeps(rows)
+    const router = new McpToolRouter(deps)
+
+    const r1 = await router.resolveAll(AGENT_ID, [], [])
+    const r2 = await router.resolveAll(AGENT_ID, ["mcp:srv:tool_a"], [])
+
+    // Different cache keys → different filtered results
+    // r1 has no allow filter so returns all; r2 filters to just tool_a
+    expect(r1).toHaveLength(1)
+    expect(r2).toHaveLength(1)
+
+    // After invalidation, both are re-computed
+    router.invalidateCache()
+    const r3 = await router.resolveAll(AGENT_ID, ["mcp:nonexistent:x"], [])
+    expect(r3).toHaveLength(0)
+  })
+
+  it("invalidateCache clears all cached entries", async () => {
+    const rows = [makeRow({ toolName: "tool_a", serverSlug: "srv" })]
+    const deps = makeDeps(rows)
+    const db = deps.db as unknown as { selectFrom: ReturnType<typeof vi.fn> }
+    const router = new McpToolRouter(deps)
+
+    await router.resolveAll(AGENT_ID, [], [])
+
+    router.invalidateCache()
+
+    await router.resolveAll(AGENT_ID, [], [])
+
+    expect(db.selectFrom).toHaveBeenCalledTimes(2)
+  })
+
+  it("caches resolve (qualified) results", async () => {
+    const rows = [makeRow({ toolName: "tool_a", serverSlug: "srv" })]
+    const deps = makeDeps(rows)
+    const db = deps.db as unknown as { selectFrom: ReturnType<typeof vi.fn> }
+    const router = new McpToolRouter(deps)
+
+    await router.resolve("mcp:srv:tool_a", AGENT_ID)
+    await router.resolve("mcp:srv:tool_a", AGENT_ID)
+
+    expect(db.selectFrom).toHaveBeenCalledTimes(1)
+  })
+
+  it("caches resolve (unqualified) results", async () => {
+    const rows = [makeRow({ toolName: "tool_a", serverSlug: "srv" })]
+    const deps = makeDeps(rows)
+    const db = deps.db as unknown as { selectFrom: ReturnType<typeof vi.fn> }
+    const router = new McpToolRouter(deps)
+
+    await router.resolve("tool_a", AGENT_ID)
+    await router.resolve("tool_a", AGENT_ID)
+
+    expect(db.selectFrom).toHaveBeenCalledTimes(1)
+  })
+
+  it("caches null results for missing tools", async () => {
+    const deps = makeDeps([])
+    const db = deps.db as unknown as { selectFrom: ReturnType<typeof vi.fn> }
+    const router = new McpToolRouter(deps)
+
+    const r1 = await router.resolve("mcp:missing:tool", AGENT_ID)
+    const r2 = await router.resolve("mcp:missing:tool", AGENT_ID)
+
+    expect(r1).toBeNull()
+    expect(r2).toBeNull()
+    expect(db.selectFrom).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// getServerPriority edge cases
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("McpToolRouter.resolve — server priority edge cases", () => {
+  it("handles missing mcp_preferences in agentConfig", async () => {
+    const sameTime = new Date("2025-01-01T00:00:00Z")
+    const rowA = makeRow({
+      toolName: "op",
+      serverSlug: "srv-a",
+      serverId: "id-a",
+      agentScope: [],
+      serverCreatedAt: sameTime,
+    })
+    const rowB = makeRow({
+      toolName: "op",
+      serverSlug: "srv-b",
+      serverId: "id-b",
+      agentScope: [],
+      serverCreatedAt: sameTime,
+    })
+    const deps = makeDeps([rowA, rowB])
+    const router = new McpToolRouter(deps)
+
+    // agentConfig without mcp_preferences → falls through
+    await expect(router.resolve("op", AGENT_ID, { other_key: true })).rejects.toThrow(/Ambiguous/)
+  })
+
+  it("handles non-array server_priority gracefully", async () => {
+    const sameTime = new Date("2025-01-01T00:00:00Z")
+    const rowA = makeRow({
+      toolName: "op",
+      serverSlug: "srv-a",
+      serverId: "id-a",
+      agentScope: [],
+      serverCreatedAt: sameTime,
+    })
+    const rowB = makeRow({
+      toolName: "op",
+      serverSlug: "srv-b",
+      serverId: "id-b",
+      agentScope: [],
+      serverCreatedAt: sameTime,
+    })
+    const deps = makeDeps([rowA, rowB])
+    const router = new McpToolRouter(deps)
+
+    const agentConfig = {
+      mcp_preferences: { server_priority: "not-an-array" },
+    }
+
+    await expect(router.resolve("op", AGENT_ID, agentConfig)).rejects.toThrow(/Ambiguous/)
+  })
+
+  it("handles undefined agentConfig", async () => {
+    const row = makeRow({ toolName: "solo", serverSlug: "srv" })
+    const deps = makeDeps([row])
+    const router = new McpToolRouter(deps)
+
+    const result = await router.resolve("solo", AGENT_ID, undefined)
+
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe("mcp:srv:solo")
+  })
+})

--- a/packages/control-plane/src/backends/tool-executor.ts
+++ b/packages/control-plane/src/backends/tool-executor.ts
@@ -5,6 +5,7 @@
  * Tools are registered with a name, description, JSON Schema, and handler.
  */
 
+import type { McpToolRouter } from "../mcp/tool-router.js"
 import { createHttpRequestTool } from "./tools/http-request.js"
 import { createMemoryQueryTool } from "./tools/memory-query.js"
 import { createMemoryStoreTool } from "./tools/memory-store.js"
@@ -104,13 +105,36 @@ export function createDefaultToolRegistry(): ToolRegistry {
  *
  * Starts with the default built-in tools, then registers any custom
  * webhook tools defined in the agent's config.tools array.
+ *
+ * When an McpToolRouter is provided, MCP tools available to the agent
+ * are resolved and merged into the registry.
  */
-export function createAgentToolRegistry(agentConfig: Record<string, unknown>): ToolRegistry {
+export async function createAgentToolRegistry(
+  agentConfig: Record<string, unknown>,
+  opts?: {
+    agentId?: string
+    mcpRouter?: McpToolRouter
+    allowedTools?: string[]
+    deniedTools?: string[]
+  },
+): Promise<ToolRegistry> {
   const registry = createDefaultToolRegistry()
 
   const webhookSpecs = parseWebhookTools(agentConfig)
   for (const spec of webhookSpecs) {
     registry.register(createWebhookTool(spec))
+  }
+
+  // Merge MCP tools when a router is available
+  if (opts?.mcpRouter && opts.agentId) {
+    const mcpTools = await opts.mcpRouter.resolveAll(
+      opts.agentId,
+      opts.allowedTools ?? [],
+      opts.deniedTools ?? [],
+    )
+    for (const tool of mcpTools) {
+      registry.register(tool)
+    }
   }
 
   return registry

--- a/packages/control-plane/src/mcp/tool-bridge.ts
+++ b/packages/control-plane/src/mcp/tool-bridge.ts
@@ -1,0 +1,59 @@
+/**
+ * MCP Tool Bridge
+ *
+ * Adapts an MCP server tool record into a ToolDefinition that can be
+ * registered in the existing ToolRegistry.  Execution delegates to the
+ * MCP client pool which manages transport-level communication.
+ */
+
+import type { ToolDefinition } from "../backends/tool-executor.js"
+import type { McpServer, McpServerTool } from "../db/types.js"
+
+/**
+ * Minimal interface for the MCP client pool dependency.
+ * Only the `callTool` capability is required by the bridge.
+ */
+export interface McpClientPool {
+  callTool(serverSlug: string, toolName: string, args: Record<string, unknown>): Promise<string>
+}
+
+/**
+ * Build the qualified MCP tool name: `mcp:<server-slug>:<tool-name>`.
+ */
+export function qualifiedName(serverSlug: string, toolName: string): string {
+  return `mcp:${serverSlug}:${toolName}`
+}
+
+/**
+ * Parse a qualified MCP tool name into its components.
+ * Returns null if the name does not match `mcp:<slug>:<name>`.
+ */
+export function parseQualifiedName(name: string): { serverSlug: string; toolName: string } | null {
+  if (!name.startsWith("mcp:")) return null
+  const parts = name.split(":")
+  if (parts.length !== 3 || !parts[1] || !parts[2]) return null
+  return { serverSlug: parts[1], toolName: parts[2] }
+}
+
+/**
+ * Bridge an MCP server tool into a ToolDefinition.
+ *
+ * The returned definition uses the qualified name as the tool name so
+ * there is no ambiguity when multiple servers expose identically-named
+ * tools.  Execution calls through the client pool.
+ */
+export function createMcpToolDefinition(
+  pool: McpClientPool,
+  server: McpServer,
+  tool: McpServerTool,
+): ToolDefinition {
+  const qName = qualifiedName(server.slug, tool.name)
+  return {
+    name: qName,
+    description: tool.description ?? `MCP tool ${tool.name} from ${server.name}`,
+    inputSchema: tool.input_schema,
+    execute: async (input: Record<string, unknown>) => {
+      return pool.callTool(server.slug, tool.name, input)
+    },
+  }
+}

--- a/packages/control-plane/src/mcp/tool-router.ts
+++ b/packages/control-plane/src/mcp/tool-router.ts
@@ -1,0 +1,452 @@
+/**
+ * MCP Tool Router
+ *
+ * Resolves MCP tools by qualified or unqualified name with conflict
+ * handling, glob-based allow/deny filtering, and a TTL cache.
+ *
+ * Resolution order for unqualified names:
+ *   1. Agent scope  — if only one server includes this agent in agent_scope
+ *   2. Agent preference — agent.config.mcp_preferences.server_priority
+ *   3. First registered — mcp_server.created_at ASC
+ *   4. Ambiguity error  — asks for a qualified name
+ */
+
+import type { Kysely } from "kysely"
+
+import type { ToolDefinition } from "../backends/tool-executor.js"
+import type { Database, McpServer, McpServerTool } from "../db/types.js"
+import type { McpClientPool } from "./tool-bridge.js"
+import { createMcpToolDefinition, parseQualifiedName, qualifiedName } from "./tool-bridge.js"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface McpToolRouterDeps {
+  db: Kysely<Database>
+  clientPool: McpClientPool
+}
+
+interface CacheEntry<T> {
+  value: T
+  expiresAt: number
+}
+
+/** Joined row returned by the resolveAll query. */
+interface ToolWithServer {
+  tool: McpServerTool
+  server: McpServer
+}
+
+// ---------------------------------------------------------------------------
+// Glob helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a simple glob pattern (supporting `*` as wildcard) into a RegExp.
+ * Only `*` is supported — it maps to `[^:]*` when inside the qualified name
+ * structure and `.*` at the tail.
+ */
+function globToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/([.+?^${}()|[\]\\])/g, "\\$1").replace(/\*/g, ".*")
+  return new RegExp(`^${escaped}$`)
+}
+
+function matchesAnyGlob(name: string, patterns: string[]): boolean {
+  return patterns.some((p) => {
+    if (p === name) return true
+    if (p.includes("*")) return globToRegex(p).test(name)
+    return false
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL_MS = 60_000
+
+// ---------------------------------------------------------------------------
+// McpToolRouter
+// ---------------------------------------------------------------------------
+
+export class McpToolRouter {
+  private db: Kysely<Database>
+  private clientPool: McpClientPool
+  private cache = new Map<string, CacheEntry<unknown>>()
+
+  constructor(deps: McpToolRouterDeps) {
+    this.db = deps.db
+    this.clientPool = deps.clientPool
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /**
+   * Resolve a single tool name to a ToolDefinition.
+   *
+   * 1. Qualified MCP name (`mcp:<slug>:<name>`) → direct lookup
+   * 2. Unqualified name → search mcp_server_tool table
+   *    - 0 results → null (fall through to webhook/built-in)
+   *    - 1 result  → return it
+   *    - N results → conflict resolution
+   */
+  async resolve(
+    toolName: string,
+    agentId: string,
+    agentConfig?: Record<string, unknown>,
+  ): Promise<ToolDefinition | null> {
+    const parsed = parseQualifiedName(toolName)
+
+    if (parsed) {
+      return this.resolveQualified(parsed.serverSlug, parsed.toolName)
+    }
+
+    return this.resolveUnqualified(toolName, agentId, agentConfig)
+  }
+
+  /**
+   * Resolve all MCP tools available to an agent.
+   *
+   * Filters:
+   *  - mcp_server.status = 'ACTIVE'
+   *  - mcp_server_tool.status = 'available'
+   *  - agent_scope includes agentId (or scope is empty → all agents)
+   *  - qualified name matches allowedTools (exact or glob)
+   *  - denied tools take precedence over allowed
+   */
+  async resolveAll(
+    agentId: string,
+    allowedTools: string[],
+    deniedTools: string[],
+  ): Promise<ToolDefinition[]> {
+    const cacheKey = `resolveAll:${agentId}:${allowedTools.join(",")}:${deniedTools.join(",")}`
+    const cached = this.getCache<ToolDefinition[]>(cacheKey)
+    if (cached !== undefined) return cached
+
+    const rows = await this.fetchActiveTools()
+
+    const results: ToolDefinition[] = []
+    for (const { tool, server } of rows) {
+      // Agent scope filter: empty scope means available to all agents
+      const scope = server.agent_scope
+      if (scope.length > 0 && !scope.includes(agentId)) continue
+
+      const qName = qualifiedName(server.slug, tool.name)
+
+      // Allow filter: tool must match at least one allowed pattern
+      if (allowedTools.length > 0 && !matchesAnyGlob(qName, allowedTools)) continue
+
+      // Deny filter: denied takes precedence
+      if (deniedTools.length > 0 && matchesAnyGlob(qName, deniedTools)) continue
+
+      results.push(createMcpToolDefinition(this.clientPool, server, tool))
+    }
+
+    this.setCache(cacheKey, results)
+    return results
+  }
+
+  /** Invalidate the entire resolution cache. */
+  invalidateCache(): void {
+    this.cache.clear()
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private async resolveQualified(
+    serverSlug: string,
+    toolName: string,
+  ): Promise<ToolDefinition | null> {
+    const qName = qualifiedName(serverSlug, toolName)
+    const cacheKey = `qualified:${qName}`
+    const cached = this.getCache<ToolDefinition | null>(cacheKey)
+    if (cached !== undefined) return cached
+
+    const rows = await this.db
+      .selectFrom("mcp_server_tool")
+      .innerJoin("mcp_server", "mcp_server.id", "mcp_server_tool.mcp_server_id")
+      .selectAll("mcp_server_tool")
+      .select([
+        "mcp_server.id as server_id",
+        "mcp_server.name as server_name",
+        "mcp_server.slug as server_slug",
+        "mcp_server.transport as server_transport",
+        "mcp_server.connection as server_connection",
+        "mcp_server.agent_scope as server_agent_scope",
+        "mcp_server.status as server_status",
+        "mcp_server.description as server_description",
+        "mcp_server.protocol_version as server_protocol_version",
+        "mcp_server.server_info as server_server_info",
+        "mcp_server.capabilities as server_capabilities",
+        "mcp_server.health_probe_interval_ms as server_health_probe_interval_ms",
+        "mcp_server.last_healthy_at as server_last_healthy_at",
+        "mcp_server.error_message as server_error_message",
+        "mcp_server.created_at as server_created_at",
+        "mcp_server.updated_at as server_updated_at",
+      ])
+      .where("mcp_server.slug", "=", serverSlug)
+      .where("mcp_server_tool.name", "=", toolName)
+      .where("mcp_server.status", "=", "ACTIVE")
+      .where("mcp_server_tool.status", "=", "available")
+      .execute()
+
+    if (rows.length === 0) {
+      this.setCache(cacheKey, null)
+      return null
+    }
+
+    const row = rows[0]
+    const server = this.extractServer(row)
+    const tool = this.extractTool(row)
+    const def = createMcpToolDefinition(this.clientPool, server, tool)
+    this.setCache(cacheKey, def)
+    return def
+  }
+
+  private async resolveUnqualified(
+    toolName: string,
+    agentId: string,
+    agentConfig?: Record<string, unknown>,
+  ): Promise<ToolDefinition | null> {
+    const cacheKey = `unqualified:${toolName}:${agentId}`
+    const cached = this.getCache<ToolDefinition | null>(cacheKey)
+    if (cached !== undefined) return cached
+
+    const rows = await this.db
+      .selectFrom("mcp_server_tool")
+      .innerJoin("mcp_server", "mcp_server.id", "mcp_server_tool.mcp_server_id")
+      .selectAll("mcp_server_tool")
+      .select([
+        "mcp_server.id as server_id",
+        "mcp_server.name as server_name",
+        "mcp_server.slug as server_slug",
+        "mcp_server.transport as server_transport",
+        "mcp_server.connection as server_connection",
+        "mcp_server.agent_scope as server_agent_scope",
+        "mcp_server.status as server_status",
+        "mcp_server.description as server_description",
+        "mcp_server.protocol_version as server_protocol_version",
+        "mcp_server.server_info as server_server_info",
+        "mcp_server.capabilities as server_capabilities",
+        "mcp_server.health_probe_interval_ms as server_health_probe_interval_ms",
+        "mcp_server.last_healthy_at as server_last_healthy_at",
+        "mcp_server.error_message as server_error_message",
+        "mcp_server.created_at as server_created_at",
+        "mcp_server.updated_at as server_updated_at",
+      ])
+      .where("mcp_server_tool.name", "=", toolName)
+      .where("mcp_server.status", "=", "ACTIVE")
+      .where("mcp_server_tool.status", "=", "available")
+      .orderBy("mcp_server.created_at", "asc")
+      .execute()
+
+    if (rows.length === 0) {
+      this.setCache(cacheKey, null)
+      return null
+    }
+
+    // Single match — no conflict
+    if (rows.length === 1) {
+      const row = rows[0]
+      const def = createMcpToolDefinition(
+        this.clientPool,
+        this.extractServer(row),
+        this.extractTool(row),
+      )
+      this.setCache(cacheKey, def)
+      return def
+    }
+
+    // Multiple matches — conflict resolution
+    const resolved = this.resolveConflict(rows, agentId, agentConfig)
+    this.setCache(cacheKey, resolved)
+    return resolved
+  }
+
+  /**
+   * Conflict resolution for unqualified names with multiple matches.
+   *
+   * Priority order:
+   *  1. Agent scope — prefer servers that include this agent in agent_scope
+   *  2. Agent preference — mcp_preferences.server_priority ordering
+   *  3. First registered — already sorted by created_at ASC
+   *  4. Ambiguity error
+   */
+  private resolveConflict(
+    rows: Array<Record<string, unknown>>,
+    agentId: string,
+    agentConfig?: Record<string, unknown>,
+  ): ToolDefinition {
+    // Step 1: filter by agent_scope
+    const scopeFiltered = rows.filter((r) => {
+      const scope = r.server_agent_scope as string[]
+      return scope.length > 0 && scope.includes(agentId)
+    })
+
+    if (scopeFiltered.length === 1) {
+      const row = scopeFiltered[0]
+      return createMcpToolDefinition(
+        this.clientPool,
+        this.extractServer(row),
+        this.extractTool(row),
+      )
+    }
+
+    // Use scope-filtered list if any matches, otherwise fall back to all
+    const candidates = scopeFiltered.length > 0 ? scopeFiltered : rows
+
+    // Step 2: agent preference (mcp_preferences.server_priority)
+    const priority = this.getServerPriority(agentConfig)
+    if (priority.length > 0) {
+      for (const slug of priority) {
+        const match = candidates.find((r) => r.server_slug === slug)
+        if (match) {
+          return createMcpToolDefinition(
+            this.clientPool,
+            this.extractServer(match),
+            this.extractTool(match),
+          )
+        }
+      }
+    }
+
+    // Step 3: first registered (already ordered by created_at ASC)
+    // Only use this if there's a clear winner — multiple candidates with
+    // different created_at timestamps, take the earliest.
+    const first = candidates[0]
+    const second = candidates[1]
+    const firstCreatedAt = first.server_created_at as Date
+    const secondCreatedAt = second.server_created_at as Date
+
+    if (firstCreatedAt.getTime() !== secondCreatedAt.getTime()) {
+      return createMcpToolDefinition(
+        this.clientPool,
+        this.extractServer(first),
+        this.extractTool(first),
+      )
+    }
+
+    // Step 4: ambiguity error
+    const toolName = first.name as string
+    const serverSlugs = candidates.map((r) => r.server_slug as string)
+    const qualifiedOptions = serverSlugs.map((s) => `mcp:${s}:${toolName}`).join(", ")
+    throw new Error(
+      `Ambiguous tool name "${toolName}": available from multiple MCP servers. ` +
+        `Use a qualified name: ${qualifiedOptions}`,
+    )
+  }
+
+  private getServerPriority(agentConfig?: Record<string, unknown>): string[] {
+    if (!agentConfig) return []
+    const prefs = agentConfig.mcp_preferences as Record<string, unknown> | undefined
+    if (!prefs) return []
+    const priority = prefs.server_priority
+    if (!Array.isArray(priority)) return []
+    return priority.filter((p): p is string => typeof p === "string")
+  }
+
+  /** Fetch all active tools joined with their servers. */
+  private async fetchActiveTools(): Promise<ToolWithServer[]> {
+    const cacheKey = "activeTools"
+    const cached = this.getCache<ToolWithServer[]>(cacheKey)
+    if (cached !== undefined) return cached
+
+    const rows = await this.db
+      .selectFrom("mcp_server_tool")
+      .innerJoin("mcp_server", "mcp_server.id", "mcp_server_tool.mcp_server_id")
+      .selectAll("mcp_server_tool")
+      .select([
+        "mcp_server.id as server_id",
+        "mcp_server.name as server_name",
+        "mcp_server.slug as server_slug",
+        "mcp_server.transport as server_transport",
+        "mcp_server.connection as server_connection",
+        "mcp_server.agent_scope as server_agent_scope",
+        "mcp_server.status as server_status",
+        "mcp_server.description as server_description",
+        "mcp_server.protocol_version as server_protocol_version",
+        "mcp_server.server_info as server_server_info",
+        "mcp_server.capabilities as server_capabilities",
+        "mcp_server.health_probe_interval_ms as server_health_probe_interval_ms",
+        "mcp_server.last_healthy_at as server_last_healthy_at",
+        "mcp_server.error_message as server_error_message",
+        "mcp_server.created_at as server_created_at",
+        "mcp_server.updated_at as server_updated_at",
+      ])
+      .where("mcp_server.status", "=", "ACTIVE")
+      .where("mcp_server_tool.status", "=", "available")
+      .orderBy("mcp_server.created_at", "asc")
+      .execute()
+
+    const results: ToolWithServer[] = rows.map((row) => ({
+      tool: this.extractTool(row),
+      server: this.extractServer(row),
+    }))
+
+    this.setCache(cacheKey, results)
+    return results
+  }
+
+  // -------------------------------------------------------------------------
+  // Row extraction helpers
+  // -------------------------------------------------------------------------
+
+  private extractServer(row: Record<string, unknown>): McpServer {
+    return {
+      id: row.server_id as string,
+      name: row.server_name as string,
+      slug: row.server_slug as string,
+      transport: row.server_transport,
+      connection: row.server_connection,
+      agent_scope: row.server_agent_scope,
+      status: row.server_status,
+      description: row.server_description,
+      protocol_version: row.server_protocol_version,
+      server_info: row.server_server_info,
+      capabilities: row.server_capabilities,
+      health_probe_interval_ms: row.server_health_probe_interval_ms,
+      last_healthy_at: row.server_last_healthy_at,
+      error_message: row.server_error_message,
+      created_at: row.server_created_at,
+      updated_at: row.server_updated_at,
+    } as McpServer
+  }
+
+  private extractTool(row: Record<string, unknown>): McpServerTool {
+    return {
+      id: row.id as string,
+      mcp_server_id: row.mcp_server_id as string,
+      name: row.name as string,
+      qualified_name: row.qualified_name as string,
+      description: row.description as string | null,
+      input_schema: row.input_schema as Record<string, unknown>,
+      annotations: row.annotations as Record<string, unknown> | null,
+      status: row.status as string,
+      created_at: row.created_at as Date,
+      updated_at: row.updated_at as Date,
+    } as McpServerTool
+  }
+
+  // -------------------------------------------------------------------------
+  // Cache helpers
+  // -------------------------------------------------------------------------
+
+  private getCache<T>(key: string): T | undefined {
+    const entry = this.cache.get(key)
+    if (!entry) return undefined
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key)
+      return undefined
+    }
+    return entry.value as T
+  }
+
+  private setCache(key: string, value: unknown): void {
+    this.cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS })
+  }
+}


### PR DESCRIPTION
## Summary
- **Created `tool-bridge.ts`**: Adapts MCP server tool records into `ToolDefinition` with qualified name format (`mcp:<server-slug>:<tool-name>`), parsing utilities, and execution delegation to `McpClientPool`
- **Created `tool-router.ts`**: Resolves MCP tools by qualified or unqualified name with conflict handling (agent scope → `mcp_preferences.server_priority` → first registered → ambiguity error), glob-based allow/deny filtering, agent_scope filtering, and 60s TTL cache with `invalidateCache()`
- **Modified `tool-executor.ts`**: Integrated MCP resolution into `createAgentToolRegistry()` — when an `McpToolRouter` and `agentId` are provided, MCP tools are resolved and merged into the registry alongside built-in and webhook tools
- **Added comprehensive tests** (51 new tests): `mcp-tool-bridge.test.ts` (16 tests), `mcp-tool-router.test.ts` (35 tests), plus 3 new MCP integration tests in `builtin-tools.test.ts`; also fixed existing `createAgentToolRegistry` tests to properly `await` the now-async function

Closes #284

## Test plan
- [x] All 831 tests pass (53 test files)
- [x] Lint passes for all modified/new files
- [x] Formatting passes (prettier)
- [x] Qualified name resolution (direct lookup via `mcp:<slug>:<name>`)
- [x] Unqualified name resolution (single match, conflict resolution)
- [x] Conflict resolution chain: agent scope → server_priority → first registered → ambiguity error
- [x] `resolveAll` with agent_scope, allowed/denied, glob patterns
- [x] Glob deny takes precedence over glob allow
- [x] 60s TTL cache and `invalidateCache()` behavior
- [x] MCP integration in `createAgentToolRegistry()` (with/without router)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated MCP (Model Context Protocol) tools into the agent tool registry with qualified naming and conflict resolution.
  * Added tool filtering with allow/deny patterns and agent-scoped access controls.
  * Implemented caching layer for improved performance in tool resolution.

* **Tests**
  * Comprehensive test coverage for MCP tool bridge utilities, routing logic, and registry integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->