### PR TITLE
feat(db): migrate mcp_server.agent_scope → agent_tool_binding rows

### DIFF
--- a/packages/control-plane/migrations/019_migrate_agent_scope.down.sql
+++ b/packages/control-plane/migrations/019_migrate_agent_scope.down.sql
@@ -1,0 +1,36 @@
+-- 019 down: Restore mcp_server.agent_scope from agent_tool_binding rows
+--           and remove bindings that were created by migration 019.
+
+-- 1. Restore agent_scope arrays on mcp_server from bindings that
+--    reference tools belonging to each server.
+UPDATE mcp_server s
+SET agent_scope  = sub.agent_ids,
+    updated_at   = now()
+FROM (
+  SELECT
+    t.mcp_server_id,
+    jsonb_agg(DISTINCT b.agent_id::text) AS agent_ids
+  FROM agent_tool_binding b
+  JOIN mcp_server_tool t ON t.qualified_name = b.tool_ref
+  GROUP BY t.mcp_server_id
+) sub
+WHERE s.id = sub.mcp_server_id;
+
+-- 2. Delete MCP-originated bindings (tool_ref matches an mcp_server_tool)
+DELETE FROM agent_tool_binding b
+USING mcp_server_tool t
+WHERE b.tool_ref = t.qualified_name;
+
+-- 3. Delete skill_config-originated bindings (tool_ref found in the
+--    agent's skill_config.allowedTools array)
+DELETE FROM agent_tool_binding b
+WHERE EXISTS (
+  SELECT 1
+  FROM agent a
+  WHERE a.id = b.agent_id
+    AND a.skill_config ? 'allowedTools'
+    AND jsonb_typeof(a.skill_config -> 'allowedTools') = 'array'
+    AND b.tool_ref IN (
+      SELECT jsonb_array_elements_text(a.skill_config -> 'allowedTools')
+    )
+);

--- a/packages/control-plane/migrations/019_migrate_agent_scope.up.sql
+++ b/packages/control-plane/migrations/019_migrate_agent_scope.up.sql
@@ -1,0 +1,37 @@
+-- 019: Migrate mcp_server.agent_scope → agent_tool_binding rows.
+--      Also migrates agent skill_config.allowedTools → agent_tool_binding.
+--      Idempotent: ON CONFLICT DO NOTHING on all inserts.
+--      Part of the agent capabilities epic (#264), Phase 2 (#306).
+
+-- 1. Migrate mcp_server.agent_scope → agent_tool_binding
+--    For each MCP server with a non-empty agent_scope array, create a
+--    binding for every tool on that server for each agent in scope.
+INSERT INTO agent_tool_binding (agent_id, tool_ref, approval_policy)
+SELECT
+  scope_agent.agent_id::uuid,
+  t.qualified_name,
+  'auto'::tool_approval_policy
+FROM mcp_server s
+CROSS JOIN LATERAL jsonb_array_elements_text(s.agent_scope) AS scope_agent(agent_id)
+JOIN mcp_server_tool t ON t.mcp_server_id = s.id
+WHERE jsonb_array_length(s.agent_scope) > 0
+ON CONFLICT (agent_id, tool_ref) DO NOTHING;
+
+-- 2. Migrate agent skill_config.allowedTools → agent_tool_binding
+INSERT INTO agent_tool_binding (agent_id, tool_ref, approval_policy)
+SELECT
+  a.id,
+  tool_name.value,
+  'auto'::tool_approval_policy
+FROM agent a
+CROSS JOIN LATERAL jsonb_array_elements_text(a.skill_config -> 'allowedTools') AS tool_name(value)
+WHERE a.skill_config ? 'allowedTools'
+  AND jsonb_typeof(a.skill_config -> 'allowedTools') = 'array'
+  AND jsonb_array_length(a.skill_config -> 'allowedTools') > 0
+ON CONFLICT (agent_id, tool_ref) DO NOTHING;
+
+-- 3. Clear migrated agent_scope arrays
+UPDATE mcp_server
+SET agent_scope  = '[]'::jsonb,
+    updated_at   = now()
+WHERE jsonb_array_length(agent_scope) > 0;


### PR DESCRIPTION
Closes #306

Data migration converting legacy `mcp_server.agent_scope` arrays and `skill_config.allowedTools` into explicit `agent_tool_binding` rows.

Depends on #343 (migration 018)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database migration scripts to reorganize agent configuration storage, with a corresponding rollback migration for reverting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->