### PR TITLE
feat(dashboard): MCP server management UI

### DIFF
--- a/packages/dashboard/src/app/mcp-servers/[id]/page.tsx
+++ b/packages/dashboard/src/app/mcp-servers/[id]/page.tsx
@@ -1,0 +1,378 @@
+"use client"
+
+import Link from "next/link"
+import { useParams, useRouter } from "next/navigation"
+import { useCallback, useState } from "react"
+
+import { ApiErrorBanner } from "@/components/layout/api-error-banner"
+import { Skeleton } from "@/components/layout/skeleton"
+import { McpHealthBadge } from "@/components/mcp/McpHealthBadge"
+import { McpServerForm } from "@/components/mcp/McpServerForm"
+import { McpToolList } from "@/components/mcp/McpToolList"
+import { useApiQuery } from "@/hooks/use-api"
+import { deleteMcpServer, getMcpServer, refreshMcpServer } from "@/lib/api-client"
+
+function transportLabel(transport: string): string {
+  return transport === "streamable-http" ? "Streamable HTTP" : "stdio"
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "N/A"
+  return new Date(iso).toLocaleString()
+}
+
+function formatInterval(ms: number): string {
+  if (ms < 60_000) return `${ms / 1000}s`
+  if (ms < 3_600_000) return `${ms / 60_000}m`
+  return `${ms / 3_600_000}h`
+}
+
+export default function McpServerDetailPage(): React.JSX.Element {
+  const params = useParams<{ id: string }>()
+  const router = useRouter()
+  const [editOpen, setEditOpen] = useState(false)
+  const [deleteConfirm, setDeleteConfirm] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  const {
+    data: server,
+    isLoading,
+    error,
+    errorCode,
+    refetch,
+  } = useApiQuery(() => getMcpServer(params.id), [params.id])
+
+  const handleRefreshTools = useCallback(async () => {
+    setRefreshing(true)
+    try {
+      await refreshMcpServer(params.id)
+      await refetch()
+    } finally {
+      setRefreshing(false)
+    }
+  }, [params.id, refetch])
+
+  const handleDelete = useCallback(async () => {
+    setDeleting(true)
+    try {
+      await deleteMcpServer(params.id)
+      router.push("/mcp-servers")
+    } catch {
+      setDeleting(false)
+      setDeleteConfirm(false)
+    }
+  }, [params.id, router])
+
+  const handleEditSuccess = useCallback(() => {
+    setEditOpen(false)
+    void refetch()
+  }, [refetch])
+
+  // Loading
+  if (isLoading && !server) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <div className="lg:col-span-2 space-y-4">
+            <Skeleton className="h-48 w-full" />
+            <Skeleton className="h-64 w-full" />
+          </div>
+          <div className="space-y-4">
+            <Skeleton className="h-48 w-full" />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Error
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <Link
+          href="/mcp-servers"
+          className="inline-flex items-center gap-1 text-sm text-text-muted hover:text-primary transition-colors"
+        >
+          <span className="material-symbols-outlined text-[16px]">arrow_back</span>
+          Back to servers
+        </Link>
+        <ApiErrorBanner error={error} errorCode={errorCode} onRetry={() => void refetch()} />
+      </div>
+    )
+  }
+
+  if (!server) return <></>
+
+  return (
+    <div className="space-y-6">
+      {/* Breadcrumb + actions */}
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/mcp-servers"
+            className="flex size-8 items-center justify-center rounded-lg text-text-muted hover:bg-secondary transition-colors"
+          >
+            <span className="material-symbols-outlined text-[20px]">arrow_back</span>
+          </Link>
+          <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10">
+            <span className="material-symbols-outlined text-[20px] text-primary">dns</span>
+          </div>
+          <div>
+            <h1 className="font-display text-2xl font-extrabold tracking-tight text-text-main dark:text-slate-100">
+              {server.name}
+            </h1>
+            <p className="text-xs text-text-muted">{server.slug}</p>
+          </div>
+          <McpHealthBadge status={server.status} />
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            onClick={() => void handleRefreshTools()}
+            disabled={refreshing}
+            className="flex items-center gap-2 rounded-lg border border-primary/20 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary transition-all hover:bg-primary/20 disabled:opacity-50"
+          >
+            {refreshing ? (
+              <span className="size-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            ) : (
+              <span className="material-symbols-outlined text-lg">refresh</span>
+            )}
+            Refresh Tools
+          </button>
+          <button
+            onClick={() => setEditOpen(true)}
+            className="flex items-center gap-2 rounded-lg bg-slate-200 px-4 py-2 text-sm font-semibold transition-all hover:bg-slate-300 dark:bg-slate-800 dark:hover:bg-slate-700"
+          >
+            <span className="material-symbols-outlined text-lg">edit</span>
+            Edit
+          </button>
+          <button
+            onClick={() => setDeleteConfirm(true)}
+            className="flex items-center gap-2 rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-2 text-sm font-semibold text-red-500 transition-all hover:bg-red-500/20"
+          >
+            <span className="material-symbols-outlined text-lg">delete</span>
+            Delete
+          </button>
+        </div>
+      </div>
+
+      {/* Content grid */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        {/* Left: info + tools */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Server info */}
+          <div className="rounded-xl border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900/40">
+            <div className="border-b border-slate-100 px-5 py-3 dark:border-slate-800">
+              <h2 className="text-sm font-bold text-text-main dark:text-white">
+                Server Information
+              </h2>
+            </div>
+            <div className="grid grid-cols-2 gap-4 p-5 sm:grid-cols-3">
+              <InfoItem label="Transport" value={transportLabel(server.transport)} />
+              <InfoItem
+                label="Endpoint"
+                value={
+                  server.transport === "streamable-http"
+                    ? ((server.connection.url as string) ?? "N/A")
+                    : ((server.connection.command as string) ?? "N/A")
+                }
+              />
+              <InfoItem
+                label="Health Interval"
+                value={formatInterval(server.health_probe_interval_ms)}
+              />
+              <InfoItem label="Protocol Version" value={server.protocol_version ?? "Unknown"} />
+              <InfoItem label="Created" value={formatDate(server.created_at)} />
+              <InfoItem label="Last Healthy" value={formatDate(server.last_healthy_at)} />
+            </div>
+            {server.description && (
+              <div className="border-t border-slate-100 px-5 py-3 dark:border-slate-800">
+                <p className="text-xs text-text-muted">{server.description}</p>
+              </div>
+            )}
+            {server.error_message && (
+              <div className="border-t border-red-500/10 bg-red-500/5 px-5 py-3">
+                <div className="flex items-start gap-2">
+                  <span className="material-symbols-outlined mt-0.5 text-[16px] text-red-500">
+                    error
+                  </span>
+                  <div>
+                    <p className="text-xs font-semibold text-red-500">Error</p>
+                    <p className="mt-0.5 text-xs text-red-400">{server.error_message}</p>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Tool catalog */}
+          <div className="rounded-xl border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900/40">
+            <div className="border-b border-slate-100 px-5 py-3 dark:border-slate-800">
+              <div className="flex items-center justify-between">
+                <h2 className="text-sm font-bold text-text-main dark:text-white">Tool Catalog</h2>
+                <span className="text-xs font-medium text-text-muted">
+                  {server.tools.length} {server.tools.length === 1 ? "tool" : "tools"}
+                </span>
+              </div>
+            </div>
+            <div className="p-5">
+              <McpToolList tools={server.tools} />
+            </div>
+          </div>
+        </div>
+
+        {/* Right: capabilities + agent scope */}
+        <div className="space-y-6">
+          {/* Capabilities */}
+          {server.capabilities && Object.keys(server.capabilities).length > 0 && (
+            <div className="rounded-xl border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900/40">
+              <div className="border-b border-slate-100 px-5 py-3 dark:border-slate-800">
+                <h2 className="text-sm font-bold text-text-main dark:text-white">Capabilities</h2>
+              </div>
+              <div className="p-5">
+                <div className="flex flex-wrap gap-2">
+                  {Object.entries(server.capabilities).map(([key, val]) => (
+                    <span
+                      key={key}
+                      className={`rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider ${
+                        val
+                          ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                          : "border-slate-300/20 bg-slate-300/10 text-slate-400"
+                      }`}
+                    >
+                      {key}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Server info (JSON) */}
+          {server.server_info && Object.keys(server.server_info).length > 0 && (
+            <div className="rounded-xl border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900/40">
+              <div className="border-b border-slate-100 px-5 py-3 dark:border-slate-800">
+                <h2 className="text-sm font-bold text-text-main dark:text-white">
+                  Server Metadata
+                </h2>
+              </div>
+              <div className="p-5">
+                <pre className="overflow-x-auto text-xs text-text-muted leading-relaxed">
+                  {JSON.stringify(server.server_info, null, 2)}
+                </pre>
+              </div>
+            </div>
+          )}
+
+          {/* Agent scope */}
+          <div className="rounded-xl border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900/40">
+            <div className="border-b border-slate-100 px-5 py-3 dark:border-slate-800">
+              <h2 className="text-sm font-bold text-text-main dark:text-white">Agent Scope</h2>
+            </div>
+            <div className="p-5">
+              {server.agent_scope.length === 0 ? (
+                <p className="text-xs text-text-muted">
+                  Available to all agents (no scope restriction).
+                </p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {server.agent_scope.map((agentId) => (
+                    <span
+                      key={agentId}
+                      className="rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-[10px] font-bold text-primary"
+                    >
+                      {agentId}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Edit modal */}
+      <McpServerForm
+        open={editOpen}
+        onClose={() => setEditOpen(false)}
+        onSuccess={handleEditSuccess}
+        server={server}
+      />
+
+      {/* Delete confirmation dialog */}
+      {deleteConfirm && (
+        <DeleteConfirmDialog
+          serverName={server.name}
+          deleting={deleting}
+          onConfirm={() => void handleDelete()}
+          onCancel={() => setDeleteConfirm(false)}
+        />
+      )}
+    </div>
+  )
+}
+
+/* ── Sub-components ──────────────────────────────────── */
+
+function InfoItem({ label, value }: { label: string; value: string }): React.JSX.Element {
+  return (
+    <div>
+      <p className="text-[10px] font-bold uppercase tracking-wider text-text-muted">{label}</p>
+      <p className="mt-0.5 truncate text-sm font-medium text-text-main dark:text-white">{value}</p>
+    </div>
+  )
+}
+
+function DeleteConfirmDialog({
+  serverName,
+  deleting,
+  onConfirm,
+  onCancel,
+}: {
+  serverName: string
+  deleting: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}): React.JSX.Element {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-sm rounded-xl border border-surface-border bg-surface-light p-6 shadow-2xl dark:bg-surface-dark">
+        <div className="flex items-start gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-red-500/10">
+            <span className="material-symbols-outlined text-[20px] text-red-500">warning</span>
+          </div>
+          <div>
+            <h3 className="text-sm font-bold text-text-main dark:text-white">Delete server?</h3>
+            <p className="mt-1 text-xs text-text-muted">
+              This will permanently delete <strong>{serverName}</strong> and all its registered
+              tools. This action cannot be undone.
+            </p>
+          </div>
+        </div>
+        <div className="mt-5 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={deleting}
+            className="rounded-lg border border-surface-border px-4 py-2 text-sm font-semibold text-text-main transition-colors hover:bg-secondary dark:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={deleting}
+            className="flex items-center gap-2 rounded-lg bg-red-500 px-4 py-2 text-sm font-semibold text-white transition-all hover:bg-red-600 disabled:opacity-50"
+          >
+            {deleting && (
+              <span className="size-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+            )}
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/dashboard/src/app/mcp-servers/page.tsx
+++ b/packages/dashboard/src/app/mcp-servers/page.tsx
@@ -1,0 +1,211 @@
+"use client"
+
+import { useCallback, useMemo, useState } from "react"
+
+import { ApiErrorBanner } from "@/components/layout/api-error-banner"
+import { EmptyState } from "@/components/layout/empty-state"
+import { Skeleton } from "@/components/layout/skeleton"
+import { McpHealthBadge } from "@/components/mcp/McpHealthBadge"
+import { McpServerCard } from "@/components/mcp/McpServerCard"
+import { McpServerForm } from "@/components/mcp/McpServerForm"
+import { useApiQuery } from "@/hooks/use-api"
+import type { McpServer, McpServerStatus } from "@/lib/api-client"
+import { listMcpServers } from "@/lib/api-client"
+
+const STATUS_FILTERS: { label: string; value: McpServerStatus | "ALL" }[] = [
+  { label: "All Statuses", value: "ALL" },
+  { label: "Active", value: "ACTIVE" },
+  { label: "Pending", value: "PENDING" },
+  { label: "Degraded", value: "DEGRADED" },
+  { label: "Error", value: "ERROR" },
+  { label: "Disabled", value: "DISABLED" },
+]
+
+export default function McpServersPage(): React.JSX.Element {
+  const [search, setSearch] = useState("")
+  const [statusFilter, setStatusFilter] = useState<McpServerStatus | "ALL">("ALL")
+  const [registerOpen, setRegisterOpen] = useState(false)
+
+  const { data, isLoading, error, errorCode, refetch } = useApiQuery(
+    () => listMcpServers({ limit: 100 }),
+    [],
+  )
+
+  const servers: McpServer[] = data?.servers ?? []
+
+  const filtered = useMemo(() => {
+    return servers.filter((s) => {
+      if (statusFilter !== "ALL" && s.status !== statusFilter) return false
+      if (search) {
+        const q = search.toLowerCase()
+        return (
+          s.name.toLowerCase().includes(q) ||
+          s.slug.toLowerCase().includes(q) ||
+          (s.description ?? "").toLowerCase().includes(q)
+        )
+      }
+      return true
+    })
+  }, [servers, search, statusFilter])
+
+  const activeCount = servers.filter((s) => s.status === "ACTIVE").length
+
+  const handleRefresh = useCallback(() => {
+    void refetch()
+  }, [refetch])
+
+  const handleRegisterSuccess = useCallback(() => {
+    setRegisterOpen(false)
+    void refetch()
+  }, [refetch])
+
+  // Loading skeleton
+  if (isLoading && servers.length === 0) {
+    return (
+      <div className="space-y-8">
+        <div className="flex items-center gap-3">
+          <span className="material-symbols-outlined text-[28px] text-primary">dns</span>
+          <h1 className="font-display text-2xl font-bold tracking-tight text-text-main dark:text-white">
+            MCP Servers
+          </h1>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="space-y-3 rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-900/40"
+            >
+              <div className="flex items-center gap-3">
+                <Skeleton className="size-10 rounded-lg" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-3 w-1/2" />
+                </div>
+              </div>
+              <Skeleton className="h-8 w-full" />
+              <div className="grid grid-cols-2 gap-3">
+                <Skeleton className="h-6 w-full" />
+                <Skeleton className="h-6 w-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+        <div className="space-y-1">
+          <h1 className="font-display text-3xl font-extrabold tracking-tight text-text-main dark:text-slate-100">
+            MCP Servers
+          </h1>
+          <p className="max-w-lg text-slate-500 dark:text-slate-400">
+            Register, monitor, and manage Model Context Protocol servers.
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <button
+            onClick={() => setRegisterOpen(true)}
+            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-primary/20 transition-all hover:bg-primary/90"
+          >
+            <span className="material-symbols-outlined text-lg">add</span>
+            Register Server
+          </button>
+        </div>
+      </div>
+
+      {/* Filters Bar */}
+      <div className="flex flex-wrap items-center justify-between gap-4 rounded-xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900/40">
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Search */}
+          <div className="relative">
+            <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-lg text-slate-400">
+              search
+            </span>
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search servers..."
+              className="rounded-lg border-none bg-slate-100 py-2 pl-10 pr-4 text-sm outline-none transition-all focus:ring-2 focus:ring-primary/50 dark:bg-slate-800"
+            />
+          </div>
+
+          {/* Status Filter */}
+          <div className="relative">
+            <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-lg text-slate-400">
+              filter_alt
+            </span>
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value as McpServerStatus | "ALL")}
+              className="cursor-pointer appearance-none rounded-lg border-none bg-slate-100 py-2 pl-10 pr-8 text-sm focus:ring-2 focus:ring-primary/50 dark:bg-slate-800"
+            >
+              {STATUS_FILTERS.map((f) => (
+                <option key={f.value} value={f.value}>
+                  {f.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          {/* Active count */}
+          <McpHealthBadge status="ACTIVE" />
+          <span className="text-xs font-bold text-slate-500">{activeCount} active</span>
+
+          {/* Refresh */}
+          <button
+            onClick={handleRefresh}
+            className="flex items-center gap-2 rounded-lg border border-primary/20 bg-primary/10 px-4 py-2 text-sm font-bold text-primary transition-all hover:bg-primary/20"
+          >
+            <span className="material-symbols-outlined text-lg">refresh</span>
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && <ApiErrorBanner error={error} errorCode={errorCode} onRetry={handleRefresh} />}
+
+      {/* Empty state */}
+      {!isLoading && !error && servers.length === 0 ? (
+        <EmptyState
+          icon="dns"
+          title="No MCP servers registered"
+          description="Register your first MCP server to connect tools and capabilities to your agents."
+          actionLabel="Register Server"
+          onAction={() => setRegisterOpen(true)}
+        />
+      ) : (
+        <>
+          {/* Count */}
+          <div className="text-sm font-medium text-slate-500 dark:text-slate-400">
+            Showing{" "}
+            <span className="font-bold text-slate-900 dark:text-slate-100">{filtered.length}</span>{" "}
+            of{" "}
+            <span className="font-bold text-slate-900 dark:text-slate-100">{servers.length}</span>{" "}
+            servers
+          </div>
+
+          {/* Server grid */}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {filtered.map((server) => (
+              <McpServerCard key={server.id} server={server} />
+            ))}
+          </div>
+        </>
+      )}
+
+      <McpServerForm
+        open={registerOpen}
+        onClose={() => setRegisterOpen(false)}
+        onSuccess={handleRegisterSuccess}
+      />
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/layout/nav-shell.tsx
+++ b/packages/dashboard/src/components/layout/nav-shell.tsx
@@ -11,6 +11,7 @@ import { useAuthGuard } from "@/hooks/use-auth-guard"
 const navItems = [
   { href: "/", label: "Dashboard", icon: "dashboard" },
   { href: "/agents", label: "Agents", icon: "smart_toy" },
+  { href: "/mcp-servers", label: "MCP Servers", icon: "dns" },
   { href: "/approvals", label: "Approvals", icon: "verified_user" },
   { href: "/jobs", label: "Jobs", icon: "list_alt" },
   { href: "/memory", label: "Memory", icon: "memory" },

--- a/packages/dashboard/src/components/mcp/McpHealthBadge.tsx
+++ b/packages/dashboard/src/components/mcp/McpHealthBadge.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import type { McpServerStatus } from "@/lib/api-client"
+
+const STATUS_CONFIG: Record<
+  McpServerStatus,
+  { label: string; dotClass: string; bgClass: string; textClass: string }
+> = {
+  ACTIVE: {
+    label: "Active",
+    dotClass: "bg-emerald-500",
+    bgClass: "border-emerald-500/20 bg-emerald-500/10",
+    textClass: "text-emerald-600 dark:text-emerald-400",
+  },
+  PENDING: {
+    label: "Pending",
+    dotClass: "bg-amber-500",
+    bgClass: "border-amber-500/20 bg-amber-500/10",
+    textClass: "text-amber-600 dark:text-amber-400",
+  },
+  DEGRADED: {
+    label: "Degraded",
+    dotClass: "bg-orange-500",
+    bgClass: "border-orange-500/20 bg-orange-500/10",
+    textClass: "text-orange-600 dark:text-orange-400",
+  },
+  ERROR: {
+    label: "Error",
+    dotClass: "bg-red-500",
+    bgClass: "border-red-500/20 bg-red-500/10",
+    textClass: "text-red-500",
+  },
+  DISABLED: {
+    label: "Disabled",
+    dotClass: "bg-slate-400",
+    bgClass: "border-slate-400/20 bg-slate-400/10",
+    textClass: "text-slate-500 dark:text-slate-400",
+  },
+}
+
+interface McpHealthBadgeProps {
+  status: McpServerStatus
+}
+
+export function McpHealthBadge({ status }: McpHealthBadgeProps): React.JSX.Element {
+  const config = STATUS_CONFIG[status] ?? STATUS_CONFIG.PENDING
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 ${config.bgClass}`}
+    >
+      <span
+        className={`size-1.5 rounded-full ${config.dotClass} ${status === "ACTIVE" ? "animate-pulse" : ""}`}
+      />
+      <span className={`text-[10px] font-bold uppercase tracking-wider ${config.textClass}`}>
+        {config.label}
+      </span>
+    </span>
+  )
+}

--- a/packages/dashboard/src/components/mcp/McpServerCard.tsx
+++ b/packages/dashboard/src/components/mcp/McpServerCard.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import Link from "next/link"
+
+import type { McpServer } from "@/lib/api-client"
+
+import { McpHealthBadge } from "./McpHealthBadge"
+
+function transportLabel(transport: string): string {
+  return transport === "streamable-http" ? "HTTP" : "stdio"
+}
+
+function timeAgo(iso: string | null | undefined): string {
+  if (!iso) return "Never"
+  const diff = Date.now() - new Date(iso).getTime()
+  const seconds = Math.floor(diff / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+interface McpServerCardProps {
+  server: McpServer
+  toolCount?: number
+}
+
+export function McpServerCard({ server, toolCount }: McpServerCardProps): React.JSX.Element {
+  return (
+    <Link
+      href={`/mcp-servers/${server.id}`}
+      className="group flex flex-col rounded-xl border border-slate-200 bg-white p-5 transition-all hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 dark:border-slate-800 dark:bg-slate-900/40 dark:hover:border-primary/30"
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+            <span className="material-symbols-outlined text-[20px] text-primary">dns</span>
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 className="truncate text-sm font-bold text-text-main dark:text-white group-hover:text-primary transition-colors">
+              {server.name}
+            </h3>
+            <p className="truncate text-xs text-text-muted">{server.slug}</p>
+          </div>
+        </div>
+        <McpHealthBadge status={server.status} />
+      </div>
+
+      {/* Description */}
+      {server.description && (
+        <p className="mt-3 line-clamp-2 text-xs text-text-muted leading-relaxed">
+          {server.description}
+        </p>
+      )}
+
+      {/* Footer stats */}
+      <div className="mt-auto pt-4 flex items-center gap-4 border-t border-slate-100 dark:border-slate-800 mt-4">
+        <div className="flex items-center gap-1.5">
+          <span className="material-symbols-outlined text-[14px] text-text-muted">swap_horiz</span>
+          <span className="text-xs font-medium text-text-muted">
+            {transportLabel(server.transport)}
+          </span>
+        </div>
+        {toolCount !== undefined && (
+          <div className="flex items-center gap-1.5">
+            <span className="material-symbols-outlined text-[14px] text-text-muted">build</span>
+            <span className="text-xs font-medium text-text-muted">
+              {toolCount} {toolCount === 1 ? "tool" : "tools"}
+            </span>
+          </div>
+        )}
+        <div className="ml-auto flex items-center gap-1.5">
+          <span className="material-symbols-outlined text-[14px] text-text-muted">schedule</span>
+          <span className="text-xs font-medium text-text-muted">
+            {timeAgo(server.last_healthy_at)}
+          </span>
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/packages/dashboard/src/components/mcp/McpServerForm.tsx
+++ b/packages/dashboard/src/components/mcp/McpServerForm.tsx
@@ -1,0 +1,458 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import type { CreateMcpServerRequest, McpServer, McpTransport } from "@/lib/api-client"
+import { createMcpServer, updateMcpServer } from "@/lib/api-client"
+
+interface McpServerFormProps {
+  open: boolean
+  onClose: () => void
+  onSuccess: () => void
+  /** When set, form acts as "edit" mode pre-populated with server data. */
+  server?: McpServer
+}
+
+interface FormState {
+  name: string
+  slug: string
+  transport: McpTransport
+  description: string
+  url: string
+  headers: Array<{ key: string; value: string }>
+  command: string
+  image: string
+  envVars: Array<{ key: string; value: string }>
+  healthProbeIntervalMs: number
+}
+
+function initialState(server?: McpServer): FormState {
+  if (server) {
+    const conn = server.connection
+    return {
+      name: server.name,
+      slug: server.slug,
+      transport: server.transport,
+      description: server.description ?? "",
+      url: (conn.url as string) ?? "",
+      headers: Array.isArray(conn.headers)
+        ? (conn.headers as Array<{ key: string; value: string }>)
+        : Object.entries((conn.headers as Record<string, string>) ?? {}).map(([key, value]) => ({
+            key,
+            value,
+          })),
+      command: (conn.command as string) ?? "",
+      image: (conn.image as string) ?? "",
+      envVars: Array.isArray(conn.env)
+        ? (conn.env as Array<{ key: string; value: string }>)
+        : Object.entries((conn.env as Record<string, string>) ?? {}).map(([key, value]) => ({
+            key,
+            value,
+          })),
+      healthProbeIntervalMs: server.health_probe_interval_ms,
+    }
+  }
+  return {
+    name: "",
+    slug: "",
+    transport: "streamable-http",
+    description: "",
+    url: "",
+    headers: [],
+    command: "",
+    image: "",
+    envVars: [],
+    healthProbeIntervalMs: 30000,
+  }
+}
+
+export function McpServerForm({
+  open,
+  onClose,
+  onSuccess,
+  server,
+}: McpServerFormProps): React.JSX.Element | null {
+  const [form, setForm] = useState<FormState>(() => initialState(server))
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  const isEdit = !!server
+
+  // Reset form when server prop changes
+  useEffect(() => {
+    setForm(initialState(server))
+    setError(null)
+  }, [server])
+
+  // Open/close dialog
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    if (open && !dialog.open) {
+      dialog.showModal()
+    } else if (!open && dialog.open) {
+      dialog.close()
+    }
+  }, [open])
+
+  const updateField = useCallback(<K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }))
+  }, [])
+
+  const addKvPair = useCallback((field: "headers" | "envVars") => {
+    setForm((prev) => ({ ...prev, [field]: [...prev[field], { key: "", value: "" }] }))
+  }, [])
+
+  const removeKvPair = useCallback((field: "headers" | "envVars", index: number) => {
+    setForm((prev) => ({
+      ...prev,
+      [field]: prev[field].filter((_, i) => i !== index),
+    }))
+  }, [])
+
+  const updateKvPair = useCallback(
+    (field: "headers" | "envVars", index: number, key: string, value: string) => {
+      setForm((prev) => ({
+        ...prev,
+        [field]: prev[field].map((pair, i) => (i === index ? { key, value } : pair)),
+      }))
+    },
+    [],
+  )
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault()
+      setError(null)
+
+      if (!form.name.trim()) {
+        setError("Name is required")
+        return
+      }
+
+      const connection: Record<string, unknown> = {}
+      if (form.transport === "streamable-http") {
+        if (!form.url.trim()) {
+          setError("URL is required for HTTP transport")
+          return
+        }
+        connection.url = form.url.trim()
+        const headersObj: Record<string, string> = {}
+        for (const h of form.headers) {
+          if (h.key.trim()) headersObj[h.key.trim()] = h.value
+        }
+        if (Object.keys(headersObj).length > 0) connection.headers = headersObj
+      } else {
+        if (!form.command.trim()) {
+          setError("Command is required for stdio transport")
+          return
+        }
+        connection.command = form.command.trim()
+        if (form.image.trim()) connection.image = form.image.trim()
+        const envObj: Record<string, string> = {}
+        for (const v of form.envVars) {
+          if (v.key.trim()) envObj[v.key.trim()] = v.value
+        }
+        if (Object.keys(envObj).length > 0) connection.env = envObj
+      }
+
+      const body: CreateMcpServerRequest = {
+        name: form.name.trim(),
+        transport: form.transport,
+        connection,
+        description: form.description.trim() || undefined,
+        health_probe_interval_ms: form.healthProbeIntervalMs,
+      }
+      if (form.slug.trim()) body.slug = form.slug.trim()
+
+      setSubmitting(true)
+      try {
+        if (isEdit && server) {
+          await updateMcpServer(server.id, body)
+        } else {
+          await createMcpServer(body)
+        }
+        onSuccess()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "An error occurred")
+      } finally {
+        setSubmitting(false)
+      }
+    },
+    [form, isEdit, server, onSuccess],
+  )
+
+  if (!open) return null
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onClose}
+      className="fixed inset-0 z-50 m-auto w-full max-w-lg rounded-xl border border-surface-border bg-surface-light p-0 shadow-2xl backdrop:bg-black/50 dark:bg-surface-dark"
+    >
+      <form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-surface-border px-6 py-4">
+          <h2 className="font-display text-lg font-bold text-text-main dark:text-white">
+            {isEdit ? "Edit MCP Server" : "Register MCP Server"}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex size-8 items-center justify-center rounded-lg text-text-muted hover:bg-secondary transition-colors"
+          >
+            <span className="material-symbols-outlined text-[20px]">close</span>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="space-y-4 overflow-y-auto px-6 py-5" style={{ maxHeight: "60vh" }}>
+          {/* Name */}
+          <div>
+            <label className="mb-1.5 block text-xs font-semibold text-text-muted">Name</label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => updateField("name", e.target.value)}
+              placeholder="My MCP Server"
+              className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main outline-none transition-all focus:border-primary focus:ring-2 focus:ring-primary/20 dark:bg-slate-800"
+            />
+          </div>
+
+          {/* Slug (optional) */}
+          <div>
+            <label className="mb-1.5 block text-xs font-semibold text-text-muted">
+              Slug <span className="font-normal">(optional, auto-generated)</span>
+            </label>
+            <input
+              type="text"
+              value={form.slug}
+              onChange={(e) => updateField("slug", e.target.value)}
+              placeholder="my-mcp-server"
+              pattern="^[a-z0-9-]*$"
+              className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main outline-none transition-all focus:border-primary focus:ring-2 focus:ring-primary/20 dark:bg-slate-800"
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="mb-1.5 block text-xs font-semibold text-text-muted">
+              Description
+            </label>
+            <textarea
+              value={form.description}
+              onChange={(e) => updateField("description", e.target.value)}
+              placeholder="What does this server provide?"
+              rows={2}
+              className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main outline-none transition-all focus:border-primary focus:ring-2 focus:ring-primary/20 dark:bg-slate-800 resize-none"
+            />
+          </div>
+
+          {/* Transport selector */}
+          <div>
+            <label className="mb-1.5 block text-xs font-semibold text-text-muted">Transport</label>
+            <div className="flex gap-2">
+              {(["streamable-http", "stdio"] as const).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => updateField("transport", t)}
+                  className={`flex-1 rounded-lg border px-4 py-2.5 text-sm font-semibold transition-all ${
+                    form.transport === t
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-surface-border text-text-muted hover:bg-secondary"
+                  }`}
+                >
+                  <span className="material-symbols-outlined mr-1.5 align-middle text-[16px]">
+                    {t === "streamable-http" ? "language" : "terminal"}
+                  </span>
+                  {t === "streamable-http" ? "Streamable HTTP" : "stdio"}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* HTTP connection fields */}
+          {form.transport === "streamable-http" && (
+            <>
+              <div>
+                <label className="mb-1.5 block text-xs font-semibold text-text-muted">URL</label>
+                <input
+                  type="url"
+                  value={form.url}
+                  onChange={(e) => updateField("url", e.target.value)}
+                  placeholder="https://mcp.example.com/sse"
+                  className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main outline-none transition-all focus:border-primary focus:ring-2 focus:ring-primary/20 dark:bg-slate-800"
+                />
+              </div>
+              <KeyValueEditor
+                label="Headers"
+                pairs={form.headers}
+                keyPlaceholder="Authorization"
+                valuePlaceholder="Bearer token..."
+                onAdd={() => addKvPair("headers")}
+                onRemove={(i) => removeKvPair("headers", i)}
+                onUpdate={(i, k, v) => updateKvPair("headers", i, k, v)}
+              />
+            </>
+          )}
+
+          {/* stdio connection fields */}
+          {form.transport === "stdio" && (
+            <>
+              <div>
+                <label className="mb-1.5 block text-xs font-semibold text-text-muted">
+                  Command
+                </label>
+                <input
+                  type="text"
+                  value={form.command}
+                  onChange={(e) => updateField("command", e.target.value)}
+                  placeholder="npx -y @example/mcp-server"
+                  className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main outline-none transition-all focus:border-primary focus:ring-2 focus:ring-primary/20 dark:bg-slate-800"
+                />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-xs font-semibold text-text-muted">
+                  Image <span className="font-normal">(optional)</span>
+                </label>
+                <input
+                  type="text"
+                  value={form.image}
+                  onChange={(e) => updateField("image", e.target.value)}
+                  placeholder="node:20-slim"
+                  className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main outline-none transition-all focus:border-primary focus:ring-2 focus:ring-primary/20 dark:bg-slate-800"
+                />
+              </div>
+              <KeyValueEditor
+                label="Environment Variables"
+                pairs={form.envVars}
+                keyPlaceholder="API_KEY"
+                valuePlaceholder="value..."
+                onAdd={() => addKvPair("envVars")}
+                onRemove={(i) => removeKvPair("envVars", i)}
+                onUpdate={(i, k, v) => updateKvPair("envVars", i, k, v)}
+              />
+            </>
+          )}
+
+          {/* Health probe interval */}
+          <div>
+            <label className="mb-1.5 block text-xs font-semibold text-text-muted">
+              Health Probe Interval
+            </label>
+            <select
+              value={form.healthProbeIntervalMs}
+              onChange={(e) => updateField("healthProbeIntervalMs", Number(e.target.value))}
+              className="w-full cursor-pointer rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main outline-none transition-all focus:border-primary focus:ring-2 focus:ring-primary/20 dark:bg-slate-800"
+            >
+              <option value={10000}>10 seconds</option>
+              <option value={30000}>30 seconds</option>
+              <option value={60000}>1 minute</option>
+              <option value={300000}>5 minutes</option>
+              <option value={900000}>15 minutes</option>
+              <option value={3600000}>1 hour</option>
+            </select>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2">
+              <span className="material-symbols-outlined mt-0.5 text-[16px] text-red-500">
+                error
+              </span>
+              <p className="text-xs text-red-500">{error}</p>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 border-t border-surface-border px-6 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-surface-border px-4 py-2 text-sm font-semibold text-text-main transition-colors hover:bg-secondary dark:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="flex items-center gap-2 rounded-lg bg-primary px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-primary/20 transition-all hover:bg-primary/90 disabled:opacity-50"
+          >
+            {submitting && (
+              <span className="size-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+            )}
+            {isEdit ? "Save Changes" : "Register Server"}
+          </button>
+        </div>
+      </form>
+    </dialog>
+  )
+}
+
+/* ── Key-Value pair editor ────────────────────────────── */
+
+function KeyValueEditor({
+  label,
+  pairs,
+  keyPlaceholder,
+  valuePlaceholder,
+  onAdd,
+  onRemove,
+  onUpdate,
+}: {
+  label: string
+  pairs: Array<{ key: string; value: string }>
+  keyPlaceholder: string
+  valuePlaceholder: string
+  onAdd: () => void
+  onRemove: (index: number) => void
+  onUpdate: (index: number, key: string, value: string) => void
+}): React.JSX.Element {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center justify-between">
+        <label className="text-xs font-semibold text-text-muted">{label}</label>
+        <button
+          type="button"
+          onClick={onAdd}
+          className="flex items-center gap-1 text-xs font-semibold text-primary hover:text-primary/80 transition-colors"
+        >
+          <span className="material-symbols-outlined text-[14px]">add</span>
+          Add
+        </button>
+      </div>
+      {pairs.length > 0 && (
+        <div className="space-y-2">
+          {pairs.map((pair, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <input
+                type="text"
+                value={pair.key}
+                onChange={(e) => onUpdate(i, e.target.value, pair.value)}
+                placeholder={keyPlaceholder}
+                className="flex-1 rounded-lg border border-surface-border bg-surface-dark px-3 py-1.5 text-xs text-text-main outline-none focus:border-primary dark:bg-slate-800"
+              />
+              <input
+                type="text"
+                value={pair.value}
+                onChange={(e) => onUpdate(i, pair.key, e.target.value)}
+                placeholder={valuePlaceholder}
+                className="flex-1 rounded-lg border border-surface-border bg-surface-dark px-3 py-1.5 text-xs text-text-main outline-none focus:border-primary dark:bg-slate-800"
+              />
+              <button
+                type="button"
+                onClick={() => onRemove(i)}
+                className="flex size-7 shrink-0 items-center justify-center rounded-lg text-text-muted hover:bg-red-500/10 hover:text-red-500 transition-colors"
+              >
+                <span className="material-symbols-outlined text-[16px]">close</span>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/mcp/McpToolList.tsx
+++ b/packages/dashboard/src/components/mcp/McpToolList.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import { useState } from "react"
+
+import type { McpServerTool } from "@/lib/api-client"
+
+interface McpToolListProps {
+  tools: McpServerTool[]
+}
+
+function ToolStatusBadge({ status }: { status: string }): React.JSX.Element {
+  const isAvailable = status === "available"
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
+        isAvailable
+          ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+          : "border-slate-400/20 bg-slate-400/10 text-slate-500 dark:text-slate-400"
+      }`}
+    >
+      <span className={`size-1 rounded-full ${isAvailable ? "bg-emerald-500" : "bg-slate-400"}`} />
+      {status}
+    </span>
+  )
+}
+
+export function McpToolList({ tools }: McpToolListProps): React.JSX.Element {
+  const [search, setSearch] = useState("")
+  const [expanded, setExpanded] = useState<string | null>(null)
+
+  const filtered = tools.filter((t) => {
+    if (!search) return true
+    const q = search.toLowerCase()
+    return (
+      t.name.toLowerCase().includes(q) ||
+      (t.description ?? "").toLowerCase().includes(q) ||
+      t.qualified_name.toLowerCase().includes(q)
+    )
+  })
+
+  if (tools.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-surface-border px-6 py-10 text-center">
+        <div className="mb-3 flex size-10 items-center justify-center rounded-full bg-primary/10">
+          <span className="material-symbols-outlined text-[20px] text-primary">build</span>
+        </div>
+        <h3 className="text-sm font-bold text-text-main dark:text-white">No tools discovered</h3>
+        <p className="mt-1 max-w-sm text-xs text-text-muted">
+          Tools will appear here after the server is probed successfully.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Search */}
+      {tools.length > 5 && (
+        <div className="relative">
+          <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-lg text-slate-400">
+            search
+          </span>
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Filter tools..."
+            className="w-full rounded-lg border-none bg-slate-100 py-2 pl-10 pr-4 text-sm outline-none transition-all focus:ring-2 focus:ring-primary/50 dark:bg-slate-800"
+          />
+        </div>
+      )}
+
+      {/* Tool list */}
+      <div className="divide-y divide-slate-100 rounded-xl border border-slate-200 bg-white dark:divide-slate-800 dark:border-slate-800 dark:bg-slate-900/40">
+        {filtered.map((tool) => (
+          <div key={tool.id} className="px-4 py-3">
+            <button
+              type="button"
+              onClick={() => setExpanded(expanded === tool.id ? null : tool.id)}
+              className="flex w-full items-center gap-3 text-left"
+            >
+              <span className="material-symbols-outlined text-[18px] text-primary">build</span>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold text-text-main dark:text-white">
+                    {tool.name}
+                  </span>
+                  <ToolStatusBadge status={tool.status} />
+                </div>
+                {tool.description && (
+                  <p className="mt-0.5 truncate text-xs text-text-muted">{tool.description}</p>
+                )}
+              </div>
+              <span
+                className={`material-symbols-outlined text-[16px] text-text-muted transition-transform ${expanded === tool.id ? "rotate-180" : ""}`}
+              >
+                expand_more
+              </span>
+            </button>
+
+            {/* Expanded: show input schema */}
+            {expanded === tool.id && (
+              <div className="mt-3 ml-8 rounded-lg bg-slate-50 p-3 dark:bg-slate-800/60">
+                <p className="mb-1.5 text-[10px] font-bold uppercase tracking-wider text-text-muted">
+                  Input Schema
+                </p>
+                <pre className="overflow-x-auto text-xs text-text-muted leading-relaxed">
+                  {JSON.stringify(tool.input_schema, null, 2)}
+                </pre>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Count */}
+      <p className="text-xs text-text-muted">
+        {filtered.length === tools.length
+          ? `${tools.length} ${tools.length === 1 ? "tool" : "tools"}`
+          : `${filtered.length} of ${tools.length} tools`}
+      </p>
+    </div>
+  )
+}

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -43,6 +43,11 @@ import {
   ProviderListResponseSchema,
 } from "./schemas/credentials"
 import { JobDetailSchema, JobListResponseSchema } from "./schemas/jobs"
+import {
+  McpServerDetailSchema,
+  McpServerListResponseSchema,
+  McpServerSchema,
+} from "./schemas/mcp-servers"
 import { MemorySearchResponseSchema } from "./schemas/memory"
 
 // ---------------------------------------------------------------------------
@@ -805,4 +810,67 @@ export async function unbindAgentCredential(
     method: "DELETE",
     schema: z.unknown(),
   })
+}
+
+// ---------------------------------------------------------------------------
+// MCP server endpoint functions
+// ---------------------------------------------------------------------------
+
+export type {
+  McpServer,
+  McpServerDetail,
+  McpServerStatus,
+  McpServerTool,
+  McpTransport,
+} from "./schemas/mcp-servers"
+
+export interface CreateMcpServerRequest {
+  name: string
+  slug?: string
+  transport: "streamable-http" | "stdio"
+  connection: Record<string, unknown>
+  agent_scope?: string[]
+  description?: string
+  health_probe_interval_ms?: number
+}
+
+export async function listMcpServers(params?: {
+  status?: string
+  limit?: number
+  offset?: number
+}): Promise<{
+  servers: import("./schemas/mcp-servers").McpServer[]
+  pagination: import("./schemas/common").Pagination
+}> {
+  const search = new URLSearchParams()
+  if (params?.status) search.set("status", params.status)
+  if (params?.limit) search.set("limit", String(params.limit))
+  if (params?.offset) search.set("offset", String(params.offset))
+  const qs = search.toString()
+  return apiFetch(`/mcp-servers${qs ? `?${qs}` : ""}`, { schema: McpServerListResponseSchema })
+}
+
+export async function getMcpServer(
+  id: string,
+): Promise<import("./schemas/mcp-servers").McpServerDetail> {
+  return apiFetch(`/mcp-servers/${id}`, { schema: McpServerDetailSchema })
+}
+
+export async function createMcpServer(body: CreateMcpServerRequest): Promise<unknown> {
+  return apiFetch("/mcp-servers", { method: "POST", body, schema: McpServerSchema })
+}
+
+export async function updateMcpServer(
+  id: string,
+  body: Partial<CreateMcpServerRequest> & { status?: string },
+): Promise<unknown> {
+  return apiFetch(`/mcp-servers/${id}`, { method: "PUT", body, schema: McpServerSchema })
+}
+
+export async function deleteMcpServer(id: string): Promise<unknown> {
+  return apiFetch(`/mcp-servers/${id}`, { method: "DELETE", schema: z.unknown() })
+}
+
+export async function refreshMcpServer(id: string): Promise<unknown> {
+  return apiFetch(`/mcp-servers/${id}/refresh`, { method: "POST", schema: McpServerSchema })
 }

--- a/packages/dashboard/src/lib/schemas/mcp-servers.ts
+++ b/packages/dashboard/src/lib/schemas/mcp-servers.ts
@@ -1,0 +1,66 @@
+import { z } from "zod"
+
+import { PaginationSchema } from "./common"
+
+export const McpTransportSchema = z.enum(["streamable-http", "stdio"])
+
+export const McpServerStatusSchema = z.enum(["PENDING", "ACTIVE", "DEGRADED", "ERROR", "DISABLED"])
+
+export const McpServerToolSchema = z.object({
+  id: z.string(),
+  mcp_server_id: z.string(),
+  name: z.string(),
+  qualified_name: z.string(),
+  description: z.string().optional().nullable(),
+  input_schema: z.record(z.string(), z.unknown()),
+  annotations: z.record(z.string(), z.unknown()).optional().nullable(),
+  status: z.string(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export const McpServerSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  transport: McpTransportSchema,
+  connection: z.record(z.string(), z.unknown()),
+  agent_scope: z.array(z.string()),
+  description: z.string().optional().nullable(),
+  status: McpServerStatusSchema,
+  protocol_version: z.string().optional().nullable(),
+  server_info: z.record(z.string(), z.unknown()).optional().nullable(),
+  capabilities: z.record(z.string(), z.unknown()).optional().nullable(),
+  health_probe_interval_ms: z.number(),
+  last_healthy_at: z.string().optional().nullable(),
+  error_message: z.string().optional().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export const McpServerDetailSchema = McpServerSchema.extend({
+  tools: z.array(McpServerToolSchema).optional().default([]),
+})
+
+export const McpServerListResponseSchema = z
+  .object({
+    servers: z.array(McpServerSchema),
+    pagination: PaginationSchema.optional(),
+    count: z.number().optional(),
+  })
+  .transform((data) => {
+    if (data.pagination) {
+      return { servers: data.servers, pagination: data.pagination }
+    }
+    const total = data.count ?? data.servers.length
+    return {
+      servers: data.servers,
+      pagination: { total, limit: total, offset: 0, hasMore: false },
+    }
+  })
+
+export type McpTransport = z.infer<typeof McpTransportSchema>
+export type McpServerStatus = z.infer<typeof McpServerStatusSchema>
+export type McpServerTool = z.infer<typeof McpServerToolSchema>
+export type McpServer = z.infer<typeof McpServerSchema>
+export type McpServerDetail = z.infer<typeof McpServerDetailSchema>


### PR DESCRIPTION
## Summary
- Add MCP Servers list page (`/mcp-servers`) with status filtering, search, and card grid layout
- Add MCP Server detail page (`/mcp-servers/:id`) with server info, tool catalog, capabilities, and agent scope
- Add register/edit form dialog with transport-specific fields (Streamable HTTP / stdio)
- Add MCP health status badge component, server card, and tool list with expandable schema viewer
- Add Zod schemas and typed API client functions for all MCP server CRUD + refresh endpoints
- Add "MCP Servers" nav item to sidebar and mobile bottom tabs

Closes #287

## Test plan
- [x] Lint passes (0 errors on new/modified files)
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [x] Dashboard build passes (Next.js production build)
- [x] Control-plane tests pass (942/942)
- [ ] Manual: navigate to `/mcp-servers` from sidebar
- [ ] Manual: register a new MCP server via form
- [ ] Manual: view server detail page with tool catalog
- [ ] Manual: edit and delete server from detail page
- [ ] Manual: verify responsive layout on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP Servers management dashboard with list view, search, and status filtering
  * Added functionality to create, edit, and delete MCP servers with configuration options
  * Added detailed server pages displaying configuration, health status, and available tool catalog
  * Added server health status indicators and sidebar navigation for MCP Servers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->