### PR TITLE
feat(db): migrate mcp_server.agent_scope to agent_tool_binding rows

### DIFF
--- a/packages/control-plane/migrations/021_migrate_agent_scope.down.sql
+++ b/packages/control-plane/migrations/021_migrate_agent_scope.down.sql
@@ -1,0 +1,34 @@
+-- 021 down: Restore mcp_server.agent_scope from agent_tool_binding rows.
+--           Reverses the data migration performed by 021 up.
+--           Idempotent: safe to run multiple times.
+
+-- 1. Rebuild agent_scope arrays from MCP tool bindings.
+--    For each server, collect distinct agent_ids that have bindings matching
+--    that server's slug in the tool_ref pattern  mcp:<slug>:<name>.
+UPDATE mcp_server s
+SET agent_scope = sub.scope_array, updated_at = now()
+FROM (
+  SELECT
+    split_part(atb.tool_ref, ':', 2) AS server_slug,
+    jsonb_agg(DISTINCT atb.agent_id::text) AS scope_array
+  FROM agent_tool_binding atb
+  WHERE atb.tool_ref LIKE 'mcp:%:%'
+  GROUP BY split_part(atb.tool_ref, ':', 2)
+) sub
+WHERE s.slug = sub.server_slug;
+
+-- 2. Remove MCP tool bindings (the rows created from agent_scope expansion).
+DELETE FROM agent_tool_binding
+WHERE tool_ref LIKE 'mcp:%:%';
+
+-- 3. Remove skill_config-derived bindings.
+--    Match tool_ref against the agent's own allowed_tools / allowedTools list.
+DELETE FROM agent_tool_binding atb
+USING agent a
+WHERE atb.agent_id = a.id
+  AND atb.tool_ref NOT LIKE 'mcp:%'
+  AND atb.tool_ref IN (
+    SELECT jsonb_array_elements_text(
+      COALESCE(a.skill_config->'allowedTools', a.skill_config->'allowed_tools')
+    )
+  );

--- a/packages/control-plane/migrations/021_migrate_agent_scope.up.sql
+++ b/packages/control-plane/migrations/021_migrate_agent_scope.up.sql
@@ -1,0 +1,49 @@
+-- 021: Migrate mcp_server.agent_scope → agent_tool_binding rows.
+--      Also migrates agent skill_config.allowedTools / allowed_tools entries.
+--      Part of the agent capabilities epic (#264), Phase 2.
+--      References: GitHub issue #306.
+--
+--      Idempotent: uses ON CONFLICT (agent_id, tool_ref) DO NOTHING.
+
+-- 1. For each mcp_server with a non-empty agent_scope array, expand every
+--    (agent_id, tool) pair into an agent_tool_binding row.
+INSERT INTO agent_tool_binding (agent_id, tool_ref, approval_policy)
+SELECT
+  scope_agent.agent_id::uuid,
+  'mcp:' || s.slug || ':' || t.name,
+  'auto'
+FROM mcp_server s
+CROSS JOIN LATERAL jsonb_array_elements_text(s.agent_scope) AS scope_agent(agent_id)
+JOIN mcp_server_tool t ON t.mcp_server_id = s.id
+-- Only include agent_ids that still exist (FK safety)
+JOIN agent a ON a.id = scope_agent.agent_id::uuid
+WHERE jsonb_array_length(s.agent_scope) > 0
+ON CONFLICT (agent_id, tool_ref) DO NOTHING;
+
+-- 2. For each agent with skill_config allowedTools / allowed_tools,
+--    insert a binding per tool name.
+INSERT INTO agent_tool_binding (agent_id, tool_ref, approval_policy)
+SELECT
+  a.id,
+  tool.value,
+  'auto'
+FROM agent a
+CROSS JOIN LATERAL jsonb_array_elements_text(
+  COALESCE(a.skill_config->'allowedTools', a.skill_config->'allowed_tools')
+) AS tool(value)
+WHERE COALESCE(
+        a.skill_config->'allowedTools',
+        a.skill_config->'allowed_tools'
+      ) IS NOT NULL
+  AND jsonb_typeof(
+        COALESCE(a.skill_config->'allowedTools', a.skill_config->'allowed_tools')
+      ) = 'array'
+  AND jsonb_array_length(
+        COALESCE(a.skill_config->'allowedTools', a.skill_config->'allowed_tools')
+      ) > 0
+ON CONFLICT (agent_id, tool_ref) DO NOTHING;
+
+-- 3. Clear non-empty agent_scope arrays after successful migration.
+UPDATE mcp_server
+SET agent_scope = '[]'::jsonb, updated_at = now()
+WHERE agent_scope != '[]'::jsonb;

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -226,6 +226,9 @@ export interface JobTable {
   completed_at: Date | null
   heartbeat_at: Date | null
   approval_expires_at: Date | null
+  llm_call_count: ColumnType<number, number | undefined, number>
+  tool_call_count: ColumnType<number, number | undefined, number>
+  cost_usd: ColumnType<number, number | undefined, number>
 }
 
 export type Job = Selectable<JobTable>
@@ -512,6 +515,73 @@ export type NewMcpServerTool = Insertable<McpServerToolTable>
 export type McpServerToolUpdate = Updateable<McpServerToolTable>
 
 // ---------------------------------------------------------------------------
+// Enum: tool_approval_policy
+// ---------------------------------------------------------------------------
+export type ToolApprovalPolicy = "auto" | "always_approve" | "conditional"
+
+// ---------------------------------------------------------------------------
+// Table: agent_tool_binding
+// ---------------------------------------------------------------------------
+export interface AgentToolBindingTable {
+  id: Generated<string>
+  agent_id: string
+  tool_ref: string
+  approval_policy: ColumnType<ToolApprovalPolicy, ToolApprovalPolicy | undefined, ToolApprovalPolicy>
+  approval_condition: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  rate_limit: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  cost_budget: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  data_scope: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  enabled: ColumnType<boolean, boolean | undefined, boolean>
+  created_at: ColumnType<Date, Date | undefined, never>
+  updated_at: ColumnType<Date, Date | undefined, Date>
+}
+
+export type AgentToolBinding = Selectable<AgentToolBindingTable>
+export type NewAgentToolBinding = Insertable<AgentToolBindingTable>
+export type AgentToolBindingUpdate = Updateable<AgentToolBindingTable>
+
+// ---------------------------------------------------------------------------
+// Table: agent_checkpoint
+// ---------------------------------------------------------------------------
+export interface AgentCheckpointTable {
+  id: Generated<string>
+  agent_id: string
+  label: string | null
+  state: ColumnType<
+    Record<string, unknown>,
+    Record<string, unknown> | undefined,
+    Record<string, unknown>
+  >
+  context_snapshot: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  state_crc: number
+  created_by: string | null
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
+export type AgentCheckpoint = Selectable<AgentCheckpointTable>
+export type NewAgentCheckpoint = Insertable<AgentCheckpointTable>
+
+// ---------------------------------------------------------------------------
 // Database interface — register all tables here.
 // ---------------------------------------------------------------------------
 export interface Database {
@@ -534,4 +604,6 @@ export interface Database {
   agent_credential_binding: AgentCredentialBindingTable
   mcp_server: McpServerTable
   mcp_server_tool: McpServerToolTable
+  agent_tool_binding: AgentToolBindingTable
+  agent_checkpoint: AgentCheckpointTable
 }


### PR DESCRIPTION
## Summary

- Adds migration 021 that expands coarse-grained `mcp_server.agent_scope` arrays into fine-grained `agent_tool_binding` rows (one row per agent × MCP tool, with `approval_policy='auto'`)
- Migrates `agent.skill_config.allowedTools` / `allowed_tools` entries into equivalent `agent_tool_binding` rows
- Clears non-empty `agent_scope` arrays after successful migration
- Down migration restores `agent_scope` from existing MCP tool bindings and removes migrated rows
- Adds `AgentToolBindingTable`, `AgentCheckpointTable`, and `ToolApprovalPolicy` types to `db/types.ts` (for migrations 018–019)

All operations use `ON CONFLICT DO NOTHING` for idempotency.

Closes #306

## Test plan

- [x] All 913 existing tests pass (57 test files), including migration up/down cycle test
- [ ] Verify with seeded data that agent_scope entries produce correct agent_tool_binding rows
- [ ] Verify down migration restores agent_scope arrays from bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool approval policies with conditional approval rules and multiple approval states
  * Per-tool rate limiting and cost budget enforcement
  * Data scope controls for tools
  * Agent state checkpoints for saving and restoring execution context
  * Enhanced job tracking metrics including LLM calls, tool calls, and cost data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->