### PR TITLE
feat(routes): agent credential binding CRUD routes + service

### DIFF
--- a/packages/control-plane/src/__tests__/agent-credential-routes.test.ts
+++ b/packages/control-plane/src/__tests__/agent-credential-routes.test.ts
@@ -1,0 +1,393 @@
+import Fastify from "fastify"
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import type { Database } from "../db/types.js"
+import type { AuthConfig } from "../middleware/types.js"
+import { agentCredentialRoutes } from "../routes/agent-credentials.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEV_AUTH_CONFIG: AuthConfig = {
+  requireAuth: false,
+  apiKeys: [],
+}
+
+const AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+const CRED_ID = "cccccccc-1111-2222-3333-444444444444"
+const USER_ID = "dev-user"
+const BINDING_ID = "bbbbbbbb-1111-2222-3333-444444444444"
+
+function makeCredential(overrides: Record<string, unknown> = {}) {
+  return {
+    id: CRED_ID,
+    user_account_id: USER_ID,
+    credential_class: "llm_provider",
+    provider: "anthropic",
+    display_label: "Anthropic (direct)",
+    status: "active",
+    ...overrides,
+  }
+}
+
+function makeBinding(overrides: Record<string, unknown> = {}) {
+  return {
+    id: BINDING_ID,
+    agent_id: AGENT_ID,
+    provider_credential_id: CRED_ID,
+    scope: null,
+    created_at: new Date(),
+    ...overrides,
+  }
+}
+
+function makeJoinedBinding(overrides: Record<string, unknown> = {}) {
+  return {
+    id: BINDING_ID,
+    credentialId: CRED_ID,
+    credentialClass: "llm_provider",
+    provider: "anthropic",
+    displayLabel: "Anthropic (direct)",
+    status: "active",
+    grantedAt: new Date(),
+    ...overrides,
+  }
+}
+
+/**
+ * Build a mock Kysely database that supports the query patterns used by
+ * agentCredentialRoutes. Each table handler returns chainable methods.
+ */
+function mockDb(
+  opts: {
+    agentExists?: boolean
+    credential?: Record<string, unknown> | null
+    existingBinding?: Record<string, unknown> | null
+    insertedBinding?: Record<string, unknown>
+    joinedBindings?: Record<string, unknown>[]
+  } = {},
+) {
+  const {
+    agentExists = true,
+    credential = makeCredential(),
+    existingBinding = null,
+    insertedBinding = makeBinding(),
+    joinedBindings = [makeJoinedBinding()],
+  } = opts
+
+  // Track insertInto calls for audit log verification
+  const auditInsertValues = vi.fn().mockReturnValue({
+    execute: vi.fn().mockResolvedValue([]),
+  })
+
+  // Track deleteFrom calls
+  const deleteExecute = vi.fn().mockResolvedValue([])
+  const deleteWhere2 = vi.fn().mockReturnValue({ execute: deleteExecute })
+  const deleteWhere1 = vi.fn().mockReturnValue({ where: deleteWhere2 })
+
+  // selectFrom dispatch — the route uses multiple tables
+  let selectCallCount = 0
+
+  function agentSelectChain() {
+    const row = agentExists ? { id: AGENT_ID } : null
+    const executeTakeFirst = vi.fn().mockResolvedValue(row)
+    const where = vi.fn().mockReturnValue({ executeTakeFirst })
+    const select = vi.fn().mockReturnValue({ where })
+    return { select }
+  }
+
+  function credentialSelectChain() {
+    const executeTakeFirst = vi.fn().mockResolvedValue(credential)
+    const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+    whereFn.mockReturnValue({ where: whereFn, executeTakeFirst })
+    const select = vi.fn().mockReturnValue({ where: whereFn })
+    return { select }
+  }
+
+  function bindingSelectChain() {
+    const executeTakeFirst = vi.fn().mockResolvedValue(existingBinding)
+    const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+    whereFn.mockReturnValue({ where: whereFn, executeTakeFirst })
+    const select = vi.fn().mockReturnValue({ where: whereFn })
+    return { select }
+  }
+
+  function bindingJoinSelectChain() {
+    const execute = vi.fn().mockResolvedValue(joinedBindings)
+    const orderBy = vi.fn().mockReturnValue({ execute })
+    const where = vi.fn().mockReturnValue({ orderBy })
+    const select = vi.fn().mockReturnValue({ where })
+    const innerJoin = vi.fn().mockReturnValue({ select })
+    return { innerJoin }
+  }
+
+  const db = {
+    selectFrom: vi.fn().mockImplementation((table: string) => {
+      if (table === "agent") return agentSelectChain()
+
+      if (table === "provider_credential") {
+        // POST uses this for credential lookup, DELETE uses for audit metadata
+        return credentialSelectChain()
+      }
+
+      if (table === "agent_credential_binding") {
+        selectCallCount++
+        // First call in POST: duplicate check. In GET: join query. In DELETE: binding lookup.
+        if (selectCallCount === 1 && existingBinding !== undefined) {
+          // Could be POST duplicate check or GET join or DELETE lookup
+          // We handle via the opts pattern
+        }
+        // For GET route, return the join chain
+        return { ...bindingSelectChain(), ...bindingJoinSelectChain() }
+      }
+
+      return agentSelectChain()
+    }),
+
+    insertInto: vi.fn().mockImplementation((table: string) => {
+      if (table === "agent_credential_binding") {
+        const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(insertedBinding)
+        const returningAll = vi.fn().mockReturnValue({ executeTakeFirstOrThrow })
+        const values = vi.fn().mockReturnValue({ returningAll })
+        return { values }
+      }
+
+      if (table === "credential_audit_log") {
+        return { values: auditInsertValues }
+      }
+
+      return {
+        values: vi.fn().mockReturnValue({
+          returningAll: vi.fn().mockReturnValue({
+            executeTakeFirstOrThrow: vi.fn().mockResolvedValue({}),
+          }),
+          execute: vi.fn().mockResolvedValue([]),
+        }),
+      }
+    }),
+
+    deleteFrom: vi.fn().mockReturnValue({ where: deleteWhere1 }),
+  } as unknown as Kysely<Database>
+
+  return { db, auditInsertValues, deleteExecute }
+}
+
+async function buildTestApp(dbOpts: Parameters<typeof mockDb>[0] = {}) {
+  const app = Fastify({ logger: false })
+  const { db, auditInsertValues, deleteExecute } = mockDb(dbOpts)
+
+  await app.register(agentCredentialRoutes({ db, authConfig: DEV_AUTH_CONFIG }))
+
+  return { app, db, auditInsertValues, deleteExecute }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/credentials
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/credentials", () => {
+  it("binds a credential to an agent", async () => {
+    const { app, auditInsertValues } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/credentials`,
+      payload: { credentialId: CRED_ID },
+    })
+
+    expect(res.statusCode).toBe(201)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.binding).toBeDefined()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.binding.agentId).toBe(AGENT_ID)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.binding.credentialId).toBe(CRED_ID)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.binding.credentialClass).toBe("llm_provider")
+
+    // Verify audit log was written
+    expect(auditInsertValues).toHaveBeenCalled()
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const { app } = await buildTestApp({ agentExists: false })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/credentials`,
+      payload: { credentialId: CRED_ID },
+    })
+
+    expect(res.statusCode).toBe(404)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.json().message).toContain("Agent")
+  })
+
+  it("returns 404 when credential does not exist", async () => {
+    const { app } = await buildTestApp({ credential: null })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/credentials`,
+      payload: { credentialId: CRED_ID },
+    })
+
+    expect(res.statusCode).toBe(404)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.json().message).toContain("Credential")
+  })
+
+  it("returns 400 when credential is not active", async () => {
+    const { app } = await buildTestApp({
+      credential: makeCredential({ status: "expired" }),
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/credentials`,
+      payload: { credentialId: CRED_ID },
+    })
+
+    expect(res.statusCode).toBe(400)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.json().message).toContain("not active")
+  })
+
+  it("returns 403 when user does not own the credential", async () => {
+    const { app } = await buildTestApp({
+      credential: makeCredential({ user_account_id: "other-user-id" }),
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/credentials`,
+      payload: { credentialId: CRED_ID },
+    })
+
+    expect(res.statusCode).toBe(403)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.json().message).toContain("own credentials")
+  })
+
+  it("allows admin to bind tool_secret credential", async () => {
+    const { app } = await buildTestApp({
+      credential: makeCredential({
+        credential_class: "tool_specific",
+        user_account_id: "admin-user-id",
+      }),
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/credentials`,
+      payload: { credentialId: CRED_ID },
+    })
+
+    // Dev mode principal has admin role, so this should succeed
+    expect(res.statusCode).toBe(201)
+  })
+
+  it("returns 409 on duplicate binding", async () => {
+    const { app } = await buildTestApp({
+      existingBinding: makeBinding(),
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/credentials`,
+      payload: { credentialId: CRED_ID },
+    })
+
+    expect(res.statusCode).toBe(409)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.json().message).toContain("already bound")
+  })
+
+  it("validates required credentialId field", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/credentials`,
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: GET /agents/:agentId/credentials
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/:agentId/credentials", () => {
+  it("returns list of bindings with credential metadata", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/credentials`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.bindings).toBeDefined()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(Array.isArray(body.bindings)).toBe(true)
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const { app } = await buildTestApp({ agentExists: false })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/credentials`,
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: DELETE /agents/:agentId/credentials/:credentialId
+// ---------------------------------------------------------------------------
+
+describe("DELETE /agents/:agentId/credentials/:credentialId", () => {
+  it("unbinds a credential from an agent", async () => {
+    const { app, auditInsertValues } = await buildTestApp({
+      existingBinding: makeBinding(),
+    })
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/agents/${AGENT_ID}/credentials/${CRED_ID}`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ ok: true })
+
+    // Verify audit log was written
+    expect(auditInsertValues).toHaveBeenCalled()
+  })
+
+  it("returns 404 when binding does not exist", async () => {
+    const { app } = await buildTestApp({
+      existingBinding: null,
+    })
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/agents/${AGENT_ID}/credentials/${CRED_ID}`,
+    })
+
+    expect(res.statusCode).toBe(404)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.json().message).toContain("Binding")
+  })
+})

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -26,6 +26,7 @@ import { McpToolRouter } from "./mcp/tool-router.js"
 import { loadAuthConfig } from "./middleware/api-keys.js"
 import { BrowserObservationService } from "./observation/service.js"
 import { agentChannelRoutes } from "./routes/agent-channels.js"
+import { agentCredentialRoutes } from "./routes/agent-credentials.js"
 import { agentRoutes } from "./routes/agents.js"
 import { approvalRoutes } from "./routes/approval.js"
 import { authRoutes } from "./routes/auth.js"
@@ -196,6 +197,15 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
   await app.register(
     agentChannelRoutes({
       service: agentChannelService,
+      authConfig,
+      sessionService,
+    }),
+  )
+
+  // Register agent credential binding routes
+  await app.register(
+    agentCredentialRoutes({
+      db,
       authConfig,
       sessionService,
     }),

--- a/packages/control-plane/src/routes/agent-credentials.ts
+++ b/packages/control-plane/src/routes/agent-credentials.ts
@@ -1,0 +1,299 @@
+/**
+ * Agent Credential Binding Routes
+ *
+ * Endpoints for binding credentials to agents:
+ *   POST   /agents/:agentId/credentials              — bind a credential to an agent
+ *   GET    /agents/:agentId/credentials              — list agent's credential bindings
+ *   DELETE /agents/:agentId/credentials/:credentialId — unbind a credential from an agent
+ */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
+import type { Kysely } from "kysely"
+
+import type { SessionService } from "../auth/session-service.js"
+import type { Database } from "../db/types.js"
+import { createRequireAuth, type PreHandler } from "../middleware/auth.js"
+import type { AuthConfig, AuthenticatedRequest } from "../middleware/types.js"
+
+export interface AgentCredentialRouteDeps {
+  db: Kysely<Database>
+  authConfig: AuthConfig
+  sessionService?: SessionService
+}
+
+export function agentCredentialRoutes(deps: AgentCredentialRouteDeps) {
+  const { db, authConfig, sessionService } = deps
+
+  const requireAuth: PreHandler = createRequireAuth({
+    config: authConfig,
+    sessionService,
+  })
+
+  return function register(app: FastifyInstance): void {
+    /**
+     * POST /agents/:agentId/credentials — bind a credential to an agent
+     */
+    app.post<{
+      Params: { agentId: string }
+      Body: { credentialId: string }
+    }>(
+      "/agents/:agentId/credentials",
+      {
+        preHandler: [requireAuth],
+        schema: {
+          body: {
+            type: "object",
+            properties: {
+              credentialId: { type: "string", minLength: 1 },
+            },
+            required: ["credentialId"],
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{
+          Params: { agentId: string }
+          Body: { credentialId: string }
+        }>,
+        reply: FastifyReply,
+      ) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          reply.status(401).send({ error: "unauthorized" })
+          return
+        }
+
+        const { agentId } = request.params
+        const { credentialId } = request.body
+
+        // Verify agent exists
+        const agent = await db
+          .selectFrom("agent")
+          .select("id")
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          reply.status(404).send({ error: "not_found", message: "Agent not found" })
+          return
+        }
+
+        // Verify credential exists and is active
+        const credential = await db
+          .selectFrom("provider_credential")
+          .select([
+            "id",
+            "user_account_id",
+            "credential_class",
+            "provider",
+            "display_label",
+            "status",
+          ])
+          .where("id", "=", credentialId)
+          .executeTakeFirst()
+
+        if (!credential) {
+          reply.status(404).send({ error: "not_found", message: "Credential not found" })
+          return
+        }
+
+        if (credential.status !== "active") {
+          reply.status(400).send({
+            error: "bad_request",
+            message: "Credential is not active",
+          })
+          return
+        }
+
+        // Authorization: tool_secret requires admin role, others require ownership
+        if (credential.credential_class === "tool_specific") {
+          if (!principal.roles.includes("admin")) {
+            reply.status(403).send({
+              error: "forbidden",
+              message: "Only admins can bind tool_secret credentials",
+            })
+            return
+          }
+        } else {
+          if (credential.user_account_id !== principal.userId) {
+            reply.status(403).send({
+              error: "forbidden",
+              message: "You can only bind your own credentials",
+            })
+            return
+          }
+        }
+
+        // Check for duplicate binding
+        const existing = await db
+          .selectFrom("agent_credential_binding")
+          .select("id")
+          .where("agent_id", "=", agentId)
+          .where("provider_credential_id", "=", credentialId)
+          .executeTakeFirst()
+
+        if (existing) {
+          reply.status(409).send({
+            error: "conflict",
+            message: "Credential is already bound to this agent",
+          })
+          return
+        }
+
+        // Create the binding
+        const binding = await db
+          .insertInto("agent_credential_binding")
+          .values({
+            agent_id: agentId,
+            provider_credential_id: credentialId,
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow()
+
+        // Audit log
+        await db
+          .insertInto("credential_audit_log")
+          .values({
+            user_account_id: principal.userId,
+            provider_credential_id: credentialId,
+            event_type: "credential_bound",
+            provider: credential.provider,
+            details: { agent_id: agentId, binding_id: binding.id },
+          })
+          .execute()
+
+        reply.status(201).send({
+          binding: {
+            id: binding.id,
+            agentId: binding.agent_id,
+            credentialId: binding.provider_credential_id,
+            credentialClass: credential.credential_class,
+            provider: credential.provider,
+            displayLabel: credential.display_label,
+            grantedBy: principal.userId,
+            grantedAt: binding.created_at,
+          },
+        })
+      },
+    )
+
+    /**
+     * GET /agents/:agentId/credentials — list credential bindings for an agent
+     */
+    app.get<{ Params: { agentId: string } }>(
+      "/agents/:agentId/credentials",
+      {
+        preHandler: [requireAuth],
+      },
+      async (request: FastifyRequest<{ Params: { agentId: string } }>, reply: FastifyReply) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          reply.status(401).send({ error: "unauthorized" })
+          return
+        }
+
+        const { agentId } = request.params
+
+        // Verify agent exists
+        const agent = await db
+          .selectFrom("agent")
+          .select("id")
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          reply.status(404).send({ error: "not_found", message: "Agent not found" })
+          return
+        }
+
+        // Query bindings with joined credential metadata
+        const rows = await db
+          .selectFrom("agent_credential_binding")
+          .innerJoin(
+            "provider_credential",
+            "provider_credential.id",
+            "agent_credential_binding.provider_credential_id",
+          )
+          .select([
+            "agent_credential_binding.id",
+            "agent_credential_binding.provider_credential_id as credentialId",
+            "provider_credential.credential_class as credentialClass",
+            "provider_credential.provider",
+            "provider_credential.display_label as displayLabel",
+            "provider_credential.status",
+            "agent_credential_binding.created_at as grantedAt",
+          ])
+          .where("agent_credential_binding.agent_id", "=", agentId)
+          .orderBy("agent_credential_binding.created_at", "asc")
+          .execute()
+
+        return {
+          bindings: rows,
+        }
+      },
+    )
+
+    /**
+     * DELETE /agents/:agentId/credentials/:credentialId — unbind a credential from an agent
+     */
+    app.delete<{ Params: { agentId: string; credentialId: string } }>(
+      "/agents/:agentId/credentials/:credentialId",
+      {
+        preHandler: [requireAuth],
+      },
+      async (
+        request: FastifyRequest<{ Params: { agentId: string; credentialId: string } }>,
+        reply: FastifyReply,
+      ) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          reply.status(401).send({ error: "unauthorized" })
+          return
+        }
+
+        const { agentId, credentialId } = request.params
+
+        // Look up the binding to confirm it exists
+        const binding = await db
+          .selectFrom("agent_credential_binding")
+          .select(["id", "provider_credential_id"])
+          .where("agent_id", "=", agentId)
+          .where("provider_credential_id", "=", credentialId)
+          .executeTakeFirst()
+
+        if (!binding) {
+          reply.status(404).send({ error: "not_found", message: "Binding not found" })
+          return
+        }
+
+        // Look up the credential for audit metadata
+        const credential = await db
+          .selectFrom("provider_credential")
+          .select(["provider"])
+          .where("id", "=", credentialId)
+          .executeTakeFirst()
+
+        // Delete the binding
+        await db
+          .deleteFrom("agent_credential_binding")
+          .where("agent_id", "=", agentId)
+          .where("provider_credential_id", "=", credentialId)
+          .execute()
+
+        // Audit log
+        await db
+          .insertInto("credential_audit_log")
+          .values({
+            user_account_id: principal.userId,
+            provider_credential_id: credentialId,
+            event_type: "credential_unbound",
+            provider: credential?.provider ?? null,
+            details: { agent_id: agentId, binding_id: binding.id },
+          })
+          .execute()
+
+        return { ok: true }
+      },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Add `POST /agents/:agentId/credentials` to bind a credential to an agent (201 Created)
- Add `GET /agents/:agentId/credentials` to list bindings with joined credential metadata
- Add `DELETE /agents/:agentId/credentials/:credentialId` to unbind a credential
- Enforce ownership checks: user can only bind their own credentials
- Admin-only binding for `tool_secret` (credential_class = `tool_specific`)
- Return 409 Conflict on duplicate binding
- Emit `credential_bound` / `credential_unbound` audit log entries
- Register route plugin in `app.ts`
- 12 tests covering all endpoints, authorization, validation, and error cases

Closes #274
Depends on #272, #273

## Test plan
- [x] `POST` creates binding and returns 201 with binding metadata
- [x] `POST` returns 404 for missing agent or credential
- [x] `POST` returns 400 for inactive credential
- [x] `POST` returns 403 for non-owned credential
- [x] `POST` allows admin to bind tool_secret
- [x] `POST` returns 409 on duplicate binding
- [x] `POST` validates required `credentialId` field
- [x] `GET` returns list of bindings with credential metadata
- [x] `GET` returns 404 for missing agent
- [x] `DELETE` removes binding and returns `{ ok: true }`
- [x] `DELETE` returns 404 for missing binding
- [x] Audit log entries emitted for bind/unbind
- [x] All 890 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent-level credential binding to manage credential assignments per agent
  * Introduced MCP (Model Context Protocol) tool integration with health monitoring and routing
  * Added support for tool-specific credentials with admin management capabilities

* **Bug Fixes**
  * Enhanced credential validation for tool-secret operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->