### PR TITLE
feat(control): dry run — simulate agent turn without tool execution (#265-T9)

### DIFF
--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -25,6 +25,7 @@ import { McpHealthSupervisor } from "./mcp/health-supervisor.js"
 import { McpToolRouter } from "./mcp/tool-router.js"
 import { loadAuthConfig } from "./middleware/api-keys.js"
 import { BrowserObservationService } from "./observation/service.js"
+import { agentControlRoutes } from "./routes/agent-control.js"
 import { agentChannelRoutes } from "./routes/agent-channels.js"
 import { agentCredentialRoutes } from "./routes/agent-credentials.js"
 import { agentRoutes } from "./routes/agents.js"
@@ -189,6 +190,16 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
       enqueueJob: async (jobId: string) => {
         await workerUtils.addJob("agent_execute", { jobId }, { jobKey: `exec:${jobId}` })
       },
+    }),
+  )
+
+  // Register agent control routes (dry-run, etc.)
+  await app.register(
+    agentControlRoutes({
+      db,
+      authConfig,
+      sessionService,
+      mcpToolRouter,
     }),
   )
 

--- a/packages/control-plane/src/observability/__tests__/dry-run.test.ts
+++ b/packages/control-plane/src/observability/__tests__/dry-run.test.ts
@@ -1,0 +1,314 @@
+import type { TokenUsage } from "@cortex/shared/backends"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { DryRunError, executeDryRun, stubToolRegistry } from "../dry-run.js"
+
+// ---------------------------------------------------------------------------
+// Mock: HttpLlmBackend + tool-executor
+// ---------------------------------------------------------------------------
+
+// We need to mock the HttpLlmBackend to avoid real API calls,
+// and loadConversationHistory to avoid real DB queries.
+
+const mockBackendStop = vi.fn().mockResolvedValue(undefined)
+const mockBackendStart = vi.fn().mockResolvedValue(undefined)
+
+const mockToolRegistry = {
+  get: vi.fn().mockReturnValue({ name: "echo", description: "test", inputSchema: {} }),
+  resolve: vi.fn().mockReturnValue([]),
+  register: vi.fn(),
+  execute: vi.fn().mockResolvedValue({ output: "ok", isError: false }),
+}
+
+const mockCreateAgentRegistry = vi.fn().mockResolvedValue(mockToolRegistry)
+
+const mockEvents: Array<{
+  type: string
+  timestamp: string
+  content?: string
+  toolName?: string
+  toolInput?: Record<string, unknown>
+  tokenUsage?: TokenUsage
+}> = []
+
+const mockHandle = {
+  taskId: "dry-run-test",
+  events: async function* () {
+    for (const e of mockEvents) {
+      yield e
+    }
+  },
+  result: vi.fn().mockResolvedValue({ status: "completed" }),
+  cancel: vi.fn(),
+}
+
+const mockExecuteTask = vi.fn().mockResolvedValue(mockHandle)
+
+vi.mock("../../backends/http-llm.js", () => ({
+  HttpLlmBackend: vi.fn().mockImplementation(() => ({
+    start: mockBackendStart,
+    stop: mockBackendStop,
+    createAgentRegistry: mockCreateAgentRegistry,
+    executeTask: mockExecuteTask,
+  })),
+}))
+
+vi.mock("../../channels/message-dispatch.js", () => ({
+  loadConversationHistory: vi.fn().mockResolvedValue([]),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAgent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "agent-dry-001",
+    name: "Test Agent",
+    slug: "test-agent",
+    role: "assistant",
+    description: "A test agent",
+    model_config: {},
+    skill_config: {},
+    resource_limits: {},
+    channel_permissions: {},
+    config: {},
+    status: "ACTIVE",
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  }
+}
+
+function selectChain(rows: Record<string, unknown>[]) {
+  const executeTakeFirst = vi.fn().mockResolvedValue(rows[0] ?? null)
+  const terminal = { executeTakeFirst }
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  whereFn.mockReturnValue({ where: whereFn, ...terminal })
+  const selectAll = vi.fn().mockReturnValue({ where: whereFn, ...terminal })
+  const select = vi.fn().mockReturnValue({ where: whereFn, ...terminal })
+  return { selectAll, select }
+}
+
+function mockDb(
+  opts: { agent?: Record<string, unknown> | null; session?: { id: string } | null } = {},
+) {
+  const { agent = makeAgent(), session = null } = opts
+
+  return {
+    selectFrom: vi.fn().mockImplementation((table: string) => {
+      if (table === "agent") return selectChain(agent ? [agent] : [])
+      if (table === "session") return selectChain(session ? [session] : [])
+      if (table === "session_message") return selectChain([])
+      return selectChain([])
+    }),
+  } as unknown as import("kysely").Kysely<import("../../db/types.js").Database>
+}
+
+// ---------------------------------------------------------------------------
+// Tests: stubToolRegistry
+// ---------------------------------------------------------------------------
+
+describe("stubToolRegistry", () => {
+  it("replaces execute with a dry-run stub", async () => {
+    const { ToolRegistry } = await import("../../backends/tool-executor.js")
+    const registry = new ToolRegistry()
+    registry.register({
+      name: "test_tool",
+      description: "A test tool",
+      inputSchema: { type: "object", properties: {} },
+      execute: () => Promise.resolve("real output"),
+    })
+
+    stubToolRegistry(registry)
+
+    const result = await registry.execute("test_tool", { key: "value" })
+    expect(result.output).toContain("[DRY RUN]")
+    expect(result.output).toContain("test_tool")
+    expect(result.output).toContain('"key":"value"')
+    expect(result.isError).toBe(false)
+  })
+
+  it("preserves unknown-tool error behavior", async () => {
+    const { ToolRegistry } = await import("../../backends/tool-executor.js")
+    const registry = new ToolRegistry()
+    stubToolRegistry(registry)
+
+    const result = await registry.execute("nonexistent", {})
+    expect(result.output).toContain("Unknown tool")
+    expect(result.isError).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: executeDryRun
+// ---------------------------------------------------------------------------
+
+describe("executeDryRun", () => {
+  beforeEach(() => {
+    mockEvents.length = 0
+    vi.clearAllMocks()
+  })
+
+  it("returns planned actions and agent response for a text-only response", async () => {
+    mockEvents.push(
+      { type: "text", timestamp: new Date().toISOString(), content: "Hello from dry run" },
+      {
+        type: "usage",
+        timestamp: new Date().toISOString(),
+        tokenUsage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          costUsd: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+        },
+      },
+    )
+
+    const db = mockDb()
+    const result = await executeDryRun("agent-dry-001", { message: "Hello" }, { db })
+
+    expect(result.plannedActions).toEqual([])
+    expect(result.agentResponse).toBe("Hello from dry run")
+    expect(result.tokensUsed).toEqual({ in: 100, out: 50 })
+    expect(result.estimatedCostUsd).toBeGreaterThan(0)
+  })
+
+  it("collects tool calls as planned actions", async () => {
+    mockEvents.push(
+      { type: "text", timestamp: new Date().toISOString(), content: "Let me search." },
+      {
+        type: "tool_use",
+        timestamp: new Date().toISOString(),
+        toolName: "web_search",
+        toolInput: { query: "test" },
+      },
+      {
+        type: "usage",
+        timestamp: new Date().toISOString(),
+        tokenUsage: {
+          inputTokens: 200,
+          outputTokens: 80,
+          costUsd: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+        },
+      },
+    )
+
+    const db = mockDb()
+    const result = await executeDryRun("agent-dry-001", { message: "Search for test" }, { db })
+
+    expect(result.plannedActions).toHaveLength(1)
+    expect(result.plannedActions[0]).toEqual({
+      type: "tool_call",
+      toolRef: "web_search",
+      input: { query: "test" },
+    })
+    expect(result.agentResponse).toBe("Let me search.")
+  })
+
+  it("throws DryRunError when agent not found", async () => {
+    const db = mockDb({ agent: null })
+
+    await expect(executeDryRun("nonexistent", { message: "Hello" }, { db })).rejects.toThrow(
+      DryRunError,
+    )
+
+    try {
+      await executeDryRun("nonexistent", { message: "Hello" }, { db })
+    } catch (err) {
+      expect(err).toBeInstanceOf(DryRunError)
+      expect((err as DryRunError).code).toBe("not_found")
+    }
+  })
+
+  it("throws DryRunError when agent is not ACTIVE", async () => {
+    const db = mockDb({ agent: makeAgent({ status: "DISABLED" }) })
+
+    await expect(executeDryRun("agent-dry-001", { message: "Hello" }, { db })).rejects.toThrow(
+      DryRunError,
+    )
+
+    try {
+      await executeDryRun("agent-dry-001", { message: "Hello" }, { db })
+    } catch (err) {
+      expect(err).toBeInstanceOf(DryRunError)
+      expect((err as DryRunError).code).toBe("conflict")
+    }
+  })
+
+  it("does not write to any database tables (no session_message, no job, no checkpoint)", async () => {
+    mockEvents.push(
+      { type: "text", timestamp: new Date().toISOString(), content: "No side effects" },
+      {
+        type: "usage",
+        timestamp: new Date().toISOString(),
+        tokenUsage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          costUsd: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+        },
+      },
+    )
+
+    const db = mockDb()
+    await executeDryRun("agent-dry-001", { message: "Hello" }, { db })
+
+    // Verify no insertInto or updateTable calls
+    expect(db.selectFrom).toHaveBeenCalled() // reads are expected
+    expect((db as unknown as Record<string, unknown>).insertInto).toBeUndefined()
+    expect((db as unknown as Record<string, unknown>).updateTable).toBeUndefined()
+  })
+
+  it("stops the backend after execution", async () => {
+    mockEvents.push(
+      { type: "text", timestamp: new Date().toISOString(), content: "Done" },
+      {
+        type: "usage",
+        timestamp: new Date().toISOString(),
+        tokenUsage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          costUsd: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+        },
+      },
+    )
+
+    const db = mockDb()
+    await executeDryRun("agent-dry-001", { message: "Hello" }, { db })
+
+    expect(mockBackendStop).toHaveBeenCalled()
+  })
+
+  it("passes maxTurns from input", async () => {
+    mockEvents.push(
+      { type: "text", timestamp: new Date().toISOString(), content: "Done" },
+      {
+        type: "usage",
+        timestamp: new Date().toISOString(),
+        tokenUsage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          costUsd: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+        },
+      },
+    )
+
+    const db = mockDb()
+    await executeDryRun("agent-dry-001", { message: "Hello", maxTurns: 3 }, { db })
+
+    // Verify executeTask was called and the task constraints reflect maxTurns
+    expect(mockExecuteTask).toHaveBeenCalled()
+    const calls = mockExecuteTask.mock.calls
+    const taskArg = calls[0]![0] as { constraints: { maxTurns: number } }
+    expect(taskArg.constraints.maxTurns).toBe(3)
+  })
+})

--- a/packages/control-plane/src/observability/dry-run.ts
+++ b/packages/control-plane/src/observability/dry-run.ts
@@ -1,0 +1,260 @@
+/**
+ * Dry Run — simulate an agent turn without tool execution
+ *
+ * Builds a full execution context (system prompt, tool definitions,
+ * conversation history) and runs one LLM turn. Tool calls requested
+ * by the LLM are collected but never executed for real — stubs return
+ * a deterministic placeholder instead.
+ *
+ * No side effects: no session_message writes, no checkpoint updates,
+ * no job creation.
+ */
+
+import type { ExecutionTask, OutputEvent, TokenUsage } from "@cortex/shared/backends"
+import type { Kysely } from "kysely"
+
+import { HttpLlmBackend, type McpDeps } from "../backends/http-llm.js"
+import { type ToolDefinition, type ToolRegistry } from "../backends/tool-executor.js"
+import { loadConversationHistory } from "../channels/message-dispatch.js"
+import type { Database } from "../db/types.js"
+import type { McpToolRouter } from "../mcp/tool-router.js"
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface DryRunInput {
+  message: string
+  sessionId?: string
+  maxTurns?: number
+}
+
+export interface PlannedAction {
+  type: "tool_call"
+  toolRef: string
+  input: Record<string, unknown>
+}
+
+export interface DryRunResult {
+  plannedActions: PlannedAction[]
+  agentResponse: string
+  tokensUsed: { in: number; out: number }
+  estimatedCostUsd: number
+}
+
+export interface DryRunDeps {
+  db: Kysely<Database>
+  mcpToolRouter?: McpToolRouter
+}
+
+// ---------------------------------------------------------------------------
+// Cost estimation (rough per-token pricing for common models)
+// ---------------------------------------------------------------------------
+
+const COST_PER_1K_INPUT = 0.003
+const COST_PER_1K_OUTPUT = 0.015
+
+function estimateCost(usage: TokenUsage): number {
+  return (
+    (usage.inputTokens / 1000) * COST_PER_1K_INPUT +
+    (usage.outputTokens / 1000) * COST_PER_1K_OUTPUT
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Dry-run stub factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap every tool in the registry so that execute() returns a
+ * deterministic stub instead of performing real work.
+ */
+export function stubToolRegistry(registry: ToolRegistry): ToolRegistry {
+  // The ToolRegistry class doesn't expose iteration, so we create a
+  // thin proxy that intercepts execute() calls.  We do this by
+  // replacing the `execute` method on the registry itself.
+  const originalExecute = registry.execute.bind(registry)
+
+  registry.execute = async (
+    name: string,
+    input: Record<string, unknown>,
+  ): Promise<{ output: string; isError: boolean }> => {
+    // Verify the tool exists (so "unknown tool" errors still surface)
+    const tool = registry.get(name)
+    if (!tool) {
+      return originalExecute(name, input)
+    }
+
+    return {
+      output: `[DRY RUN] Tool ${name} would be called with: ${JSON.stringify(input)}`,
+      isError: false,
+    }
+  }
+
+  return registry
+}
+
+// ---------------------------------------------------------------------------
+// Core dry-run executor
+// ---------------------------------------------------------------------------
+
+export async function executeDryRun(
+  agentId: string,
+  input: DryRunInput,
+  deps: DryRunDeps,
+): Promise<DryRunResult> {
+  const { db, mcpToolRouter } = deps
+
+  // ── Load agent ──
+  const agent = await db
+    .selectFrom("agent")
+    .selectAll()
+    .where("id", "=", agentId)
+    .executeTakeFirst()
+
+  if (!agent) {
+    throw new DryRunError("not_found", "Agent not found")
+  }
+
+  if (agent.status !== "ACTIVE") {
+    throw new DryRunError("conflict", `Agent is ${agent.status}, must be ACTIVE`)
+  }
+
+  // ── Load conversation history (if sessionId provided) ──
+  let conversationHistory: Array<{ role: "user" | "assistant"; content: string }> = []
+  if (input.sessionId) {
+    const session = await db
+      .selectFrom("session")
+      .select("id")
+      .where("id", "=", input.sessionId)
+      .where("agent_id", "=", agentId)
+      .where("status", "=", "active")
+      .executeTakeFirst()
+
+    if (session) {
+      conversationHistory = await loadConversationHistory(db, session.id)
+    }
+  }
+
+  // ── Build execution task ──
+  const agentConfig = agent.model_config
+  const skillConfig = agent.skill_config
+  const resourceLimits = agent.resource_limits
+
+  const allowedTools: string[] = Array.isArray(skillConfig.allowedTools)
+    ? (skillConfig.allowedTools as string[])
+    : []
+  const deniedTools: string[] = Array.isArray(skillConfig.deniedTools)
+    ? (skillConfig.deniedTools as string[])
+    : []
+
+  const task: ExecutionTask = {
+    id: `dry-run-${Date.now()}`,
+    jobId: `dry-run-${Date.now()}`,
+    agentId: agent.id,
+    instruction: {
+      prompt: input.message,
+      goalType: "research",
+      conversationHistory: conversationHistory.length > 0 ? conversationHistory : undefined,
+    },
+    context: {
+      workspacePath:
+        typeof agentConfig.workspacePath === "string" ? agentConfig.workspacePath : "/workspace",
+      systemPrompt:
+        typeof agentConfig.systemPrompt === "string"
+          ? agentConfig.systemPrompt
+          : `You are ${agent.name}, a ${agent.role} agent.${agent.description ? ` ${agent.description}` : ""}`,
+      memories: [],
+      relevantFiles: {},
+      environment: {},
+    },
+    constraints: {
+      timeoutMs: 120_000,
+      maxTokens: typeof resourceLimits.maxTokens === "number" ? resourceLimits.maxTokens : 200_000,
+      model:
+        typeof agentConfig.model === "string" ? agentConfig.model : "claude-sonnet-4-5-20250514",
+      allowedTools,
+      deniedTools,
+      maxTurns: input.maxTurns ?? 1,
+      networkAccess: false,
+      shellAccess: false,
+    },
+  }
+
+  // ── Build tool registry with stubs ──
+  const backend = new HttpLlmBackend()
+  await backend.start({
+    provider: (agentConfig.provider as string) ?? process.env.LLM_PROVIDER ?? "anthropic",
+    apiKey: (agentConfig.apiKey as string) ?? process.env.LLM_API_KEY,
+    model: task.constraints.model,
+    baseUrl: (agentConfig.baseUrl as string) ?? process.env.LLM_BASE_URL,
+  })
+
+  try {
+    const mcpDeps: McpDeps | undefined = mcpToolRouter
+      ? {
+          mcpRouter: mcpToolRouter,
+          agentId: agent.id,
+          allowedTools,
+          deniedTools,
+        }
+      : undefined
+
+    const registry = await backend.createAgentRegistry(agent.config ?? {}, mcpDeps)
+    const stubbedRegistry = stubToolRegistry(registry)
+
+    // ── Execute one LLM turn ──
+    const handle = await backend.executeTask(task, stubbedRegistry)
+
+    const plannedActions: PlannedAction[] = []
+    let agentResponse = ""
+    let tokensUsed: TokenUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    }
+
+    for await (const event of handle.events()) {
+      switch (event.type) {
+        case "text":
+          agentResponse += event.content
+          break
+        case "tool_use":
+          plannedActions.push({
+            type: "tool_call",
+            toolRef: event.toolName,
+            input: event.toolInput,
+          })
+          break
+        case "usage":
+          tokensUsed = event.tokenUsage
+          break
+      }
+    }
+
+    return {
+      plannedActions,
+      agentResponse,
+      tokensUsed: { in: tokensUsed.inputTokens, out: tokensUsed.outputTokens },
+      estimatedCostUsd: estimateCost(tokensUsed),
+    }
+  } finally {
+    await backend.stop()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error class
+// ---------------------------------------------------------------------------
+
+export class DryRunError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message)
+    this.name = "DryRunError"
+  }
+}

--- a/packages/control-plane/src/routes/agent-control.ts
+++ b/packages/control-plane/src/routes/agent-control.ts
@@ -1,0 +1,112 @@
+/**
+ * Agent Control Routes
+ *
+ * POST /agents/:agentId/dry-run — Simulate an agent turn without tool execution
+ */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
+import type { Kysely } from "kysely"
+
+import type { SessionService } from "../auth/session-service.js"
+import type { Database } from "../db/types.js"
+import type { McpToolRouter } from "../mcp/tool-router.js"
+import {
+  type AuthMiddlewareOptions,
+  createRequireAuth,
+  createRequireRole,
+  type PreHandler,
+} from "../middleware/auth.js"
+import type { AuthConfig } from "../middleware/types.js"
+import { DryRunError, executeDryRun } from "../observability/dry-run.js"
+
+// ---------------------------------------------------------------------------
+// Route types
+// ---------------------------------------------------------------------------
+
+interface DryRunParams {
+  agentId: string
+}
+
+interface DryRunBody {
+  message: string
+  sessionId?: string
+  maxTurns?: number
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+export interface AgentControlRouteDeps {
+  db: Kysely<Database>
+  authConfig: AuthConfig
+  sessionService?: SessionService
+  mcpToolRouter?: McpToolRouter
+}
+
+export function agentControlRoutes(deps: AgentControlRouteDeps) {
+  const { db, authConfig, sessionService, mcpToolRouter } = deps
+
+  const authOpts: AuthMiddlewareOptions = { config: authConfig, sessionService }
+  const requireAuth: PreHandler = createRequireAuth(authOpts)
+  const requireOperator: PreHandler = createRequireRole("operator")
+
+  return function register(app: FastifyInstance): void {
+    // -----------------------------------------------------------------
+    // POST /agents/:agentId/dry-run — Simulate agent turn
+    // Requires: auth + operator role
+    // -----------------------------------------------------------------
+    app.post<{ Params: DryRunParams; Body: DryRunBody }>(
+      "/agents/:agentId/dry-run",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string" },
+            },
+            required: ["agentId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              message: { type: "string", minLength: 1, maxLength: 50_000 },
+              sessionId: { type: "string" },
+              maxTurns: { type: "number", minimum: 1, maximum: 5 },
+            },
+            required: ["message"],
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: DryRunParams; Body: DryRunBody }>,
+        reply: FastifyReply,
+      ) => {
+        try {
+          const result = await executeDryRun(
+            request.params.agentId,
+            {
+              message: request.body.message,
+              sessionId: request.body.sessionId,
+              maxTurns: request.body.maxTurns,
+            },
+            { db, mcpToolRouter },
+          )
+
+          return reply.status(200).send(result)
+        } catch (err) {
+          if (err instanceof DryRunError) {
+            const statusMap: Record<string, number> = {
+              not_found: 404,
+              conflict: 409,
+            }
+            const status = statusMap[err.code] ?? 500
+            return reply.status(status).send({ error: err.code, message: err.message })
+          }
+          throw err
+        }
+      },
+    )
+  }
+}


### PR DESCRIPTION
Closes #329

Dry run mode that simulates agent execution without calling tools. Part of epic #265.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dry-run simulation for agents: preview responses, view planned tool calls, track token usage, and estimate execution costs without actual tool invocation.
  * Supports optional session conversation history context.

* **Tests**
  * Added comprehensive test suite covering dry-run execution paths, tool invocation stubbing, failure scenarios, and database non-persistence guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->