### PR TITLE
feat(db): migration — agent_checkpoint table (#266-T6)

### DIFF
--- a/packages/control-plane/migrations/019_agent_checkpoint.down.sql
+++ b/packages/control-plane/migrations/019_agent_checkpoint.down.sql
@@ -1,0 +1,4 @@
+-- 019 down: Drop agent_checkpoint table and index.
+
+DROP INDEX IF EXISTS idx_acp_agent;
+DROP TABLE IF EXISTS agent_checkpoint;

--- a/packages/control-plane/migrations/019_agent_checkpoint.up.sql
+++ b/packages/control-plane/migrations/019_agent_checkpoint.up.sql
@@ -1,0 +1,18 @@
+-- 019: Create agent_checkpoint table.
+--      Provides persistent state snapshots for agents, enabling
+--      checkpoint/restore across job boundaries.
+--      Part of the agent capabilities epic (#266), Task T6.
+
+CREATE TABLE agent_checkpoint (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id          UUID NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
+  job_id            UUID REFERENCES job(id) ON DELETE SET NULL,
+  label             TEXT,
+  state             JSONB NOT NULL,
+  state_crc         INTEGER NOT NULL,
+  context_snapshot  JSONB,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by        TEXT NOT NULL DEFAULT 'system'
+);
+
+CREATE INDEX idx_acp_agent ON agent_checkpoint(agent_id, created_at DESC);

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -39,6 +39,11 @@ export type CredentialClass =
   | "custom"
 
 // ---------------------------------------------------------------------------
+// Enum: tool_approval_policy
+// ---------------------------------------------------------------------------
+export type ToolApprovalPolicy = "auto" | "always_approve" | "conditional"
+
+// ---------------------------------------------------------------------------
 // Enum: mcp_server_status
 // ---------------------------------------------------------------------------
 export type McpServerStatus = "PENDING" | "ACTIVE" | "DEGRADED" | "ERROR" | "DISABLED"
@@ -512,6 +517,69 @@ export type NewMcpServerTool = Insertable<McpServerToolTable>
 export type McpServerToolUpdate = Updateable<McpServerToolTable>
 
 // ---------------------------------------------------------------------------
+// Table: agent_tool_binding
+// ---------------------------------------------------------------------------
+export interface AgentToolBindingTable {
+  id: Generated<string>
+  agent_id: string
+  tool_ref: string
+  approval_policy: ColumnType<
+    ToolApprovalPolicy,
+    ToolApprovalPolicy | undefined,
+    ToolApprovalPolicy
+  >
+  approval_condition: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  rate_limit: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  cost_budget: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  data_scope: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  enabled: ColumnType<boolean, boolean | undefined, boolean>
+  created_at: ColumnType<Date, Date | undefined, never>
+  updated_at: ColumnType<Date, Date | undefined, Date>
+}
+
+export type AgentToolBinding = Selectable<AgentToolBindingTable>
+export type NewAgentToolBinding = Insertable<AgentToolBindingTable>
+export type AgentToolBindingUpdate = Updateable<AgentToolBindingTable>
+
+// ---------------------------------------------------------------------------
+// Table: agent_checkpoint
+// ---------------------------------------------------------------------------
+export interface AgentCheckpointTable {
+  id: Generated<string>
+  agent_id: string
+  job_id: string | null
+  label: string | null
+  state: ColumnType<Record<string, unknown>, Record<string, unknown>, Record<string, unknown>>
+  state_crc: number
+  context_snapshot: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  created_at: ColumnType<Date, Date | undefined, never>
+  created_by: ColumnType<string, string | undefined, string>
+}
+
+export type AgentCheckpoint = Selectable<AgentCheckpointTable>
+export type NewAgentCheckpoint = Insertable<AgentCheckpointTable>
+
+// ---------------------------------------------------------------------------
 // Database interface — register all tables here.
 // ---------------------------------------------------------------------------
 export interface Database {
@@ -534,4 +602,6 @@ export interface Database {
   agent_credential_binding: AgentCredentialBindingTable
   mcp_server: McpServerTable
   mcp_server_tool: McpServerToolTable
+  agent_tool_binding: AgentToolBindingTable
+  agent_checkpoint: AgentCheckpointTable
 }


### PR DESCRIPTION
Closes #315

Agent checkpoint table for lifecycle resilience. CASCADE on agent delete, SET NULL on job delete, CRC integrity column, compound index.

Part of epic #266.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent checkpoint functionality enabling state persistence and recovery across job boundaries.
  * Introduced agent tool approval system with configurable policies (auto, always approve, conditional) and governance controls including rate limiting, cost budgeting, and data scope restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->