### PR TITLE
feat(routes): extend GET /agents with cost + health summary fields (#265-T12)

### DIFF
--- a/packages/control-plane/migrations/019_agent_event.down.sql
+++ b/packages/control-plane/migrations/019_agent_event.down.sql
@@ -1,0 +1,5 @@
+-- 019 down: Drop agent_event table and indexes.
+
+DROP INDEX IF EXISTS idx_agent_event_agent_model;
+DROP INDEX IF EXISTS idx_agent_event_agent_created;
+DROP TABLE IF EXISTS agent_event;

--- a/packages/control-plane/migrations/019_agent_event.up.sql
+++ b/packages/control-plane/migrations/019_agent_event.up.sql
@@ -1,0 +1,24 @@
+-- 019: Create agent_event table for cost tracking and observability.
+--      Stores per-call events (LLM calls, tool invocations) with cost_usd
+--      so the control plane can aggregate cost-per-agent summaries.
+--      Part of the Operator Visibility epic (#320), task #265-T12.
+
+CREATE TABLE agent_event (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id        UUID NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
+  job_id          UUID REFERENCES job(id) ON DELETE SET NULL,
+  event_type      TEXT NOT NULL,          -- e.g. 'llm_call', 'tool_call'
+  model           TEXT,                   -- model used (e.g. 'claude-sonnet-4-20250514')
+  cost_usd        NUMERIC(12,6) NOT NULL DEFAULT 0,
+  metadata        JSONB NOT NULL DEFAULT '{}',
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Fast per-agent cost aggregations filtered by date
+CREATE INDEX idx_agent_event_agent_created
+  ON agent_event (agent_id, created_at DESC);
+
+-- Model-level cost breakdown
+CREATE INDEX idx_agent_event_agent_model
+  ON agent_event (agent_id, model)
+  WHERE model IS NOT NULL;

--- a/packages/control-plane/src/__tests__/agent-routes.test.ts
+++ b/packages/control-plane/src/__tests__/agent-routes.test.ts
@@ -64,6 +64,7 @@ function mockDb(
   opts: {
     agents?: Record<string, unknown>[]
     jobs?: Record<string, unknown>[]
+    agentEvents?: Record<string, unknown>[]
     insertedAgent?: Record<string, unknown>
     updatedAgent?: Record<string, unknown> | null
     insertedJob?: Record<string, unknown>
@@ -72,6 +73,7 @@ function mockDb(
   const {
     agents = [makeAgent()],
     jobs = [],
+    agentEvents = [],
     insertedAgent = makeAgent(),
     updatedAgent = makeAgent(),
     insertedJob = makeJob(),
@@ -83,6 +85,7 @@ function mockDb(
     const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(rows[0] ?? {})
     const execute = vi.fn().mockResolvedValue(rows)
     const terminal = { execute, executeTakeFirst, executeTakeFirstOrThrow }
+    const groupBy = vi.fn().mockReturnValue(terminal)
     const offset = vi.fn().mockReturnValue(terminal)
     const limit = vi.fn().mockReturnValue({ ...terminal, offset })
     const orderBy = vi.fn().mockReturnValue({ ...terminal, limit, offset })
@@ -92,11 +95,12 @@ function mockDb(
       orderBy,
       limit,
       offset,
+      groupBy,
       ...terminal,
     })
     const selectAll = vi
       .fn()
-      .mockReturnValue({ where: whereFn, orderBy, limit, offset, ...terminal })
+      .mockReturnValue({ where: whereFn, orderBy, limit, offset, groupBy, ...terminal })
     // Count queries use select(fn.countAll().as("total")) — return { total: rows.length }
     // Regular selects (e.g. select("id")) still need where/executeTakeFirst
     const countResult = { total: rows.length }
@@ -108,9 +112,19 @@ function mockDb(
     const selectWhereFn: ReturnType<typeof vi.fn> = vi.fn()
     selectWhereFn.mockReturnValue({
       where: selectWhereFn,
+      groupBy,
+      orderBy,
+      limit,
       ...selectTerminal,
     })
-    const select = vi.fn().mockReturnValue({ where: selectWhereFn, ...selectTerminal })
+    // select is self-referencing to support chained .select().select() calls
+    const selectNode: Record<string, unknown> = {
+      where: selectWhereFn,
+      groupBy,
+      ...selectTerminal,
+    }
+    const select = vi.fn().mockReturnValue(selectNode)
+    selectNode.select = select
     return { selectAll, select }
   }
 
@@ -140,6 +154,7 @@ function mockDb(
     selectFrom: vi.fn().mockImplementation((table: string) => {
       if (table === "agent") return selectChain(agents)
       if (table === "job") return selectChain(jobs)
+      if (table === "agent_event") return selectChain(agentEvents)
       return selectChain([])
     }),
     insertInto: vi.fn().mockImplementation((table: string) => {
@@ -198,6 +213,37 @@ describe("GET /agents", () => {
 
     expect(res.statusCode).toBe(200)
   })
+
+  it("includes costToday, healthStatus, and runningJobId per agent", async () => {
+    const { app } = await buildTestApp({
+      agents: [makeAgent()],
+    })
+
+    const res = await app.inject({ method: "GET", url: "/agents" })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const first = body.agents[0] as Record<string, unknown>
+    expect(first.costToday).toBe(0)
+    expect(first.healthStatus).toBe("healthy")
+    expect(first.runningJobId).toBeNull()
+  })
+
+  it("maps DISABLED agent to quarantined healthStatus", async () => {
+    const { app } = await buildTestApp({
+      agents: [makeAgent({ status: "DISABLED" })],
+    })
+
+    const res = await app.inject({ method: "GET", url: "/agents" })
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const first = body.agents[0] as Record<string, unknown>
+    expect(first.healthStatus).toBe("quarantined")
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -230,6 +276,33 @@ describe("GET /agents/:id", () => {
     })
 
     expect(res.statusCode).toBe(404)
+  })
+
+  it("includes costSummary, healthStatus, runningJobId, and circuitBreakerState", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    expect(body).toHaveProperty("costSummary")
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.costSummary).toEqual({ totalToday: 0, byModel: {} })
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.healthStatus).toBe("healthy")
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.runningJobId).toBeNull()
+    expect(body).toHaveProperty("circuitBreakerState")
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.circuitBreakerState).toEqual({
+      tripped: false,
+      consecutiveFailures: 0,
+      tripReason: null,
+    })
   })
 })
 

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -512,6 +512,27 @@ export type NewMcpServerTool = Insertable<McpServerToolTable>
 export type McpServerToolUpdate = Updateable<McpServerToolTable>
 
 // ---------------------------------------------------------------------------
+// Table: agent_event
+// ---------------------------------------------------------------------------
+export interface AgentEventTable {
+  id: Generated<string>
+  agent_id: string
+  job_id: string | null
+  event_type: string
+  model: string | null
+  cost_usd: ColumnType<number, number | undefined, number>
+  metadata: ColumnType<
+    Record<string, unknown>,
+    Record<string, unknown> | undefined,
+    Record<string, unknown>
+  >
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
+export type AgentEvent = Selectable<AgentEventTable>
+export type NewAgentEvent = Insertable<AgentEventTable>
+
+// ---------------------------------------------------------------------------
 // Database interface — register all tables here.
 // ---------------------------------------------------------------------------
 export interface Database {
@@ -534,4 +555,5 @@ export interface Database {
   agent_credential_binding: AgentCredentialBindingTable
   mcp_server: McpServerTable
   mcp_server_tool: McpServerToolTable
+  agent_event: AgentEventTable
 }

--- a/packages/control-plane/src/routes/agents.ts
+++ b/packages/control-plane/src/routes/agents.ts
@@ -14,7 +14,7 @@ import { randomUUID } from "node:crypto"
 
 import type { AgentStatus, JobStatus } from "@cortex/shared"
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
-import type { Kysely } from "kysely"
+import { sql, type Kysely } from "kysely"
 
 import type { SessionService } from "../auth/session-service.js"
 import type { Database } from "../db/types.js"
@@ -95,6 +95,38 @@ interface ResumeAgentBody {
 }
 
 // ---------------------------------------------------------------------------
+// Health / cost helpers
+// ---------------------------------------------------------------------------
+
+type HealthStatus = "healthy" | "degraded" | "quarantined" | "unknown"
+
+interface CostSummary {
+  totalToday: number
+  byModel: Record<string, number>
+}
+
+interface CircuitBreakerState {
+  tripped: boolean
+  consecutiveFailures: number
+  tripReason: string | null
+}
+
+/**
+ * Map the persisted agent status to the API-level health enum.
+ * ACTIVE → healthy, DISABLED → quarantined, everything else → unknown.
+ */
+function deriveHealthStatus(agentStatus: AgentStatus): HealthStatus {
+  switch (agentStatus) {
+    case "ACTIVE":
+      return "healthy"
+    case "DISABLED":
+      return "quarantined"
+    default:
+      return "unknown"
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
 
@@ -148,8 +180,46 @@ export function agentRoutes(deps: AgentRouteDeps) {
 
         const total = Number(countResult.total)
 
+        // Batch-fetch cost + running-job summaries for the returned agents
+        const agentIds = agents.map((a) => a.id)
+
+        let costMap = new Map<string, number>()
+        let runningJobMap = new Map<string, string>()
+
+        if (agentIds.length > 0) {
+          const todayStart = new Date()
+          todayStart.setHours(0, 0, 0, 0)
+
+          const [costRows, runningJobs] = await Promise.all([
+            db
+              .selectFrom("agent_event")
+              .select(["agent_id"])
+              .select(sql<number>`coalesce(sum(cost_usd), 0)`.as("cost_today"))
+              .where("agent_id", "in", agentIds)
+              .where("created_at", ">=", todayStart)
+              .groupBy("agent_id")
+              .execute(),
+            db
+              .selectFrom("job")
+              .select(["agent_id", "id"])
+              .where("agent_id", "in", agentIds)
+              .where("status", "=", "RUNNING" as JobStatus)
+              .execute(),
+          ])
+
+          costMap = new Map(costRows.map((r) => [r.agent_id, Number(r.cost_today)]))
+          runningJobMap = new Map(runningJobs.map((r) => [r.agent_id, r.id]))
+        }
+
+        const enrichedAgents = agents.map((agent) => ({
+          ...agent,
+          costToday: costMap.get(agent.id) ?? 0,
+          healthStatus: deriveHealthStatus(agent.status),
+          runningJobId: runningJobMap.get(agent.id) ?? null,
+        }))
+
         return reply.status(200).send({
-          agents,
+          agents: enrichedAgents,
           count: agents.length,
           pagination: {
             total,
@@ -188,16 +258,81 @@ export function agentRoutes(deps: AgentRouteDeps) {
           return reply.status(404).send({ error: "not_found", message: "Agent not found" })
         }
 
-        // Fetch latest job for this agent
-        const latestJob = await db
-          .selectFrom("job")
-          .selectAll()
-          .where("agent_id", "=", agent.id)
-          .orderBy("created_at", "desc")
-          .limit(1)
-          .executeTakeFirst()
+        const todayStart = new Date()
+        todayStart.setHours(0, 0, 0, 0)
 
-        return reply.status(200).send({ ...agent, latest_job: latestJob ?? null })
+        const [latestJob, runningJob, costRows, recentFailures] = await Promise.all([
+          // Latest job
+          db
+            .selectFrom("job")
+            .selectAll()
+            .where("agent_id", "=", agent.id)
+            .orderBy("created_at", "desc")
+            .limit(1)
+            .executeTakeFirst(),
+          // Currently running job
+          db
+            .selectFrom("job")
+            .select("id")
+            .where("agent_id", "=", agent.id)
+            .where("status", "=", "RUNNING" as JobStatus)
+            .limit(1)
+            .executeTakeFirst(),
+          // Cost breakdown by model (today)
+          db
+            .selectFrom("agent_event")
+            .select(["model"])
+            .select(sql<number>`coalesce(sum(cost_usd), 0)`.as("total"))
+            .where("agent_id", "=", agent.id)
+            .where("created_at", ">=", todayStart)
+            .groupBy("model")
+            .execute(),
+          // Consecutive recent failures for circuit-breaker heuristic
+          db
+            .selectFrom("job")
+            .select(["status"])
+            .where("agent_id", "=", agent.id)
+            .where("status", "in", ["COMPLETED", "FAILED", "TIMED_OUT"] as JobStatus[])
+            .orderBy("completed_at", "desc")
+            .limit(10)
+            .execute(),
+        ])
+
+        // Build costSummary
+        let totalToday = 0
+        const byModel: Record<string, number> = {}
+        for (const row of costRows) {
+          const amount = Number(row.total)
+          totalToday += amount
+          const key = row.model ?? "unknown"
+          byModel[key] = (byModel[key] ?? 0) + amount
+        }
+        const costSummary: CostSummary = { totalToday, byModel }
+
+        // Derive circuit-breaker state from consecutive failures
+        let consecutiveFailures = 0
+        for (const j of recentFailures) {
+          if (j.status === "FAILED" || j.status === "TIMED_OUT") {
+            consecutiveFailures++
+          } else {
+            break
+          }
+        }
+        const circuitBreakerState: CircuitBreakerState = {
+          tripped: consecutiveFailures >= 5,
+          consecutiveFailures,
+          tripReason:
+            consecutiveFailures >= 5 ? `${consecutiveFailures} consecutive job failures` : null,
+        }
+
+        return reply.status(200).send({
+          ...agent,
+          latest_job: latestJob ?? null,
+          costSummary,
+          healthStatus: deriveHealthStatus(agent.status),
+          runningJobId: runningJob?.id ?? null,
+          circuitBreakerState,
+        })
       },
     )
 


### PR DESCRIPTION
Closes #332

Extends GET /agents with cost and health summary. Part of epic #265.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent endpoints now track and display daily costs per agent.
  * Cost breakdown by model is available for detailed cost analysis.
  * Agent health status is now visible (healthy, degraded, quarantined, or unknown).
  * Circuit breaker state provides insights into agent operational reliability.
  * Running job information is included in agent responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->