### PR TITLE
feat(worker): event retention pruning scheduled task (#265-T10)

### DIFF
--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -484,6 +484,57 @@ export type NewMcpServer = Insertable<McpServerTable>
 export type McpServerUpdate = Updateable<McpServerTable>
 
 // ---------------------------------------------------------------------------
+// Enum: agent_event_type
+// ---------------------------------------------------------------------------
+export type AgentEventType =
+  | "llm_call_start"
+  | "llm_call_end"
+  | "tool_call_start"
+  | "tool_call_end"
+  | "tool_denied"
+  | "tool_rate_limited"
+  | "message_received"
+  | "message_sent"
+  | "state_transition"
+  | "circuit_breaker_trip"
+  | "cost_alert"
+  | "steer_injected"
+  | "steer_acknowledged"
+  | "kill_requested"
+  | "checkpoint_created"
+  | "error"
+  | "session_start"
+  | "session_end"
+
+// ---------------------------------------------------------------------------
+// Table: agent_event
+// ---------------------------------------------------------------------------
+export interface AgentEventTable {
+  id: Generated<string>
+  agent_id: string
+  session_id: string | null
+  job_id: string | null
+  parent_event_id: string | null
+  event_type: AgentEventType
+  payload: ColumnType<
+    Record<string, unknown>,
+    Record<string, unknown> | undefined,
+    Record<string, unknown>
+  >
+  tokens_in: number | null
+  tokens_out: number | null
+  cost_usd: string | null
+  duration_ms: number | null
+  model: string | null
+  tool_ref: string | null
+  actor: string | null
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
+export type AgentEvent = Selectable<AgentEventTable>
+export type NewAgentEvent = Insertable<AgentEventTable>
+
+// ---------------------------------------------------------------------------
 // Table: mcp_server_tool
 // ---------------------------------------------------------------------------
 export interface McpServerToolTable {
@@ -534,4 +585,5 @@ export interface Database {
   agent_credential_binding: AgentCredentialBindingTable
   mcp_server: McpServerTable
   mcp_server_tool: McpServerToolTable
+  agent_event: AgentEventTable
 }

--- a/packages/control-plane/src/worker/index.ts
+++ b/packages/control-plane/src/worker/index.ts
@@ -23,6 +23,7 @@ import { createApprovalExpireTask } from "./tasks/approval-expire.js"
 import { createCorrectionStrengthenTask } from "./tasks/correction-strengthen.js"
 import { createMemoryExtractTask } from "./tasks/memory-extract.js"
 import { createProactiveDetectTask } from "./tasks/proactive-detect.js"
+import { createPruneAgentEventsTask } from "./tasks/prune-agent-events.js"
 
 export interface WorkerOptions {
   pgPool: Pool
@@ -68,6 +69,7 @@ export async function createWorker(options: WorkerOptions): Promise<Runner> {
     approval_expire: createApprovalExpireTask(db),
     correction_strengthen: createCorrectionStrengthenTask(),
     proactive_detect: createProactiveDetectTask(),
+    prune_agent_events: createPruneAgentEventsTask(db),
   }
 
   const runner = await run({
@@ -78,6 +80,8 @@ export async function createWorker(options: WorkerOptions): Promise<Runner> {
     crontab: [
       // Expire stale approval requests every 60 seconds
       "* * * * * approval_expire ?max=1",
+      // Prune old agent events daily at 03:00 UTC
+      "0 3 * * * prune_agent_events ?max=1",
     ].join("\n"),
   })
 

--- a/packages/control-plane/src/worker/tasks/__tests__/prune-agent-events.test.ts
+++ b/packages/control-plane/src/worker/tasks/__tests__/prune-agent-events.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createPruneAgentEventsTask,
+  type EventRetentionConfig,
+  type PruneResult,
+  runPruneAgentEvents,
+} from "../prune-agent-events.js"
+
+// ──────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────
+
+/**
+ * Build a mock Kysely db that tracks delete queries.
+ * Returns the mock and arrays capturing the WHERE predicates.
+ */
+function mockDb(generalDeleted = 0n, costDeleted = 0n) {
+  let callCount = 0
+
+  const executeTakeFirst = vi.fn().mockImplementation(() => {
+    callCount++
+    // First call is general events, second is cost events
+    return Promise.resolve({
+      numDeletedRows: callCount === 1 ? generalDeleted : costDeleted,
+    })
+  })
+
+  const limitFn = vi.fn().mockReturnThis()
+
+  const innerWhere = vi.fn().mockImplementation(function (this: unknown) {
+    return { limit: limitFn, where: innerWhere, select: vi.fn().mockReturnThis() }
+  })
+
+  const innerSelect = vi.fn().mockImplementation(() => ({
+    where: innerWhere,
+    limit: limitFn,
+  }))
+
+  const innerSelectFrom = vi.fn().mockImplementation(() => ({
+    select: innerSelect,
+  }))
+
+  const outerWhere = vi.fn().mockImplementation((_col: string, _op: string, subquery: unknown) => {
+    // The subquery is a callback — invoke it with our mock query builder
+    if (typeof subquery === "function") {
+      subquery({ selectFrom: innerSelectFrom })
+    }
+    return { executeTakeFirst }
+  })
+
+  const deleteFrom = vi.fn().mockImplementation(() => ({
+    where: outerWhere,
+  }))
+
+  return {
+    db: { deleteFrom } as unknown as Parameters<typeof runPruneAgentEvents>[0],
+    deleteFrom,
+    executeTakeFirst,
+  }
+}
+
+function mockHelpers() {
+  return {
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    addJob: vi.fn(),
+    job: { id: "job-1" },
+    withPgClient: vi.fn(),
+  } as unknown as Parameters<ReturnType<typeof createPruneAgentEventsTask>>[1]
+}
+
+// ──────────────────────────────────────────────────
+// runPruneAgentEvents
+// ──────────────────────────────────────────────────
+
+describe("runPruneAgentEvents", () => {
+  it("deletes general events and cost events separately", async () => {
+    const { db } = mockDb(5n, 3n)
+
+    const result = await runPruneAgentEvents(db)
+
+    expect(result.generalPruned).toBe(5)
+    expect(result.costPruned).toBe(3)
+  })
+
+  it("returns zero counts when nothing to prune", async () => {
+    const { db } = mockDb(0n, 0n)
+
+    const result = await runPruneAgentEvents(db)
+
+    expect(result.generalPruned).toBe(0)
+    expect(result.costPruned).toBe(0)
+  })
+
+  it("issues two deleteFrom calls (general + cost)", async () => {
+    const { db, deleteFrom } = mockDb(0n, 0n)
+
+    await runPruneAgentEvents(db)
+
+    expect(deleteFrom).toHaveBeenCalledTimes(2)
+    expect(deleteFrom).toHaveBeenCalledWith("agent_event")
+  })
+
+  it("respects custom config values", async () => {
+    const { db } = mockDb(10n, 2n)
+    const config: EventRetentionConfig = {
+      defaultDays: 7,
+      costEventDays: 14,
+      batchSize: 500,
+    }
+
+    const result = await runPruneAgentEvents(db, config)
+
+    expect(result.generalPruned).toBe(10)
+    expect(result.costPruned).toBe(2)
+  })
+
+  it("uses default config when none provided", async () => {
+    const { db } = mockDb(1n, 0n)
+
+    // Should not throw — defaults are applied internally
+    const result = await runPruneAgentEvents(db)
+
+    expect(result.generalPruned).toBe(1)
+    expect(result.costPruned).toBe(0)
+  })
+})
+
+// ──────────────────────────────────────────────────
+// createPruneAgentEventsTask
+// ──────────────────────────────────────────────────
+
+describe("createPruneAgentEventsTask", () => {
+  it("logs pruned count when events are deleted", async () => {
+    const { db } = mockDb(10n, 5n)
+    const task = createPruneAgentEventsTask(db)
+    const helpers = mockHelpers()
+
+    await task({}, helpers)
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(helpers.logger.info).toHaveBeenCalledWith(expect.stringContaining("pruned 15 event(s)"))
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(helpers.logger.info).toHaveBeenCalledWith(expect.stringContaining("general=10"))
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(helpers.logger.info).toHaveBeenCalledWith(expect.stringContaining("cost=5"))
+  })
+
+  it("logs no-op message when nothing pruned", async () => {
+    const { db } = mockDb(0n, 0n)
+    const task = createPruneAgentEventsTask(db)
+    const helpers = mockHelpers()
+
+    await task({}, helpers)
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(helpers.logger.info).toHaveBeenCalledWith(expect.stringContaining("no events to prune"))
+  })
+
+  it("passes config through to pipeline", async () => {
+    const { db } = mockDb(3n, 1n)
+    const config: EventRetentionConfig = { defaultDays: 7, costEventDays: 14, batchSize: 100 }
+    const task = createPruneAgentEventsTask(db, config)
+    const helpers = mockHelpers()
+
+    await task({}, helpers)
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(helpers.logger.info).toHaveBeenCalledWith(expect.stringContaining("pruned 4 event(s)"))
+  })
+
+  it("is idempotent — safe to call multiple times", async () => {
+    const { db } = mockDb(2n, 0n)
+    const task = createPruneAgentEventsTask(db)
+    const helpers = mockHelpers()
+
+    // Run twice — should not throw or produce errors
+    await task({}, helpers)
+    await task({}, helpers)
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(helpers.logger.error).not.toHaveBeenCalled()
+  })
+})

--- a/packages/control-plane/src/worker/tasks/prune-agent-events.ts
+++ b/packages/control-plane/src/worker/tasks/prune-agent-events.ts
@@ -1,0 +1,123 @@
+/**
+ * Event Retention Pruning Task — "prune_agent_events"
+ *
+ * Scheduled to run daily at 03:00 UTC to prune old agent events
+ * based on configurable retention policies.
+ *
+ * Retention rules:
+ * - General events older than `defaultDays` (30) are deleted.
+ * - Cost events (cost_usd IS NOT NULL) older than `costEventDays` (90) are deleted.
+ * - Processes in batches of `batchSize` (1000) to avoid long locks.
+ *
+ * This task is idempotent — running it multiple times is safe because
+ * it deletes by age threshold and processes in bounded batches.
+ */
+
+import type { Task } from "graphile-worker"
+import type { Kysely } from "kysely"
+
+import type { Database } from "../../db/types.js"
+
+// ──────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────
+
+export interface EventRetentionConfig {
+  /** Days to retain general (non-cost) events. Default: 30 */
+  defaultDays?: number
+  /** Days to retain cost events (cost_usd IS NOT NULL). Default: 90 */
+  costEventDays?: number
+  /** Max rows to delete per execution cycle. Default: 1000 */
+  batchSize?: number
+}
+
+export interface PruneResult {
+  /** Number of general events pruned */
+  generalPruned: number
+  /** Number of cost events pruned */
+  costPruned: number
+}
+
+// ──────────────────────────────────────────────────
+// Pipeline core (exported for testing)
+// ──────────────────────────────────────────────────
+
+/**
+ * Run the event retention pruning pipeline.
+ *
+ * Deletes general events older than `defaultDays` and cost events
+ * older than `costEventDays`, each capped at `batchSize` rows.
+ */
+export async function runPruneAgentEvents(
+  db: Kysely<Database>,
+  config: EventRetentionConfig = {},
+): Promise<PruneResult> {
+  const defaultDays = config.defaultDays ?? 30
+  const costEventDays = config.costEventDays ?? 90
+  const batchSize = config.batchSize ?? 1000
+
+  const generalCutoff = new Date()
+  generalCutoff.setUTCDate(generalCutoff.getUTCDate() - defaultDays)
+
+  const costCutoff = new Date()
+  costCutoff.setUTCDate(costCutoff.getUTCDate() - costEventDays)
+
+  // 1. Delete general events (non-cost) older than defaultDays
+  const generalResult = await db
+    .deleteFrom("agent_event")
+    .where("id", "in", (qb) =>
+      qb
+        .selectFrom("agent_event")
+        .select("id")
+        .where("created_at", "<", generalCutoff)
+        .where("cost_usd", "is", null)
+        .limit(batchSize),
+    )
+    .executeTakeFirst()
+
+  const generalPruned = Number(generalResult.numDeletedRows)
+
+  // 2. Delete cost events older than costEventDays
+  const costResult = await db
+    .deleteFrom("agent_event")
+    .where("id", "in", (qb) =>
+      qb
+        .selectFrom("agent_event")
+        .select("id")
+        .where("created_at", "<", costCutoff)
+        .where("cost_usd", "is not", null)
+        .limit(batchSize),
+    )
+    .executeTakeFirst()
+
+  const costPruned = Number(costResult.numDeletedRows)
+
+  return { generalPruned, costPruned }
+}
+
+// ──────────────────────────────────────────────────
+// Task factory
+// ──────────────────────────────────────────────────
+
+/**
+ * Create the prune_agent_events task handler.
+ */
+export function createPruneAgentEventsTask(
+  db: Kysely<Database>,
+  config?: EventRetentionConfig,
+): Task {
+  return async (_payload: unknown, helpers): Promise<void> => {
+    const result = await runPruneAgentEvents(db, config)
+
+    const total = result.generalPruned + result.costPruned
+
+    if (total > 0) {
+      helpers.logger.info(
+        `prune_agent_events: pruned ${total} event(s) — ` +
+          `general=${result.generalPruned} cost=${result.costPruned}`,
+      )
+    } else {
+      helpers.logger.info("prune_agent_events: no events to prune")
+    }
+  }
+}


### PR DESCRIPTION
Closes #330

Scheduled worker task for pruning old agent events. Part of epic #265.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added agent event tracking to the database schema with configurable event types and metadata fields.
  * Implemented automatic daily pruning of agent events based on retention policies (30 days for general events, 90 days for cost events).
  * Added comprehensive test coverage for event pruning functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->