### PR TITLE
feat(lifecycle): output validation — memory writes + checkpoint integrity (#266-T3)

### DIFF
--- a/packages/control-plane/src/lifecycle/__tests__/output-validator.test.ts
+++ b/packages/control-plane/src/lifecycle/__tests__/output-validator.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  computeCheckpointCrc,
+  DEFAULT_CHECKPOINT_MAX_BYTES,
+  DEFAULT_MEMORY_MAX_CHARS,
+  validateCheckpointWrite,
+  validateMemoryWrite,
+  verifyCheckpointIntegrity,
+} from "../output-validator.js"
+
+// ---------------------------------------------------------------------------
+// validateMemoryWrite
+// ---------------------------------------------------------------------------
+
+describe("validateMemoryWrite", () => {
+  it("accepts content within the default character limit", () => {
+    const result = validateMemoryWrite("Hello, world!")
+
+    expect(result.valid).toBe(true)
+    expect(result.sanitized).toBe("Hello, world!")
+    expect(result.violations).toHaveLength(0)
+  })
+
+  it("accepts content at exactly the default limit", () => {
+    const content = "a".repeat(DEFAULT_MEMORY_MAX_CHARS)
+    const result = validateMemoryWrite(content)
+
+    expect(result.valid).toBe(true)
+    expect(result.violations).toHaveLength(0)
+  })
+
+  it("rejects content exceeding the default 8,000 char limit", () => {
+    const content = "a".repeat(DEFAULT_MEMORY_MAX_CHARS + 1)
+    const result = validateMemoryWrite(content)
+
+    expect(result.valid).toBe(false)
+    expect(result.violations).toContain(`exceeds_max_chars:${DEFAULT_MEMORY_MAX_CHARS}`)
+  })
+
+  it("respects a custom character limit", () => {
+    const result = validateMemoryWrite("abcdef", 5)
+
+    expect(result.valid).toBe(false)
+    expect(result.violations).toContain("exceeds_max_chars:5")
+  })
+
+  it("rejects binary content containing null bytes", () => {
+    const result = validateMemoryWrite("hello\x00world")
+
+    expect(result.valid).toBe(false)
+    expect(result.violations).toContain("binary_content_detected")
+  })
+
+  it("rejects binary content with control characters", () => {
+    const result = validateMemoryWrite("data\x01\x02\x03")
+
+    expect(result.valid).toBe(false)
+    expect(result.violations).toContain("binary_content_detected")
+  })
+
+  it("allows tabs, newlines, and carriage returns", () => {
+    const result = validateMemoryWrite("line1\nline2\r\n\ttabbed")
+
+    expect(result.valid).toBe(true)
+    expect(result.violations).toHaveLength(0)
+  })
+
+  it("reports multiple violations simultaneously", () => {
+    const content = "\x00" + "a".repeat(DEFAULT_MEMORY_MAX_CHARS + 1)
+    const result = validateMemoryWrite(content)
+
+    expect(result.valid).toBe(false)
+    expect(result.violations).toContain("binary_content_detected")
+    expect(result.violations).toContain(`exceeds_max_chars:${DEFAULT_MEMORY_MAX_CHARS}`)
+    expect(result.violations).toHaveLength(2)
+  })
+
+  it("accepts an empty string", () => {
+    const result = validateMemoryWrite("")
+
+    expect(result.valid).toBe(true)
+    expect(result.violations).toHaveLength(0)
+  })
+
+  it("returns the original content as sanitized", () => {
+    const content = "preserve me"
+    const result = validateMemoryWrite(content)
+
+    expect(result.sanitized).toBe(content)
+  })
+
+  it("default max is 8,000 characters", () => {
+    expect(DEFAULT_MEMORY_MAX_CHARS).toBe(8_000)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateCheckpointWrite
+// ---------------------------------------------------------------------------
+
+describe("validateCheckpointWrite", () => {
+  it("accepts checkpoint data within the default 256 KB limit", () => {
+    const data = { step: 1, state: "running" }
+    const result = validateCheckpointWrite(data)
+
+    expect(result.valid).toBe(true)
+    expect(result.sanitized).toEqual(data)
+    expect(result.violations).toHaveLength(0)
+    expect(typeof result.crc).toBe("number")
+  })
+
+  it("computes a CRC32 for valid checkpoints", () => {
+    const data = { step: 1 }
+    const result = validateCheckpointWrite(data)
+
+    expect(result.crc).toBe(computeCheckpointCrc(data))
+  })
+
+  it("rejects checkpoint data exceeding the default byte limit", () => {
+    // Build an object larger than 256 KB
+    const data: Record<string, unknown> = {}
+    const bigString = "x".repeat(DEFAULT_CHECKPOINT_MAX_BYTES)
+    data.payload = bigString
+
+    const result = validateCheckpointWrite(data)
+
+    expect(result.valid).toBe(false)
+    expect(result.violations).toContain(`exceeds_max_bytes:${DEFAULT_CHECKPOINT_MAX_BYTES}`)
+  })
+
+  it("respects a custom byte limit", () => {
+    const data = { key: "a".repeat(100) }
+    const result = validateCheckpointWrite(data, 50)
+
+    expect(result.valid).toBe(false)
+    expect(result.violations).toContain("exceeds_max_bytes:50")
+  })
+
+  it("still computes CRC even when oversized", () => {
+    const data = { key: "a".repeat(100) }
+    const result = validateCheckpointWrite(data, 50)
+
+    expect(result.valid).toBe(false)
+    expect(typeof result.crc).toBe("number")
+    expect(result.crc).toBe(computeCheckpointCrc(data))
+  })
+
+  it("default max is 256 KB", () => {
+    expect(DEFAULT_CHECKPOINT_MAX_BYTES).toBe(256 * 1024)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeCheckpointCrc
+// ---------------------------------------------------------------------------
+
+describe("computeCheckpointCrc", () => {
+  it("returns a 32-bit unsigned integer", () => {
+    const crc = computeCheckpointCrc({ hello: "world" })
+
+    expect(crc).toBeGreaterThanOrEqual(0)
+    expect(crc).toBeLessThanOrEqual(0xffffffff)
+    expect(Number.isInteger(crc)).toBe(true)
+  })
+
+  it("is deterministic — same input always produces the same CRC", () => {
+    const data = { step: 42, context: { nested: true } }
+
+    const crc1 = computeCheckpointCrc(data)
+    const crc2 = computeCheckpointCrc(data)
+
+    expect(crc1).toBe(crc2)
+  })
+
+  it("produces the same CRC regardless of key insertion order", () => {
+    const a = { z: 1, a: 2, m: 3 }
+    const b = { a: 2, m: 3, z: 1 }
+
+    expect(computeCheckpointCrc(a)).toBe(computeCheckpointCrc(b))
+  })
+
+  it("produces the same CRC for deeply nested objects with different key order", () => {
+    const a = { outer: { z: 1, a: 2 }, list: [1, 2, 3] }
+    const b = { list: [1, 2, 3], outer: { a: 2, z: 1 } }
+
+    expect(computeCheckpointCrc(a)).toBe(computeCheckpointCrc(b))
+  })
+
+  it("produces different CRCs for different data", () => {
+    const crc1 = computeCheckpointCrc({ step: 1 })
+    const crc2 = computeCheckpointCrc({ step: 2 })
+
+    expect(crc1).not.toBe(crc2)
+  })
+
+  it("handles an empty object", () => {
+    const crc = computeCheckpointCrc({})
+
+    expect(typeof crc).toBe("number")
+    expect(crc).toBeGreaterThanOrEqual(0)
+  })
+
+  it("handles nested arrays and nulls", () => {
+    const data = { items: [null, { x: 1 }, [2, 3]], value: null }
+    const crc = computeCheckpointCrc(data)
+
+    expect(typeof crc).toBe("number")
+    // Determinism
+    expect(computeCheckpointCrc(data)).toBe(crc)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// verifyCheckpointIntegrity
+// ---------------------------------------------------------------------------
+
+describe("verifyCheckpointIntegrity", () => {
+  it("returns true when data matches the expected CRC", () => {
+    const data = { step: 10, state: "completed" }
+    const crc = computeCheckpointCrc(data)
+
+    expect(verifyCheckpointIntegrity(data, crc)).toBe(true)
+  })
+
+  it("returns false when data has been modified", () => {
+    const original = { step: 10, state: "completed" }
+    const crc = computeCheckpointCrc(original)
+
+    const tampered = { step: 10, state: "failed" }
+    expect(verifyCheckpointIntegrity(tampered, crc)).toBe(false)
+  })
+
+  it("returns false for an arbitrary wrong CRC", () => {
+    const data = { step: 1 }
+    expect(verifyCheckpointIntegrity(data, 0)).toBe(false)
+  })
+
+  it("returns true regardless of key order", () => {
+    const data = { b: 2, a: 1 }
+    const crc = computeCheckpointCrc({ a: 1, b: 2 })
+
+    expect(verifyCheckpointIntegrity(data, crc)).toBe(true)
+  })
+})

--- a/packages/control-plane/src/lifecycle/hydration.ts
+++ b/packages/control-plane/src/lifecycle/hydration.ts
@@ -20,6 +20,7 @@ import type { ResolvedSkills, SkillIndex } from "@cortex/shared/skills"
 import type { Kysely } from "kysely"
 
 import type { Database } from "../db/types.js"
+import { verifyCheckpointIntegrity } from "./output-validator.js"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -78,11 +79,23 @@ export interface QdrantClient {
 // Checkpoint loading
 // ---------------------------------------------------------------------------
 
+export interface CheckpointLogger {
+  warn: (context: Record<string, unknown>, message: string) => void
+}
+
 /**
  * Load the last checkpoint for a job from PostgreSQL.
  * This is mandatory — if the checkpoint can't be loaded, hydration fails.
+ *
+ * When both checkpoint data and a stored CRC exist, the integrity is verified.
+ * A mismatch logs a `checkpoint_corruption_detected` warning but does not
+ * prevent the checkpoint from being returned — callers decide how to handle it.
  */
-export async function loadCheckpoint(jobId: string, db: Kysely<Database>): Promise<CheckpointData> {
+export async function loadCheckpoint(
+  jobId: string,
+  db: Kysely<Database>,
+  logger?: CheckpointLogger,
+): Promise<CheckpointData> {
   const job = await db
     .selectFrom("job")
     .select(["checkpoint", "checkpoint_crc", "status", "attempt", "payload"])
@@ -93,13 +106,21 @@ export async function loadCheckpoint(jobId: string, db: Kysely<Database>): Promi
     throw new Error(`Job not found: ${jobId}`)
   }
 
-  return {
+  const result: CheckpointData = {
     checkpoint: job.checkpoint,
     checkpointCrc: job.checkpoint_crc,
     jobStatus: job.status,
     attempt: job.attempt,
     payload: job.payload,
   }
+
+  if (result.checkpoint && result.checkpointCrc !== null) {
+    if (!verifyCheckpointIntegrity(result.checkpoint, result.checkpointCrc)) {
+      logger?.warn({ jobId, expectedCrc: result.checkpointCrc }, "checkpoint_corruption_detected")
+    }
+  }
+
+  return result
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/control-plane/src/lifecycle/index.ts
+++ b/packages/control-plane/src/lifecycle/index.ts
@@ -17,6 +17,7 @@ export {
 export {
   type AgentIdentity,
   type CheckpointData,
+  type CheckpointLogger,
   hydrateAgent,
   type HydrationResult,
   loadCheckpoint,
@@ -26,6 +27,15 @@ export {
   type QdrantClient,
   type QdrantContext,
 } from "./hydration.js"
+export {
+  computeCheckpointCrc,
+  DEFAULT_CHECKPOINT_MAX_BYTES,
+  DEFAULT_MEMORY_MAX_CHARS,
+  type OutputValidationResult,
+  validateCheckpointWrite,
+  validateMemoryWrite,
+  verifyCheckpointIntegrity,
+} from "./output-validator.js"
 export { DEFAULT_IDLE_TIMEOUT_MS, IdleDetector, type IdleDetectorOptions } from "./idle-detector.js"
 export {
   type AgentContext,

--- a/packages/control-plane/src/lifecycle/output-validator.ts
+++ b/packages/control-plane/src/lifecycle/output-validator.ts
@@ -1,0 +1,169 @@
+/**
+ * Output validation for agent memory writes and checkpoint integrity.
+ *
+ * Enforces size limits on memory writes, rejects binary content, and computes
+ * CRC32 checksums for checkpoint data to detect corruption on read.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface OutputValidationResult {
+  valid: boolean
+  sanitized: string | Record<string, unknown>
+  violations: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default maximum characters for a memory write. */
+export const DEFAULT_MEMORY_MAX_CHARS = 8_000
+
+/** Default maximum bytes for a checkpoint write (256 KB). */
+export const DEFAULT_CHECKPOINT_MAX_BYTES = 256 * 1024
+
+// ---------------------------------------------------------------------------
+// CRC32
+// ---------------------------------------------------------------------------
+
+/** IEEE 802.3 CRC32 lookup table. */
+const CRC32_TABLE = /* @__PURE__ */ (() => {
+  const table = new Uint32Array(256)
+  for (let i = 0; i < 256; i++) {
+    let crc = i
+    for (let j = 0; j < 8; j++) {
+      crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1
+    }
+    table[i] = crc
+  }
+  return table
+})()
+
+function crc32(buf: Uint8Array): number {
+  let crc = 0xffffffff
+  for (let i = 0; i < buf.length; i++) {
+    crc = (crc >>> 8) ^ CRC32_TABLE[(crc ^ buf[i]!) & 0xff]!
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+/**
+ * Deterministic JSON stringify with sorted keys.
+ * Ensures the same object always produces the same byte sequence for CRC
+ * regardless of property insertion order.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || value === undefined) return "null"
+
+  const type = typeof value
+  if (type === "string" || type === "number" || type === "boolean") {
+    return JSON.stringify(value)
+  }
+
+  if (Array.isArray(value)) {
+    return "[" + value.map((item) => stableStringify(item ?? null)).join(",") + "]"
+  }
+
+  if (type === "object") {
+    const record = value as Record<string, unknown>
+    const keys = Object.keys(record).sort()
+    const parts: string[] = []
+    for (const k of keys) {
+      const v = record[k]
+      if (v !== undefined) {
+        parts.push(JSON.stringify(k) + ":" + stableStringify(v))
+      }
+    }
+    return "{" + parts.join(",") + "}"
+  }
+
+  return "null"
+}
+
+// ---------------------------------------------------------------------------
+// Binary content detection
+// ---------------------------------------------------------------------------
+
+/** Control characters that indicate binary content (excludes \t \n \r). */
+const BINARY_CHAR_RE = /[\x00-\x08\x0b\x0c\x0e-\x1f]/
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a memory write.
+ *
+ * - Rejects binary content (contains control characters like null bytes).
+ * - Rejects content exceeding the character limit (default 8,000).
+ */
+export function validateMemoryWrite(
+  content: string,
+  maxChars: number = DEFAULT_MEMORY_MAX_CHARS,
+): OutputValidationResult {
+  const violations: string[] = []
+
+  if (BINARY_CHAR_RE.test(content)) {
+    violations.push("binary_content_detected")
+  }
+
+  if (content.length > maxChars) {
+    violations.push(`exceeds_max_chars:${maxChars}`)
+  }
+
+  return {
+    valid: violations.length === 0,
+    sanitized: content,
+    violations,
+  }
+}
+
+/**
+ * Validate a checkpoint write.
+ *
+ * - Rejects data exceeding the byte size limit (default 256 KB).
+ * - Computes a CRC32 checksum for integrity verification on subsequent reads.
+ */
+export function validateCheckpointWrite(
+  data: Record<string, unknown>,
+  maxBytes: number = DEFAULT_CHECKPOINT_MAX_BYTES,
+): OutputValidationResult & { crc: number } {
+  const violations: string[] = []
+  const serialized = stableStringify(data)
+  const byteLength = Buffer.byteLength(serialized, "utf8")
+
+  if (byteLength > maxBytes) {
+    violations.push(`exceeds_max_bytes:${maxBytes}`)
+  }
+
+  const crc = crc32(Buffer.from(serialized, "utf8"))
+
+  return {
+    valid: violations.length === 0,
+    sanitized: data,
+    violations,
+    crc,
+  }
+}
+
+/**
+ * Compute a deterministic CRC32 for checkpoint data.
+ * Uses stable (sorted-key) JSON serialization to ensure consistency.
+ */
+export function computeCheckpointCrc(data: Record<string, unknown>): number {
+  const serialized = stableStringify(data)
+  return crc32(Buffer.from(serialized, "utf8"))
+}
+
+/**
+ * Verify checkpoint data integrity against an expected CRC32 checksum.
+ */
+export function verifyCheckpointIntegrity(
+  data: Record<string, unknown>,
+  expectedCrc: number,
+): boolean {
+  return computeCheckpointCrc(data) === expectedCrc
+}


### PR DESCRIPTION
Closes #312

Output validation for agent memory writes and checkpoint integrity.

- `validateMemoryWrite`: rejects binary content, enforces 8000 char limit
- `validateCheckpointWrite`: enforces 256KB limit, computes CRC32
- CRC verification on checkpoint load in hydration.ts
- Full test coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checkpoint integrity verification mechanism that detects data corruption and logs warnings.
  * Introduced memory and checkpoint data validation with configurable size limits.

* **Tests**
  * Added comprehensive test suite covering memory validation, checkpoint validation, CRC computation, and integrity verification with edge-case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->