### PR TITLE
feat(lifecycle): context budget enforcement (#266-T2)

### DIFF
--- a/packages/control-plane/src/lifecycle/__tests__/context-budget.test.ts
+++ b/packages/control-plane/src/lifecycle/__tests__/context-budget.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  truncateComponent,
+  validateContextBudget,
+  type ContextBudgetConfig,
+  type ContextComponents,
+} from "../context-budget.js"
+import { DEFAULT_CONTEXT_BUDGET } from "../defaults.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<ContextBudgetConfig> = {}): ContextBudgetConfig {
+  return { ...DEFAULT_CONTEXT_BUDGET, ...overrides }
+}
+
+function makeContext(overrides: Partial<ContextComponents> = {}): ContextComponents {
+  return {
+    systemPrompt: "You are a helpful agent.",
+    identity: "Agent Alpha, software engineer.",
+    memories: "Remember: use TypeScript.",
+    toolDefinitions: '{"name":"bash"}',
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// truncateComponent
+// ---------------------------------------------------------------------------
+
+describe("truncateComponent", () => {
+  it("returns content unchanged when within budget", () => {
+    const { result, truncated } = truncateComponent("hello", 100)
+    expect(result).toBe("hello")
+    expect(truncated).toBe(false)
+  })
+
+  it("returns content unchanged when exactly at budget", () => {
+    const { result, truncated } = truncateComponent("12345", 5)
+    expect(result).toBe("12345")
+    expect(truncated).toBe(false)
+  })
+
+  it("truncates with [TRUNCATED] marker when over budget", () => {
+    const content = "a".repeat(200)
+    const { result, truncated } = truncateComponent(content, 100)
+
+    expect(truncated).toBe(true)
+    expect(result).toHaveLength(100)
+    expect(result.endsWith("[TRUNCATED]")).toBe(true)
+  })
+
+  it("handles maxChars smaller than marker length", () => {
+    const { result, truncated } = truncateComponent("some long content", 5)
+    expect(truncated).toBe(true)
+    expect(result).toHaveLength(5)
+    // Should be a prefix of the marker itself
+    expect(result).toBe("[TRUN")
+  })
+
+  it("handles empty content", () => {
+    const { result, truncated } = truncateComponent("", 100)
+    expect(result).toBe("")
+    expect(truncated).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateContextBudget
+// ---------------------------------------------------------------------------
+
+describe("validateContextBudget", () => {
+  it("returns valid=true when all components are within budget", () => {
+    const context = makeContext()
+    const config = makeConfig()
+    const result = validateContextBudget(context, config)
+
+    expect(result.valid).toBe(true)
+    expect(result.warnings).toHaveLength(0)
+
+    // No component should be truncated
+    for (const comp of Object.values(result.components)) {
+      expect(comp.truncated).toBe(false)
+    }
+  })
+
+  it("flags system prompt exceeding its max", () => {
+    const context = makeContext({
+      systemPrompt: "x".repeat(10_000),
+    })
+    const config = makeConfig({ maxSystemPromptChars: 8_000 })
+    const result = validateContextBudget(context, config)
+
+    expect(result.components["systemPrompt"]!.truncated).toBe(true)
+    expect(result.components["systemPrompt"]!.chars).toBe(10_000)
+    expect(result.components["systemPrompt"]!.max).toBe(8_000)
+    expect(result.warnings.some((w) => w.includes("systemPrompt"))).toBe(true)
+  })
+
+  it("flags identity exceeding its max", () => {
+    const context = makeContext({
+      identity: "y".repeat(5_000),
+    })
+    const config = makeConfig({ maxIdentityChars: 4_000 })
+    const result = validateContextBudget(context, config)
+
+    expect(result.components["identity"]!.truncated).toBe(true)
+    expect(result.warnings.some((w) => w.includes("identity"))).toBe(true)
+  })
+
+  it("flags memories exceeding their max", () => {
+    const context = makeContext({
+      memories: "m".repeat(6_000),
+    })
+    const config = makeConfig({ maxMemoryChars: 4_000 })
+    const result = validateContextBudget(context, config)
+
+    expect(result.components["memories"]!.truncated).toBe(true)
+  })
+
+  it("flags tool definitions exceeding their max", () => {
+    const context = makeContext({
+      toolDefinitions: "t".repeat(20_000),
+    })
+    const config = makeConfig({ maxToolDefinitionsChars: 16_000 })
+    const result = validateContextBudget(context, config)
+
+    expect(result.components["toolDefinitions"]!.truncated).toBe(true)
+  })
+
+  it("returns valid=false when total context exceeds budget", () => {
+    // Create context that fits individual limits but exceeds total
+    const config = makeConfig({
+      maxSystemPromptChars: 50_000,
+      maxIdentityChars: 50_000,
+      maxMemoryChars: 50_000,
+      maxToolDefinitionsChars: 50_000,
+      maxTotalContextChars: 120_000,
+      reservedForConversation: 40_000,
+    })
+
+    const context = makeContext({
+      systemPrompt: "s".repeat(30_000),
+      identity: "i".repeat(25_000),
+      memories: "m".repeat(15_000),
+      toolDefinitions: "t".repeat(15_000),
+    })
+
+    const result = validateContextBudget(context, config)
+
+    // 30k+25k+15k+15k = 85k > 80k (120k - 40k reserved)
+    expect(result.valid).toBe(false)
+    expect(result.totalChars).toBe(85_000)
+    expect(result.warnings.some((w) => w.includes("Total context"))).toBe(true)
+  })
+
+  it("applies system defaults when no contextBudget config on agent", () => {
+    // Using DEFAULT_CONTEXT_BUDGET directly
+    const context = makeContext()
+    const result = validateContextBudget(context, DEFAULT_CONTEXT_BUDGET)
+
+    expect(result.valid).toBe(true)
+    expect(result.components["systemPrompt"]!.max).toBe(8_000)
+    expect(result.components["identity"]!.max).toBe(4_000)
+    expect(result.components["memories"]!.max).toBe(4_000)
+    expect(result.components["toolDefinitions"]!.max).toBe(16_000)
+  })
+
+  it("handles missing context components gracefully", () => {
+    const result = validateContextBudget({}, makeConfig())
+
+    expect(result.valid).toBe(true)
+    expect(result.totalChars).toBe(0)
+    expect(result.components["systemPrompt"]!.chars).toBe(0)
+    expect(result.components["identity"]!.chars).toBe(0)
+    expect(result.components["memories"]!.chars).toBe(0)
+    expect(result.components["toolDefinitions"]!.chars).toBe(0)
+  })
+
+  it("reports correct totalChars", () => {
+    const context = makeContext({
+      systemPrompt: "abc",
+      identity: "de",
+      memories: "f",
+      toolDefinitions: "gh",
+    })
+    const result = validateContextBudget(context, makeConfig())
+
+    expect(result.totalChars).toBe(8) // 3 + 2 + 1 + 2
+  })
+
+  it("integration: oversized identity gets truncated and job still runs", () => {
+    const oversizedIdentity = "x".repeat(6_000)
+    const config = makeConfig({ maxIdentityChars: 4_000 })
+
+    const context = makeContext({ identity: oversizedIdentity })
+    const budgetResult = validateContextBudget(context, config)
+
+    // Identity is flagged
+    expect(budgetResult.components["identity"]!.truncated).toBe(true)
+
+    // Apply truncation
+    const { result: truncatedIdentity } = truncateComponent(
+      oversizedIdentity,
+      config.maxIdentityChars,
+    )
+
+    expect(truncatedIdentity.length).toBeLessThanOrEqual(config.maxIdentityChars)
+    expect(truncatedIdentity.endsWith("[TRUNCATED]")).toBe(true)
+
+    // Re-validate with truncated identity — total should now be valid
+    const revalidated = validateContextBudget({ ...context, identity: truncatedIdentity }, config)
+    expect(revalidated.valid).toBe(true)
+    expect(revalidated.components["identity"]!.truncated).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DEFAULT_CONTEXT_BUDGET
+// ---------------------------------------------------------------------------
+
+describe("DEFAULT_CONTEXT_BUDGET", () => {
+  it("has expected default values", () => {
+    expect(DEFAULT_CONTEXT_BUDGET.maxSystemPromptChars).toBe(8_000)
+    expect(DEFAULT_CONTEXT_BUDGET.maxIdentityChars).toBe(4_000)
+    expect(DEFAULT_CONTEXT_BUDGET.maxMemoryChars).toBe(4_000)
+    expect(DEFAULT_CONTEXT_BUDGET.maxToolDefinitionsChars).toBe(16_000)
+    expect(DEFAULT_CONTEXT_BUDGET.maxTotalContextChars).toBe(120_000)
+    expect(DEFAULT_CONTEXT_BUDGET.reservedForConversation).toBe(40_000)
+  })
+})

--- a/packages/control-plane/src/lifecycle/context-budget.ts
+++ b/packages/control-plane/src/lifecycle/context-budget.ts
@@ -1,0 +1,130 @@
+/**
+ * Context budget enforcement.
+ *
+ * Validates and optionally truncates context components (system prompt,
+ * identity, memories, tool definitions) so the assembled execution context
+ * stays within the target LLM's token window.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ContextBudgetConfig {
+  /** Maximum characters for the system prompt. */
+  maxSystemPromptChars: number
+  /** Maximum characters for agent identity (name, role, description). */
+  maxIdentityChars: number
+  /** Maximum characters for memory / Qdrant context. */
+  maxMemoryChars: number
+  /** Maximum characters for serialised tool definitions. */
+  maxToolDefinitionsChars: number
+  /** Hard cap on total assembled context characters. */
+  maxTotalContextChars: number
+  /** Characters reserved for multi-turn conversation history. */
+  reservedForConversation: number
+}
+
+export interface ComponentBudget {
+  chars: number
+  max: number
+  truncated: boolean
+}
+
+export interface BudgetResult {
+  valid: boolean
+  components: Record<string, ComponentBudget>
+  totalChars: number
+  warnings: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Context shape passed to validation
+// ---------------------------------------------------------------------------
+
+export interface ContextComponents {
+  systemPrompt?: string
+  identity?: string
+  memories?: string
+  toolDefinitions?: string
+}
+
+// ---------------------------------------------------------------------------
+// Truncation
+// ---------------------------------------------------------------------------
+
+const TRUNCATED_MARKER = "[TRUNCATED]"
+
+/**
+ * Truncate `content` to at most `maxChars` characters.
+ * When truncation occurs a `[TRUNCATED]` marker is appended within the limit.
+ */
+export function truncateComponent(
+  content: string,
+  maxChars: number,
+): { result: string; truncated: boolean } {
+  if (content.length <= maxChars) {
+    return { result: content, truncated: false }
+  }
+
+  const trimTo = maxChars - TRUNCATED_MARKER.length
+  const result =
+    trimTo > 0 ? content.slice(0, trimTo) + TRUNCATED_MARKER : TRUNCATED_MARKER.slice(0, maxChars)
+  return { result, truncated: true }
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate (and optionally report on) every context component against the
+ * supplied budget configuration.
+ *
+ * Individual components that exceed their budget are flagged with
+ * `truncated: true` in the result — the caller is responsible for applying
+ * `truncateComponent()` when it wants to enforce the limit.
+ *
+ * If the **total** assembled context exceeds `maxTotalContextChars` the
+ * result's `valid` field is set to `false`.
+ */
+export function validateContextBudget(
+  context: ContextComponents,
+  config: ContextBudgetConfig,
+): BudgetResult {
+  const warnings: string[] = []
+
+  const componentEntries: Array<[string, string, number]> = [
+    ["systemPrompt", context.systemPrompt ?? "", config.maxSystemPromptChars],
+    ["identity", context.identity ?? "", config.maxIdentityChars],
+    ["memories", context.memories ?? "", config.maxMemoryChars],
+    ["toolDefinitions", context.toolDefinitions ?? "", config.maxToolDefinitionsChars],
+  ]
+
+  const components: Record<string, ComponentBudget> = {}
+  let totalChars = 0
+
+  for (const [name, value, max] of componentEntries) {
+    const chars = value.length
+    const truncated = chars > max
+
+    components[name] = { chars, max, truncated }
+    totalChars += chars
+
+    if (truncated) {
+      warnings.push(`${name} exceeds budget: ${chars} chars > ${max} max (will be truncated)`)
+    }
+  }
+
+  // Account for reserved conversation space when checking the total
+  const effectiveMax = config.maxTotalContextChars - config.reservedForConversation
+  const valid = totalChars <= effectiveMax
+
+  if (!valid) {
+    warnings.push(
+      `Total context (${totalChars} chars) exceeds budget (${effectiveMax} usable of ${config.maxTotalContextChars} total, ${config.reservedForConversation} reserved for conversation)`,
+    )
+  }
+
+  return { valid, components, totalChars, warnings }
+}

--- a/packages/control-plane/src/lifecycle/defaults.ts
+++ b/packages/control-plane/src/lifecycle/defaults.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared defaults for the agent lifecycle module.
+ */
+
+import type { ContextBudgetConfig } from "./context-budget.js"
+
+/**
+ * System-wide default context budget.
+ *
+ * These limits keep assembled execution contexts within the token window
+ * of the target LLM while reserving space for the conversation itself.
+ */
+export const DEFAULT_CONTEXT_BUDGET: ContextBudgetConfig = {
+  maxSystemPromptChars: 8_000,
+  maxIdentityChars: 4_000,
+  maxMemoryChars: 4_000,
+  maxToolDefinitionsChars: 16_000,
+  maxTotalContextChars: 120_000,
+  reservedForConversation: 40_000,
+}

--- a/packages/control-plane/src/lifecycle/index.ts
+++ b/packages/control-plane/src/lifecycle/index.ts
@@ -26,6 +26,15 @@ export {
   type QdrantClient,
   type QdrantContext,
 } from "./hydration.js"
+export {
+  truncateComponent,
+  validateContextBudget,
+  type BudgetResult,
+  type ComponentBudget,
+  type ContextBudgetConfig,
+  type ContextComponents,
+} from "./context-budget.js"
+export { DEFAULT_CONTEXT_BUDGET } from "./defaults.js"
 export { DEFAULT_IDLE_TIMEOUT_MS, IdleDetector, type IdleDetectorOptions } from "./idle-detector.js"
 export {
   type AgentContext,

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -25,6 +25,12 @@ import type { JobHelpers, Task } from "graphile-worker"
 import type { Kysely } from "kysely"
 
 import type { Database, Job } from "../../db/types.js"
+import {
+  truncateComponent,
+  validateContextBudget,
+  type ContextBudgetConfig,
+} from "../../lifecycle/context-budget.js"
+import { DEFAULT_CONTEXT_BUDGET } from "../../lifecycle/defaults.js"
 import type { McpToolRouter } from "../../mcp/tool-router.js"
 import type { SSEConnectionManager } from "../../streaming/manager.js"
 import type { AgentOutputPayload } from "../../streaming/types.js"
@@ -172,6 +178,48 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
 
         // ── Step 4: Build ExecutionTask (needed for routing) ──
         const task = buildExecutionTask(job, agent, agentConfig, resolvedSkills)
+
+        // ── Step 4a: Context budget enforcement ──
+        const budgetConfig = parseBudgetConfig(agent.resource_limits)
+        const budgetResult = validateContextBudget(
+          {
+            systemPrompt: task.context.systemPrompt,
+            identity: agent.description ?? "",
+            memories: task.context.memories.join("\n"),
+            toolDefinitions: task.context.skillInstructions ?? "",
+          },
+          budgetConfig,
+        )
+
+        if (!budgetResult.valid) {
+          // Total context exceeds budget — refuse to dispatch
+          await db
+            .updateTable("job")
+            .set({
+              status: "FAILED",
+              error: {
+                category: "CONTEXT_BUDGET_EXCEEDED",
+                message: budgetResult.warnings.join("; "),
+              },
+              completed_at: new Date(),
+            })
+            .where("id", "=", jobId)
+            .where("status", "=", "RUNNING")
+            .execute()
+          rootSpan.addEvent("context_budget_exceeded")
+          return
+        }
+
+        // Truncate individual components that exceed their limits
+        for (const [name, comp] of Object.entries(budgetResult.components)) {
+          if (!comp.truncated) continue
+          if (name === "systemPrompt") {
+            task.context.systemPrompt = truncateComponent(
+              task.context.systemPrompt,
+              comp.max,
+            ).result
+          }
+        }
 
         // Inject trace context into task environment for downstream propagation
         const traceHeaders = injectTraceContext()
@@ -636,6 +684,33 @@ function mapOutputEventType(event: OutputEvent): string {
       return "SESSION_END"
     default:
       return "LLM_RESPONSE"
+  }
+}
+
+// ── Helper: parse ContextBudgetConfig from resource_limits ──
+
+function parseBudgetConfig(resourceLimits: Record<string, unknown>): ContextBudgetConfig {
+  const raw =
+    typeof resourceLimits.contextBudget === "object" && resourceLimits.contextBudget !== null
+      ? (resourceLimits.contextBudget as Record<string, unknown>)
+      : {}
+
+  const num = (key: string, fallback: number): number =>
+    typeof raw[key] === "number" ? (raw[key] as number) : fallback
+
+  return {
+    maxSystemPromptChars: num("maxSystemPromptChars", DEFAULT_CONTEXT_BUDGET.maxSystemPromptChars),
+    maxIdentityChars: num("maxIdentityChars", DEFAULT_CONTEXT_BUDGET.maxIdentityChars),
+    maxMemoryChars: num("maxMemoryChars", DEFAULT_CONTEXT_BUDGET.maxMemoryChars),
+    maxToolDefinitionsChars: num(
+      "maxToolDefinitionsChars",
+      DEFAULT_CONTEXT_BUDGET.maxToolDefinitionsChars,
+    ),
+    maxTotalContextChars: num("maxTotalContextChars", DEFAULT_CONTEXT_BUDGET.maxTotalContextChars),
+    reservedForConversation: num(
+      "reservedForConversation",
+      DEFAULT_CONTEXT_BUDGET.reservedForConversation,
+    ),
   }
 }
 


### PR DESCRIPTION
Closes #311

Context budget enforcement for agent lifecycle. Part of epic #266.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added context budget enforcement to control the size of execution context and prevent exceeding LLM constraints.
  * Automatically truncates oversized context components when they exceed per-component limits.
  * Jobs are marked as failed when context cannot fit within configured budget constraints, preventing runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->