### PR TITLE
feat(lifecycle): extend state machine — DEGRADED, QUARANTINED, SAFE_MODE (#266-T1)

### DIFF
--- a/packages/control-plane/src/__tests__/lifecycle-state-machine.test.ts
+++ b/packages/control-plane/src/__tests__/lifecycle-state-machine.test.ts
@@ -16,6 +16,9 @@ describe("VALID_TRANSITIONS", () => {
       "HYDRATING",
       "READY",
       "EXECUTING",
+      "DEGRADED",
+      "QUARANTINED",
+      "SAFE_MODE",
       "DRAINING",
       "TERMINATED",
     ]
@@ -41,8 +44,30 @@ describe("VALID_TRANSITIONS", () => {
     expect(VALID_TRANSITIONS.READY).toEqual(["EXECUTING", "DRAINING"])
   })
 
-  it("EXECUTING can go to DRAINING or TERMINATED", () => {
-    expect(VALID_TRANSITIONS.EXECUTING).toEqual(["DRAINING", "TERMINATED"])
+  it("EXECUTING can go to DEGRADED, QUARANTINED, DRAINING, or TERMINATED", () => {
+    expect(VALID_TRANSITIONS.EXECUTING).toEqual([
+      "DEGRADED",
+      "QUARANTINED",
+      "DRAINING",
+      "TERMINATED",
+    ])
+  })
+
+  it("DEGRADED can go to EXECUTING, QUARANTINED, DRAINING, or TERMINATED", () => {
+    expect(VALID_TRANSITIONS.DEGRADED).toEqual([
+      "EXECUTING",
+      "QUARANTINED",
+      "DRAINING",
+      "TERMINATED",
+    ])
+  })
+
+  it("QUARANTINED can go to DRAINING or TERMINATED", () => {
+    expect(VALID_TRANSITIONS.QUARANTINED).toEqual(["DRAINING", "TERMINATED"])
+  })
+
+  it("SAFE_MODE can go to READY or TERMINATED", () => {
+    expect(VALID_TRANSITIONS.SAFE_MODE).toEqual(["READY", "TERMINATED"])
   })
 
   it("DRAINING can only go to TERMINATED", () => {
@@ -60,6 +85,19 @@ describe("isValidTransition", () => {
     expect(isValidTransition("EXECUTING", "DRAINING")).toBe(true)
     expect(isValidTransition("EXECUTING", "TERMINATED")).toBe(true)
     expect(isValidTransition("DRAINING", "TERMINATED")).toBe(true)
+  })
+
+  it("returns true for new state transitions", () => {
+    expect(isValidTransition("EXECUTING", "DEGRADED")).toBe(true)
+    expect(isValidTransition("EXECUTING", "QUARANTINED")).toBe(true)
+    expect(isValidTransition("DEGRADED", "EXECUTING")).toBe(true)
+    expect(isValidTransition("DEGRADED", "QUARANTINED")).toBe(true)
+    expect(isValidTransition("DEGRADED", "DRAINING")).toBe(true)
+    expect(isValidTransition("DEGRADED", "TERMINATED")).toBe(true)
+    expect(isValidTransition("QUARANTINED", "DRAINING")).toBe(true)
+    expect(isValidTransition("QUARANTINED", "TERMINATED")).toBe(true)
+    expect(isValidTransition("SAFE_MODE", "READY")).toBe(true)
+    expect(isValidTransition("SAFE_MODE", "TERMINATED")).toBe(true)
   })
 
   it("returns false for invalid transitions", () => {
@@ -82,6 +120,9 @@ describe("isValidTransition", () => {
     expect(isValidTransition("BOOTING", "BOOTING")).toBe(false)
     expect(isValidTransition("EXECUTING", "EXECUTING")).toBe(false)
     expect(isValidTransition("TERMINATED", "TERMINATED")).toBe(false)
+
+    // QUARANTINED cannot go back to EXECUTING (must go through DRAINING → re-boot)
+    expect(isValidTransition("QUARANTINED", "EXECUTING")).toBe(false)
   })
 })
 
@@ -210,6 +251,15 @@ describe("AgentLifecycleStateMachine", () => {
       expect(sm.isReady).toBe(true)
     })
 
+    it("returns true in DEGRADED", () => {
+      const sm = new AgentLifecycleStateMachine("agent-1")
+      sm.transition("HYDRATING")
+      sm.transition("READY")
+      sm.transition("EXECUTING")
+      sm.transition("DEGRADED")
+      expect(sm.isReady).toBe(true)
+    })
+
     it("returns false in DRAINING", () => {
       const sm = new AgentLifecycleStateMachine("agent-1")
       sm.transition("HYDRATING")
@@ -277,5 +327,103 @@ describe("AgentLifecycleStateMachine", () => {
     sm.transition("DRAINING", "SIGTERM")
     sm.transition("TERMINATED", "Drain complete")
     expect(sm.state).toBe("TERMINATED")
+  })
+
+  describe("isDegraded", () => {
+    it("returns true only in DEGRADED", () => {
+      const sm = new AgentLifecycleStateMachine("agent-1")
+      expect(sm.isDegraded).toBe(false)
+      sm.transition("HYDRATING")
+      sm.transition("READY")
+      sm.transition("EXECUTING")
+      expect(sm.isDegraded).toBe(false)
+      sm.transition("DEGRADED")
+      expect(sm.isDegraded).toBe(true)
+    })
+  })
+
+  describe("isQuarantined", () => {
+    it("returns true only in QUARANTINED", () => {
+      const sm = new AgentLifecycleStateMachine("agent-1")
+      expect(sm.isQuarantined).toBe(false)
+      sm.transition("HYDRATING")
+      sm.transition("READY")
+      sm.transition("EXECUTING")
+      expect(sm.isQuarantined).toBe(false)
+      sm.transition("QUARANTINED")
+      expect(sm.isQuarantined).toBe(true)
+    })
+  })
+
+  describe("isSafeMode", () => {
+    it("returns true only in SAFE_MODE", () => {
+      const sm = new AgentLifecycleStateMachine("agent-1")
+      expect(sm.isSafeMode).toBe(false)
+    })
+  })
+
+  // Acceptance criteria from issue #310
+  describe("new state transitions (issue #310)", () => {
+    it("EXECUTING → DEGRADED transition succeeds", () => {
+      const sm = new AgentLifecycleStateMachine("agent-1")
+      sm.transition("HYDRATING")
+      sm.transition("READY")
+      sm.transition("EXECUTING")
+      sm.transition("DEGRADED", "Partial tool failure")
+      expect(sm.state).toBe("DEGRADED")
+    })
+
+    it("EXECUTING → QUARANTINED transition succeeds", () => {
+      const sm = new AgentLifecycleStateMachine("agent-1")
+      sm.transition("HYDRATING")
+      sm.transition("READY")
+      sm.transition("EXECUTING")
+      sm.transition("QUARANTINED", "Security violation detected")
+      expect(sm.state).toBe("QUARANTINED")
+    })
+
+    it("QUARANTINED → DRAINING transition succeeds", () => {
+      const sm = new AgentLifecycleStateMachine("agent-1")
+      sm.transition("HYDRATING")
+      sm.transition("READY")
+      sm.transition("EXECUTING")
+      sm.transition("QUARANTINED")
+      sm.transition("DRAINING", "Draining quarantined agent")
+      expect(sm.state).toBe("DRAINING")
+    })
+
+    it("QUARANTINED → EXECUTING is rejected", () => {
+      const sm = new AgentLifecycleStateMachine("agent-1")
+      sm.transition("HYDRATING")
+      sm.transition("READY")
+      sm.transition("EXECUTING")
+      sm.transition("QUARANTINED")
+      expect(() => sm.transition("EXECUTING")).toThrow(InvalidTransitionError)
+      expect(sm.state).toBe("QUARANTINED")
+    })
+
+    it("SAFE_MODE → READY transition succeeds", () => {
+      expect(isValidTransition("SAFE_MODE", "READY")).toBe(true)
+    })
+
+    it("DEGRADED → EXECUTING recovery succeeds", () => {
+      const sm = new AgentLifecycleStateMachine("agent-1")
+      sm.transition("HYDRATING")
+      sm.transition("READY")
+      sm.transition("EXECUTING")
+      sm.transition("DEGRADED", "Tool failure")
+      sm.transition("EXECUTING", "Recovered")
+      expect(sm.state).toBe("EXECUTING")
+    })
+
+    it("DEGRADED → QUARANTINED escalation succeeds", () => {
+      const sm = new AgentLifecycleStateMachine("agent-1")
+      sm.transition("HYDRATING")
+      sm.transition("READY")
+      sm.transition("EXECUTING")
+      sm.transition("DEGRADED")
+      sm.transition("QUARANTINED", "Escalated from degraded")
+      expect(sm.state).toBe("QUARANTINED")
+    })
   })
 })

--- a/packages/control-plane/src/lifecycle/health.ts
+++ b/packages/control-plane/src/lifecycle/health.ts
@@ -241,7 +241,11 @@ export class CrashLoopDetector {
  * States where readiness probes should return 200.
  * Only READY and EXECUTING agents are ready to serve.
  */
-export const READY_STATES: ReadonlySet<AgentLifecycleState> = new Set(["READY", "EXECUTING"])
+export const READY_STATES: ReadonlySet<AgentLifecycleState> = new Set([
+  "READY",
+  "EXECUTING",
+  "DEGRADED",
+])
 
 /**
  * States where liveness probes should return 200.

--- a/packages/control-plane/src/lifecycle/state-machine.ts
+++ b/packages/control-plane/src/lifecycle/state-machine.ts
@@ -1,7 +1,7 @@
 /**
  * Agent lifecycle state machine.
  *
- * Defines the six lifecycle states of an agent pod and enforces
+ * Defines the lifecycle states of an agent pod and enforces
  * valid transitions between them. Modeled after the job state machine
  * (spike #24) but for the ephemeral pod process, not the durable job.
  *
@@ -10,6 +10,9 @@
  * - HYDRATING: loading checkpoint, Qdrant context, JSONL buffer
  * - READY: hydration complete, probes pass, SSE connected
  * - EXECUTING: actively processing job steps
+ * - DEGRADED: still serving but impaired (e.g. partial tool failures)
+ * - QUARANTINED: isolated from new work, awaiting drain
+ * - SAFE_MODE: restricted functionality, limited to safe operations
  * - DRAINING: SIGTERM received, flushing state, closing connections
  * - TERMINATED: process exited
  */
@@ -19,6 +22,9 @@ export type AgentLifecycleState =
   | "HYDRATING"
   | "READY"
   | "EXECUTING"
+  | "DEGRADED"
+  | "QUARANTINED"
+  | "SAFE_MODE"
   | "DRAINING"
   | "TERMINATED"
 
@@ -30,7 +36,10 @@ export const VALID_TRANSITIONS: Record<AgentLifecycleState, AgentLifecycleState[
   BOOTING: ["HYDRATING", "TERMINATED"],
   HYDRATING: ["READY", "TERMINATED"],
   READY: ["EXECUTING", "DRAINING"],
-  EXECUTING: ["DRAINING", "TERMINATED"],
+  EXECUTING: ["DEGRADED", "QUARANTINED", "DRAINING", "TERMINATED"],
+  DEGRADED: ["EXECUTING", "QUARANTINED", "DRAINING", "TERMINATED"],
+  QUARANTINED: ["DRAINING", "TERMINATED"],
+  SAFE_MODE: ["READY", "TERMINATED"],
   DRAINING: ["TERMINATED"],
   TERMINATED: [],
 }
@@ -116,7 +125,7 @@ export class AgentLifecycleStateMachine {
 
   /** Check if the agent is in a state where readiness probes should return 200. */
   get isReady(): boolean {
-    return this._state === "READY" || this._state === "EXECUTING"
+    return this._state === "READY" || this._state === "EXECUTING" || this._state === "DEGRADED"
   }
 
   /** Check if the agent is in a state where liveness probes should return 200. */
@@ -127,5 +136,20 @@ export class AgentLifecycleStateMachine {
   /** Check if the agent is in a terminal state. */
   get isTerminal(): boolean {
     return this._state === "TERMINATED"
+  }
+
+  /** Check if the agent is in a degraded state (still serving, but impaired). */
+  get isDegraded(): boolean {
+    return this._state === "DEGRADED"
+  }
+
+  /** Check if the agent is quarantined (isolated from new work). */
+  get isQuarantined(): boolean {
+    return this._state === "QUARANTINED"
+  }
+
+  /** Check if the agent is in safe mode (restricted functionality). */
+  get isSafeMode(): boolean {
+    return this._state === "SAFE_MODE"
   }
 }


### PR DESCRIPTION
Closes #310

Extends agent lifecycle with DEGRADED, QUARANTINED, SAFE_MODE states. Part of epic #266.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new agent lifecycle states—DEGRADED, QUARANTINED, and SAFE_MODE—for enhanced health monitoring and recovery management.
  * Expanded state transition logic to support safe progression between health states.

* **Tests**
  * Added comprehensive test coverage for new state transitions and health status validation across all agent states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->