### PR TITLE
feat(routes): agent tool binding CRUD routes + effective tools endpoint

### DIFF
--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -27,6 +27,7 @@ import { loadAuthConfig } from "./middleware/api-keys.js"
 import { BrowserObservationService } from "./observation/service.js"
 import { agentChannelRoutes } from "./routes/agent-channels.js"
 import { agentCredentialRoutes } from "./routes/agent-credentials.js"
+import { agentToolBindingRoutes } from "./routes/agent-tool-bindings.js"
 import { agentRoutes } from "./routes/agents.js"
 import { approvalRoutes } from "./routes/approval.js"
 import { authRoutes } from "./routes/auth.js"
@@ -205,6 +206,15 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
   // Register agent credential binding routes
   await app.register(
     agentCredentialRoutes({
+      db,
+      authConfig,
+      sessionService,
+    }),
+  )
+
+  // Register agent tool binding routes
+  await app.register(
+    agentToolBindingRoutes({
       db,
       authConfig,
       sessionService,

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -512,6 +512,72 @@ export type NewMcpServerTool = Insertable<McpServerToolTable>
 export type McpServerToolUpdate = Updateable<McpServerToolTable>
 
 // ---------------------------------------------------------------------------
+// Enum: tool_approval_policy
+// ---------------------------------------------------------------------------
+export type ToolApprovalPolicy = "auto" | "always_approve" | "conditional"
+
+// ---------------------------------------------------------------------------
+// Table: agent_tool_binding
+// ---------------------------------------------------------------------------
+export interface AgentToolBindingTable {
+  id: Generated<string>
+  agent_id: string
+  tool_ref: string
+  approval_policy: ColumnType<
+    ToolApprovalPolicy,
+    ToolApprovalPolicy | undefined,
+    ToolApprovalPolicy
+  >
+  approval_condition: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  rate_limit: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  cost_budget: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  data_scope: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  enabled: ColumnType<boolean, boolean | undefined, boolean>
+  created_at: ColumnType<Date, Date | undefined, never>
+  updated_at: ColumnType<Date, Date | undefined, Date>
+}
+
+export type AgentToolBinding = Selectable<AgentToolBindingTable>
+export type NewAgentToolBinding = Insertable<AgentToolBindingTable>
+export type AgentToolBindingUpdate = Updateable<AgentToolBindingTable>
+
+// ---------------------------------------------------------------------------
+// Table: capability_audit_log
+// ---------------------------------------------------------------------------
+export interface CapabilityAuditLogTable {
+  id: Generated<string>
+  agent_id: string
+  tool_ref: string
+  event_type: string
+  actor_user_id: string | null
+  details: ColumnType<
+    Record<string, unknown>,
+    Record<string, unknown> | undefined,
+    Record<string, unknown>
+  >
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
+export type CapabilityAuditLog = Selectable<CapabilityAuditLogTable>
+export type NewCapabilityAuditLog = Insertable<CapabilityAuditLogTable>
+
+// ---------------------------------------------------------------------------
 // Database interface — register all tables here.
 // ---------------------------------------------------------------------------
 export interface Database {
@@ -534,4 +600,6 @@ export interface Database {
   agent_credential_binding: AgentCredentialBindingTable
   mcp_server: McpServerTable
   mcp_server_tool: McpServerToolTable
+  agent_tool_binding: AgentToolBindingTable
+  capability_audit_log: CapabilityAuditLogTable
 }

--- a/packages/control-plane/src/routes/__tests__/agent-tool-bindings.test.ts
+++ b/packages/control-plane/src/routes/__tests__/agent-tool-bindings.test.ts
@@ -1,0 +1,566 @@
+import Fastify from "fastify"
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import type { Database } from "../../db/types.js"
+import type { AuthConfig } from "../../middleware/types.js"
+import { agentToolBindingRoutes } from "../agent-tool-bindings.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEV_AUTH_CONFIG: AuthConfig = {
+  requireAuth: false,
+  apiKeys: [],
+}
+
+const AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+const BINDING_ID = "bbbbbbbb-1111-2222-3333-444444444444"
+const MCP_SERVER_ID = "ssssssss-1111-2222-3333-444444444444"
+
+function makeBinding(overrides: Record<string, unknown> = {}) {
+  return {
+    id: BINDING_ID,
+    agent_id: AGENT_ID,
+    tool_ref: "mcp:slack:chat_postMessage",
+    approval_policy: "auto",
+    approval_condition: null,
+    rate_limit: null,
+    cost_budget: null,
+    data_scope: null,
+    enabled: true,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  }
+}
+
+/**
+ * Build a mock Kysely database that supports the query patterns used by
+ * agentToolBindingRoutes. Each table handler returns chainable methods.
+ */
+function mockDb(
+  opts: {
+    agentExists?: boolean
+    existingBinding?: Record<string, unknown> | null
+    insertedBinding?: Record<string, unknown>
+    bindings?: Record<string, unknown>[]
+    mcpServerExists?: boolean
+    mcpServerTools?: Record<string, unknown>[]
+    existingToolRefs?: string[]
+    bulkInsertedBindings?: Record<string, unknown>[]
+    updatedBinding?: Record<string, unknown>
+    mcpToolsMeta?: Record<string, unknown>[]
+  } = {},
+) {
+  const {
+    agentExists = true,
+    existingBinding = null,
+    insertedBinding = makeBinding(),
+    bindings = [makeBinding()],
+    mcpServerExists = true,
+    mcpServerTools = [{ qualified_name: "mcp:slack:chat_postMessage" }],
+    existingToolRefs = [],
+    bulkInsertedBindings = [makeBinding()],
+    updatedBinding = makeBinding(),
+    mcpToolsMeta = [],
+  } = opts
+
+  // Track insertInto calls for audit log verification
+  const auditInsertValues = vi.fn().mockReturnValue({
+    execute: vi.fn().mockResolvedValue([]),
+  })
+
+  // Track deleteFrom calls
+  const deleteExecute = vi.fn().mockResolvedValue([])
+  const deleteWhere2 = vi.fn().mockReturnValue({ execute: deleteExecute })
+  const deleteWhere1 = vi.fn().mockReturnValue({ where: deleteWhere2 })
+
+  /**
+   * Creates a universal chain object that supports all Kysely query methods.
+   * Each method returns the same chain, so any call order works.
+   */
+  function makeChain(result: unknown, resolveMode: "first" | "all" = "first") {
+    const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+    const executeTakeFirst = vi.fn().mockResolvedValue(result)
+    const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(result)
+    const execute = vi.fn().mockResolvedValue(resolveMode === "all" ? result : [result])
+
+    chain.where = vi.fn().mockImplementation(() => chain)
+    chain.orderBy = vi.fn().mockImplementation(() => chain)
+    chain.select = vi.fn().mockImplementation(() => chain)
+    chain.selectAll = vi.fn().mockImplementation(() => chain)
+    chain.innerJoin = vi.fn().mockImplementation(() => chain)
+    chain.executeTakeFirst = executeTakeFirst
+    chain.executeTakeFirstOrThrow = executeTakeFirstOrThrow
+    chain.execute = execute
+    return chain
+  }
+
+  // Track which selectFrom call count per table for disambiguation
+  const selectFromCounts: Record<string, number> = {}
+
+  const db = {
+    selectFrom: vi.fn().mockImplementation((table: string) => {
+      selectFromCounts[table] = (selectFromCounts[table] ?? 0) + 1
+      const count = selectFromCounts[table]
+
+      if (table === "agent") {
+        return makeChain(agentExists ? { id: AGENT_ID } : null)
+      }
+
+      if (table === "mcp_server") {
+        return makeChain(mcpServerExists ? { id: MCP_SERVER_ID, slug: "slack" } : null)
+      }
+
+      if (table === "mcp_server_tool") {
+        // For bulk: returns list of tools. For effective-tools: join chain
+        return makeChain(mcpToolsMeta.length > 0 ? mcpToolsMeta : mcpServerTools, "all")
+      }
+
+      if (table === "agent_tool_binding") {
+        if (count === 1) {
+          // 1st call: POST=duplicate check, GET=list, PUT/DELETE=single lookup, effective-tools=list enabled
+          // We need a chain that works for ALL patterns:
+          // - select("id").where().where().executeTakeFirst() — duplicate check
+          // - selectAll().where().orderBy().execute() — list
+          // - selectAll().where().where().executeTakeFirst() — single lookup
+          // - selectAll().where().where().orderBy().execute() — effective-tools list
+          const chain = makeChain(existingBinding)
+          // Override execute to return bindings array for list/effective routes
+          chain.execute = vi.fn().mockResolvedValue(bindings)
+          return chain
+        }
+        // 2nd call: for bulk, this is the existing tool refs check
+        return makeChain(
+          existingToolRefs.map((r) => ({ tool_ref: r })),
+          "all",
+        )
+      }
+
+      return makeChain(null)
+    }),
+
+    insertInto: vi.fn().mockImplementation((table: string) => {
+      if (table === "agent_tool_binding") {
+        const execute = vi.fn().mockResolvedValue(bulkInsertedBindings)
+        const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(insertedBinding)
+        const returningAll = vi.fn().mockReturnValue({ executeTakeFirstOrThrow, execute })
+        const values = vi.fn().mockReturnValue({ returningAll })
+        return { values }
+      }
+
+      if (table === "capability_audit_log") {
+        return { values: auditInsertValues }
+      }
+
+      return {
+        values: vi.fn().mockReturnValue({
+          returningAll: vi.fn().mockReturnValue({
+            executeTakeFirstOrThrow: vi.fn().mockResolvedValue({}),
+          }),
+          execute: vi.fn().mockResolvedValue([]),
+        }),
+      }
+    }),
+
+    updateTable: vi.fn().mockImplementation(() => {
+      const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(updatedBinding)
+      const returningAll = vi.fn().mockReturnValue({ executeTakeFirstOrThrow })
+      const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+      whereFn.mockReturnValue({ where: whereFn, returningAll })
+      const set = vi.fn().mockReturnValue({ where: whereFn })
+      return { set }
+    }),
+
+    deleteFrom: vi.fn().mockReturnValue({ where: deleteWhere1 }),
+  } as unknown as Kysely<Database>
+
+  return { db, auditInsertValues, deleteExecute }
+}
+
+async function buildTestApp(dbOpts: Parameters<typeof mockDb>[0] = {}) {
+  const app = Fastify({ logger: false })
+  const { db, auditInsertValues, deleteExecute } = mockDb(dbOpts)
+
+  await app.register(agentToolBindingRoutes({ db, authConfig: DEV_AUTH_CONFIG }))
+
+  return { app, db, auditInsertValues, deleteExecute }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/tool-bindings
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/tool-bindings", () => {
+  it("creates a tool binding", async () => {
+    const { app, auditInsertValues } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+      payload: { toolRef: "mcp:slack:chat_postMessage" },
+    })
+
+    expect(res.statusCode).toBe(201)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.binding).toBeDefined()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.binding.agentId).toBe(AGENT_ID)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.binding.toolRef).toBe("mcp:slack:chat_postMessage")
+
+    // Verify audit log was written
+    expect(auditInsertValues).toHaveBeenCalled()
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const { app } = await buildTestApp({ agentExists: false })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+      payload: { toolRef: "mcp:slack:chat_postMessage" },
+    })
+
+    expect(res.statusCode).toBe(404)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.json().message).toContain("Agent")
+  })
+
+  it("returns 409 on duplicate binding", async () => {
+    const { app } = await buildTestApp({
+      existingBinding: makeBinding(),
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+      payload: { toolRef: "mcp:slack:chat_postMessage" },
+    })
+
+    expect(res.statusCode).toBe(409)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.json().message).toContain("already bound")
+  })
+
+  it("validates required toolRef field", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+
+  it("accepts optional policy fields", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+      payload: {
+        toolRef: "web_search",
+        approvalPolicy: "always_approve",
+        rateLimit: { maxCalls: 100, windowSeconds: 3600 },
+        dataScope: { readOnly: true },
+      },
+    })
+
+    expect(res.statusCode).toBe(201)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: GET /agents/:agentId/tool-bindings
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/:agentId/tool-bindings", () => {
+  it("returns list of bindings", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.bindings).toBeDefined()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(Array.isArray(body.bindings)).toBe(true)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.total).toBeDefined()
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const { app } = await buildTestApp({ agentExists: false })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+
+  it("supports enabled filter", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/tool-bindings?enabled=true`,
+    })
+
+    expect(res.statusCode).toBe(200)
+  })
+
+  it("supports category filter", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/tool-bindings?category=communication`,
+    })
+
+    expect(res.statusCode).toBe(200)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: PUT /agents/:agentId/tool-bindings/:bindingId
+// ---------------------------------------------------------------------------
+
+describe("PUT /agents/:agentId/tool-bindings/:bindingId", () => {
+  it("updates a tool binding", async () => {
+    const updated = makeBinding({ approval_policy: "always_approve", enabled: false })
+    const { app } = await buildTestApp({
+      existingBinding: makeBinding(),
+      updatedBinding: updated,
+    })
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/agents/${AGENT_ID}/tool-bindings/${BINDING_ID}`,
+      payload: { approvalPolicy: "always_approve", enabled: false },
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.binding).toBeDefined()
+  })
+
+  it("returns 404 when binding does not exist", async () => {
+    const { app } = await buildTestApp({
+      existingBinding: null,
+    })
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/agents/${AGENT_ID}/tool-bindings/${BINDING_ID}`,
+      payload: { enabled: false },
+    })
+
+    expect(res.statusCode).toBe(404)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.json().message).toContain("Binding")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: DELETE /agents/:agentId/tool-bindings/:bindingId
+// ---------------------------------------------------------------------------
+
+describe("DELETE /agents/:agentId/tool-bindings/:bindingId", () => {
+  it("removes a tool binding and returns 204", async () => {
+    const { app, auditInsertValues } = await buildTestApp({
+      existingBinding: makeBinding(),
+    })
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/agents/${AGENT_ID}/tool-bindings/${BINDING_ID}`,
+    })
+
+    expect(res.statusCode).toBe(204)
+
+    // Verify audit log was written
+    expect(auditInsertValues).toHaveBeenCalled()
+  })
+
+  it("returns 404 when binding does not exist", async () => {
+    const { app } = await buildTestApp({
+      existingBinding: null,
+    })
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/agents/${AGENT_ID}/tool-bindings/${BINDING_ID}`,
+    })
+
+    expect(res.statusCode).toBe(404)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.json().message).toContain("Binding")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/tool-bindings/bulk
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/tool-bindings/bulk", () => {
+  it("bulk-creates bindings from MCP server", async () => {
+    const binding1 = makeBinding({ tool_ref: "mcp:slack:chat_postMessage" })
+    const { app, auditInsertValues } = await buildTestApp({
+      bindings: [],
+      bulkInsertedBindings: [binding1],
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings/bulk`,
+      payload: { mcpServerId: MCP_SERVER_ID },
+    })
+
+    expect(res.statusCode).toBe(201)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.created).toBeGreaterThanOrEqual(0)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.bindings).toBeDefined()
+
+    expect(auditInsertValues).toHaveBeenCalled()
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const { app } = await buildTestApp({ agentExists: false })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings/bulk`,
+      payload: { mcpServerId: MCP_SERVER_ID },
+    })
+
+    expect(res.statusCode).toBe(404)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.json().message).toContain("Agent")
+  })
+
+  it("returns 404 when MCP server does not exist", async () => {
+    const { app } = await buildTestApp({ mcpServerExists: false })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings/bulk`,
+      payload: { mcpServerId: MCP_SERVER_ID },
+    })
+
+    expect(res.statusCode).toBe(404)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.json().message).toContain("MCP server")
+  })
+
+  it("skips duplicate bindings during bulk create", async () => {
+    const { app } = await buildTestApp({
+      existingToolRefs: ["mcp:slack:chat_postMessage"],
+      mcpServerTools: [{ qualified_name: "mcp:slack:chat_postMessage" }],
+      bulkInsertedBindings: [],
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings/bulk`,
+      payload: { mcpServerId: MCP_SERVER_ID },
+    })
+
+    // Should succeed with 0 created (all duplicates)
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(res.json().created).toBe(0)
+  })
+
+  it("validates required mcpServerId field", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings/bulk`,
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: GET /agents/:agentId/effective-tools
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/:agentId/effective-tools", () => {
+  it("returns effective tool list", async () => {
+    const { app } = await buildTestApp({
+      bindings: [makeBinding({ tool_ref: "web_search" })],
+    })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/effective-tools`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.tools).toBeDefined()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.assembledAt).toBeDefined()
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const { app } = await buildTestApp({ agentExists: false })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/effective-tools`,
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+
+  it("includes MCP tool metadata when available", async () => {
+    const { app } = await buildTestApp({
+      bindings: [makeBinding({ tool_ref: "mcp:slack:chat_postMessage" })],
+      mcpToolsMeta: [
+        {
+          qualified_name: "mcp:slack:chat_postMessage",
+          name: "chat_postMessage",
+          description: "Post a message to Slack",
+          input_schema: { type: "object" },
+          serverStatus: "ACTIVE",
+        },
+      ],
+    })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/effective-tools`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.tools).toBeDefined()
+  })
+})

--- a/packages/control-plane/src/routes/agent-tool-bindings.ts
+++ b/packages/control-plane/src/routes/agent-tool-bindings.ts
@@ -1,0 +1,645 @@
+/**
+ * Agent Tool Binding Routes
+ *
+ * Endpoints for managing tool bindings on agents:
+ *   POST   /agents/:agentId/tool-bindings              — create a tool binding
+ *   GET    /agents/:agentId/tool-bindings              — list tool bindings
+ *   PUT    /agents/:agentId/tool-bindings/:bindingId   — update a tool binding
+ *   DELETE /agents/:agentId/tool-bindings/:bindingId   — remove a tool binding
+ *   POST   /agents/:agentId/tool-bindings/bulk         — bulk-create from MCP server
+ *   GET    /agents/:agentId/effective-tools            — resolved effective tool set
+ */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
+import type { Kysely } from "kysely"
+
+import type { SessionService } from "../auth/session-service.js"
+import type { Database, ToolApprovalPolicy } from "../db/types.js"
+import { createRequireAuth, type PreHandler } from "../middleware/auth.js"
+import type { AuthConfig, AuthenticatedRequest } from "../middleware/types.js"
+
+export interface AgentToolBindingRouteDeps {
+  db: Kysely<Database>
+  authConfig: AuthConfig
+  sessionService?: SessionService
+}
+
+interface CreateBindingBody {
+  toolRef: string
+  approvalPolicy?: ToolApprovalPolicy
+  approvalCondition?: Record<string, unknown>
+  rateLimit?: Record<string, unknown>
+  costBudget?: Record<string, unknown>
+  dataScope?: Record<string, unknown>
+}
+
+interface UpdateBindingBody {
+  approvalPolicy?: ToolApprovalPolicy
+  approvalCondition?: Record<string, unknown>
+  rateLimit?: Record<string, unknown>
+  costBudget?: Record<string, unknown>
+  dataScope?: Record<string, unknown>
+  enabled?: boolean
+}
+
+interface BulkCreateBody {
+  mcpServerId: string
+  toolRefs?: string[]
+  approvalPolicy?: ToolApprovalPolicy
+}
+
+function toBindingResponse(row: Record<string, unknown>) {
+  return {
+    id: row.id,
+    agentId: row.agent_id,
+    toolRef: row.tool_ref,
+    approvalPolicy: row.approval_policy,
+    approvalCondition: row.approval_condition ?? null,
+    rateLimit: row.rate_limit ?? null,
+    costBudget: row.cost_budget ?? null,
+    dataScope: row.data_scope ?? null,
+    enabled: row.enabled,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+export function agentToolBindingRoutes(deps: AgentToolBindingRouteDeps) {
+  const { db, authConfig, sessionService } = deps
+
+  const requireAuth: PreHandler = createRequireAuth({
+    config: authConfig,
+    sessionService,
+  })
+
+  return function register(app: FastifyInstance): void {
+    /**
+     * POST /agents/:agentId/tool-bindings — create a tool binding
+     */
+    app.post<{
+      Params: { agentId: string }
+      Body: CreateBindingBody
+    }>(
+      "/agents/:agentId/tool-bindings",
+      {
+        preHandler: [requireAuth],
+        schema: {
+          body: {
+            type: "object",
+            properties: {
+              toolRef: { type: "string", minLength: 1 },
+              approvalPolicy: {
+                type: "string",
+                enum: ["auto", "always_approve", "conditional"],
+              },
+              approvalCondition: { type: "object" },
+              rateLimit: { type: "object" },
+              costBudget: { type: "object" },
+              dataScope: { type: "object" },
+            },
+            required: ["toolRef"],
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{
+          Params: { agentId: string }
+          Body: CreateBindingBody
+        }>,
+        reply: FastifyReply,
+      ) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          reply.status(401).send({ error: "unauthorized" })
+          return
+        }
+
+        const { agentId } = request.params
+        const { toolRef, approvalPolicy, approvalCondition, rateLimit, costBudget, dataScope } =
+          request.body
+
+        // Verify agent exists
+        const agent = await db
+          .selectFrom("agent")
+          .select("id")
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          reply.status(404).send({ error: "not_found", message: "Agent not found" })
+          return
+        }
+
+        // Check for duplicate binding
+        const existing = await db
+          .selectFrom("agent_tool_binding")
+          .select("id")
+          .where("agent_id", "=", agentId)
+          .where("tool_ref", "=", toolRef)
+          .executeTakeFirst()
+
+        if (existing) {
+          reply.status(409).send({
+            error: "conflict",
+            message: "Tool is already bound to this agent",
+          })
+          return
+        }
+
+        // Create the binding
+        const binding = await db
+          .insertInto("agent_tool_binding")
+          .values({
+            agent_id: agentId,
+            tool_ref: toolRef,
+            approval_policy: approvalPolicy,
+            approval_condition: approvalCondition ?? null,
+            rate_limit: rateLimit ?? null,
+            cost_budget: costBudget ?? null,
+            data_scope: dataScope ?? null,
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow()
+
+        // Audit log
+        await db
+          .insertInto("capability_audit_log")
+          .values({
+            agent_id: agentId,
+            tool_ref: toolRef,
+            event_type: "binding_created",
+            actor_user_id: principal.userId,
+            details: { binding_id: binding.id },
+          })
+          .execute()
+
+        reply.status(201).send({
+          binding: toBindingResponse(binding as unknown as Record<string, unknown>),
+        })
+      },
+    )
+
+    /**
+     * GET /agents/:agentId/tool-bindings — list tool bindings
+     */
+    app.get<{
+      Params: { agentId: string }
+      Querystring: { enabled?: string; category?: string }
+    }>(
+      "/agents/:agentId/tool-bindings",
+      {
+        preHandler: [requireAuth],
+      },
+      async (
+        request: FastifyRequest<{
+          Params: { agentId: string }
+          Querystring: { enabled?: string; category?: string }
+        }>,
+        reply: FastifyReply,
+      ) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          reply.status(401).send({ error: "unauthorized" })
+          return
+        }
+
+        const { agentId } = request.params
+        const { enabled, category } = request.query
+
+        // Verify agent exists
+        const agent = await db
+          .selectFrom("agent")
+          .select("id")
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          reply.status(404).send({ error: "not_found", message: "Agent not found" })
+          return
+        }
+
+        let query = db.selectFrom("agent_tool_binding").selectAll().where("agent_id", "=", agentId)
+
+        if (enabled !== undefined) {
+          query = query.where("enabled", "=", enabled === "true")
+        }
+
+        if (category) {
+          // Filter by tool_ref prefix pattern for category (e.g. "mcp:slack:" for communication)
+          query = query.where("tool_ref", "like", `%${category}%`)
+        }
+
+        const rows = await query.orderBy("created_at", "asc").execute()
+
+        return {
+          bindings: rows.map((r) => toBindingResponse(r as unknown as Record<string, unknown>)),
+          total: rows.length,
+        }
+      },
+    )
+
+    /**
+     * PUT /agents/:agentId/tool-bindings/:bindingId — update a tool binding
+     */
+    app.put<{
+      Params: { agentId: string; bindingId: string }
+      Body: UpdateBindingBody
+    }>(
+      "/agents/:agentId/tool-bindings/:bindingId",
+      {
+        preHandler: [requireAuth],
+        schema: {
+          body: {
+            type: "object",
+            properties: {
+              approvalPolicy: {
+                type: "string",
+                enum: ["auto", "always_approve", "conditional"],
+              },
+              approvalCondition: { type: "object" },
+              rateLimit: { type: "object" },
+              costBudget: { type: "object" },
+              dataScope: { type: "object" },
+              enabled: { type: "boolean" },
+            },
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{
+          Params: { agentId: string; bindingId: string }
+          Body: UpdateBindingBody
+        }>,
+        reply: FastifyReply,
+      ) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          reply.status(401).send({ error: "unauthorized" })
+          return
+        }
+
+        const { agentId, bindingId } = request.params
+
+        // Verify binding exists and belongs to agent
+        const existing = await db
+          .selectFrom("agent_tool_binding")
+          .selectAll()
+          .where("id", "=", bindingId)
+          .where("agent_id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!existing) {
+          reply.status(404).send({ error: "not_found", message: "Binding not found" })
+          return
+        }
+
+        const { approvalPolicy, approvalCondition, rateLimit, costBudget, dataScope, enabled } =
+          request.body
+
+        const updates: Record<string, unknown> = { updated_at: new Date() }
+        if (approvalPolicy !== undefined) updates.approval_policy = approvalPolicy
+        if (approvalCondition !== undefined) updates.approval_condition = approvalCondition
+        if (rateLimit !== undefined) updates.rate_limit = rateLimit
+        if (costBudget !== undefined) updates.cost_budget = costBudget
+        if (dataScope !== undefined) updates.data_scope = dataScope
+        if (enabled !== undefined) updates.enabled = enabled
+
+        const updated = await db
+          .updateTable("agent_tool_binding")
+          .set(updates)
+          .where("id", "=", bindingId)
+          .where("agent_id", "=", agentId)
+          .returningAll()
+          .executeTakeFirstOrThrow()
+
+        reply.status(200).send({
+          binding: toBindingResponse(updated as unknown as Record<string, unknown>),
+        })
+      },
+    )
+
+    /**
+     * DELETE /agents/:agentId/tool-bindings/:bindingId — remove a tool binding
+     */
+    app.delete<{
+      Params: { agentId: string; bindingId: string }
+    }>(
+      "/agents/:agentId/tool-bindings/:bindingId",
+      {
+        preHandler: [requireAuth],
+      },
+      async (
+        request: FastifyRequest<{
+          Params: { agentId: string; bindingId: string }
+        }>,
+        reply: FastifyReply,
+      ) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          reply.status(401).send({ error: "unauthorized" })
+          return
+        }
+
+        const { agentId, bindingId } = request.params
+
+        // Verify binding exists
+        const binding = await db
+          .selectFrom("agent_tool_binding")
+          .select(["id", "tool_ref"])
+          .where("id", "=", bindingId)
+          .where("agent_id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!binding) {
+          reply.status(404).send({ error: "not_found", message: "Binding not found" })
+          return
+        }
+
+        // Delete the binding
+        await db
+          .deleteFrom("agent_tool_binding")
+          .where("id", "=", bindingId)
+          .where("agent_id", "=", agentId)
+          .execute()
+
+        // Audit log
+        await db
+          .insertInto("capability_audit_log")
+          .values({
+            agent_id: agentId,
+            tool_ref: binding.tool_ref,
+            event_type: "binding_removed",
+            actor_user_id: principal.userId,
+            details: { binding_id: bindingId },
+          })
+          .execute()
+
+        reply.status(204).send()
+      },
+    )
+
+    /**
+     * POST /agents/:agentId/tool-bindings/bulk — bulk-create from MCP server
+     */
+    app.post<{
+      Params: { agentId: string }
+      Body: BulkCreateBody
+    }>(
+      "/agents/:agentId/tool-bindings/bulk",
+      {
+        preHandler: [requireAuth],
+        schema: {
+          body: {
+            type: "object",
+            properties: {
+              mcpServerId: { type: "string", minLength: 1 },
+              toolRefs: { type: "array", items: { type: "string" } },
+              approvalPolicy: {
+                type: "string",
+                enum: ["auto", "always_approve", "conditional"],
+              },
+            },
+            required: ["mcpServerId"],
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{
+          Params: { agentId: string }
+          Body: BulkCreateBody
+        }>,
+        reply: FastifyReply,
+      ) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          reply.status(401).send({ error: "unauthorized" })
+          return
+        }
+
+        const { agentId } = request.params
+        const { mcpServerId, toolRefs, approvalPolicy } = request.body
+
+        // Verify agent exists
+        const agent = await db
+          .selectFrom("agent")
+          .select("id")
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          reply.status(404).send({ error: "not_found", message: "Agent not found" })
+          return
+        }
+
+        // Verify MCP server exists
+        const server = await db
+          .selectFrom("mcp_server")
+          .select(["id", "slug"])
+          .where("id", "=", mcpServerId)
+          .executeTakeFirst()
+
+        if (!server) {
+          reply.status(404).send({ error: "not_found", message: "MCP server not found" })
+          return
+        }
+
+        // Fetch tools from the MCP server
+        let toolQuery = db
+          .selectFrom("mcp_server_tool")
+          .select(["qualified_name"])
+          .where("mcp_server_id", "=", mcpServerId)
+
+        if (toolRefs && toolRefs.length > 0) {
+          toolQuery = toolQuery.where("qualified_name", "in", toolRefs)
+        }
+
+        const tools = await toolQuery.execute()
+
+        if (tools.length === 0) {
+          reply.status(200).send({ created: 0, bindings: [] })
+          return
+        }
+
+        // Get existing bindings to avoid duplicates
+        const existingBindings = await db
+          .selectFrom("agent_tool_binding")
+          .select("tool_ref")
+          .where("agent_id", "=", agentId)
+          .where(
+            "tool_ref",
+            "in",
+            tools.map((t) => t.qualified_name),
+          )
+          .execute()
+
+        const existingRefs = new Set(existingBindings.map((b) => b.tool_ref))
+        const newToolRefs = tools
+          .map((t) => t.qualified_name)
+          .filter((ref) => !existingRefs.has(ref))
+
+        if (newToolRefs.length === 0) {
+          reply.status(200).send({ created: 0, bindings: [] })
+          return
+        }
+
+        // Bulk insert
+        const values = newToolRefs.map((ref) => ({
+          agent_id: agentId,
+          tool_ref: ref,
+          approval_policy: approvalPolicy ?? ("auto" as const),
+        }))
+
+        const bindings = await db
+          .insertInto("agent_tool_binding")
+          .values(values)
+          .returningAll()
+          .execute()
+
+        // Audit log
+        await db
+          .insertInto("capability_audit_log")
+          .values(
+            bindings.map((b) => ({
+              agent_id: agentId,
+              tool_ref: b.tool_ref,
+              event_type: "binding_created" as const,
+              actor_user_id: principal.userId,
+              details: { binding_id: b.id, bulk: true, mcp_server_id: mcpServerId },
+            })),
+          )
+          .execute()
+
+        reply.status(201).send({
+          created: bindings.length,
+          bindings: bindings.map((b) => toBindingResponse(b as unknown as Record<string, unknown>)),
+        })
+      },
+    )
+
+    /**
+     * GET /agents/:agentId/effective-tools — resolved effective tool set
+     */
+    app.get<{
+      Params: { agentId: string }
+    }>(
+      "/agents/:agentId/effective-tools",
+      {
+        preHandler: [requireAuth],
+      },
+      async (
+        request: FastifyRequest<{
+          Params: { agentId: string }
+        }>,
+        reply: FastifyReply,
+      ) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          reply.status(401).send({ error: "unauthorized" })
+          return
+        }
+
+        const { agentId } = request.params
+
+        // Verify agent exists
+        const agent = await db
+          .selectFrom("agent")
+          .select("id")
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          reply.status(404).send({ error: "not_found", message: "Agent not found" })
+          return
+        }
+
+        // Get all enabled bindings
+        const bindings = await db
+          .selectFrom("agent_tool_binding")
+          .selectAll()
+          .where("agent_id", "=", agentId)
+          .where("enabled", "=", true)
+          .orderBy("created_at", "asc")
+          .execute()
+
+        // Resolve MCP tool metadata for MCP-backed bindings
+        const mcpToolRefs = bindings
+          .filter((b) => b.tool_ref.startsWith("mcp:"))
+          .map((b) => b.tool_ref)
+
+        let mcpToolMap = new Map<
+          string,
+          { name: string; description: string | null; inputSchema: Record<string, unknown> }
+        >()
+
+        if (mcpToolRefs.length > 0) {
+          const mcpTools = await db
+            .selectFrom("mcp_server_tool")
+            .innerJoin("mcp_server", "mcp_server.id", "mcp_server_tool.mcp_server_id")
+            .select([
+              "mcp_server_tool.qualified_name",
+              "mcp_server_tool.name",
+              "mcp_server_tool.description",
+              "mcp_server_tool.input_schema",
+              "mcp_server.status as serverStatus",
+            ])
+            .where("mcp_server_tool.qualified_name", "in", mcpToolRefs)
+            .execute()
+
+          for (const tool of mcpTools) {
+            // Exclude tools from non-ACTIVE servers
+            if (tool.serverStatus === "ACTIVE") {
+              mcpToolMap.set(tool.qualified_name, {
+                name: tool.name,
+                description: tool.description,
+                inputSchema: tool.input_schema,
+              })
+            }
+          }
+        }
+
+        const tools = bindings
+          .map((b) => {
+            const base = {
+              toolRef: b.tool_ref,
+              bindingId: b.id,
+              approvalPolicy: b.approval_policy,
+              approvalCondition: b.approval_condition,
+              rateLimit: b.rate_limit,
+              costBudget: b.cost_budget,
+              dataScope: b.data_scope,
+            }
+
+            const mcpMeta = mcpToolMap.get(b.tool_ref)
+            if (mcpMeta) {
+              return {
+                ...base,
+                name: mcpMeta.name,
+                description: mcpMeta.description,
+                inputSchema: mcpMeta.inputSchema,
+              }
+            }
+
+            // Built-in tool — just return the binding info
+            return {
+              ...base,
+              name: b.tool_ref,
+              description: null,
+              inputSchema: null,
+            }
+          })
+          .filter((t) => {
+            // Exclude MCP tools whose server is not active (not in mcpToolMap)
+            if (t.toolRef.startsWith("mcp:") && !mcpToolMap.has(t.toolRef)) {
+              return false
+            }
+            return true
+          })
+
+        return {
+          tools,
+          assembledAt: new Date().toISOString(),
+        }
+      },
+    )
+  }
+}


### PR DESCRIPTION
Closes #305

## Routes
- `POST /agents/:agentId/tool-bindings` — create binding
- `GET /agents/:agentId/tool-bindings` — list with filters
- `PUT /agents/:agentId/tool-bindings/:bindingId` — update
- `DELETE /agents/:agentId/tool-bindings/:bindingId` — remove (204)
- `POST /agents/:agentId/tool-bindings/bulk` — bulk create from MCP server
- `GET /agents/:agentId/effective-tools` — resolved tool list for runtime

Depends on #343 (migration 018)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent tool binding management with create, read, update, and delete operations
  * Support for tool approval policies (auto, always-approve, conditional)
  * Bulk tool binding creation from MCP servers
  * Rate limiting, cost budgeting, and data scope management per binding
  * Effective tools endpoint showing consolidated tool list with MCP server metadata
  * Audit logging for tool binding operations

* **Tests**
  * Added comprehensive test coverage for agent tool binding routes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->