### PR TITLE
feat(audit): enrich credential audit trail with agent/job/tool context

### DIFF
--- a/packages/control-plane/src/__tests__/credential-service.test.ts
+++ b/packages/control-plane/src/__tests__/credential-service.test.ts
@@ -327,7 +327,61 @@ describe("CredentialService.getToolSecret", () => {
         event_type: "credential_accessed",
         provider: "brave",
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        details: expect.objectContaining({ tool_name: "brave-search" }),
+        details: expect.objectContaining({ flow: "injection", tool_name: "brave-search" }),
+      }),
+    )
+  })
+
+  it("includes agent/job/tool context in audit log when provided", async () => {
+    const toolCred = makeCredRow({
+      credential_class: "tool_specific",
+      tool_name: "brave-search",
+      provider: "brave",
+    })
+
+    const { db, auditValues } = buildMockDb({ toolSecretCred: toolCred })
+
+    const service = new CredentialService(db, AUTH_CONFIG)
+    await service.getToolSecret("brave-search", {
+      agentId: "agent-111",
+      jobId: "job-222",
+      toolName: "brave-search",
+    })
+
+    expect(auditValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: "credential_accessed",
+        provider: "brave",
+        details: {
+          flow: "injection",
+          tool_name: "brave-search",
+          agent_id: "agent-111",
+          job_id: "job-222",
+        },
+      }),
+    )
+  })
+
+  it("omits absent context fields from audit details", async () => {
+    const toolCred = makeCredRow({
+      credential_class: "tool_specific",
+      tool_name: "brave-search",
+      provider: "brave",
+    })
+
+    const { db, auditValues } = buildMockDb({ toolSecretCred: toolCred })
+
+    const service = new CredentialService(db, AUTH_CONFIG)
+    await service.getToolSecret("brave-search", { agentId: "agent-111" })
+
+    expect(auditValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: "credential_accessed",
+        details: {
+          flow: "injection",
+          tool_name: "brave-search",
+          agent_id: "agent-111",
+        },
       }),
     )
   })
@@ -516,5 +570,99 @@ describe("SUPPORTED_PROVIDERS", () => {
     const openai = SUPPORTED_PROVIDERS.find((p) => p.id === "openai")
     expect(openai).toBeDefined()
     expect(openai!.credentialClass).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: getAuditLog filter parameters
+// ---------------------------------------------------------------------------
+
+describe("CredentialService.getAuditLog", () => {
+  function buildAuditMockDb() {
+    const whereCalls: Array<[unknown, string, unknown]> = []
+
+    const execute = vi.fn().mockResolvedValue([])
+    const limitFn = vi.fn().mockReturnValue({ execute })
+    const orderBy = vi.fn().mockReturnValue({ limit: limitFn })
+    const whereFn: ReturnType<typeof vi.fn> = vi.fn().mockImplementation((...args: unknown[]) => {
+      whereCalls.push(args as [unknown, string, unknown])
+      return chain
+    })
+    const chain = { where: whereFn, orderBy, limit: limitFn, execute }
+    const selectAll = vi.fn().mockReturnValue(chain)
+
+    const db = {
+      selectFrom: vi.fn().mockReturnValue({ selectAll }),
+    } as unknown as Kysely<Database>
+
+    return { db, whereCalls }
+  }
+
+  it("queries without filters when none provided", async () => {
+    const { db, whereCalls } = buildAuditMockDb()
+    const service = new CredentialService(db, AUTH_CONFIG)
+
+    await service.getAuditLog(ADMIN_USER_ID)
+
+    // Only the user_account_id where clause
+    expect(whereCalls).toHaveLength(1)
+    expect(whereCalls[0]).toEqual(["user_account_id", "=", ADMIN_USER_ID])
+  })
+
+  it("applies credentialId filter", async () => {
+    const { db, whereCalls } = buildAuditMockDb()
+    const service = new CredentialService(db, AUTH_CONFIG)
+
+    await service.getAuditLog(ADMIN_USER_ID, { credentialId: CRED_ID })
+
+    expect(whereCalls).toHaveLength(2)
+    expect(whereCalls[1]).toEqual(["provider_credential_id", "=", CRED_ID])
+  })
+
+  it("applies eventType filter", async () => {
+    const { db, whereCalls } = buildAuditMockDb()
+    const service = new CredentialService(db, AUTH_CONFIG)
+
+    await service.getAuditLog(ADMIN_USER_ID, { eventType: "credential_accessed" })
+
+    expect(whereCalls).toHaveLength(2)
+    expect(whereCalls[1]).toEqual(["event_type", "=", "credential_accessed"])
+  })
+
+  it("applies agentId filter via JSONB extraction", async () => {
+    const { db, whereCalls } = buildAuditMockDb()
+    const service = new CredentialService(db, AUTH_CONFIG)
+
+    await service.getAuditLog(ADMIN_USER_ID, { agentId: "agent-111" })
+
+    expect(whereCalls).toHaveLength(2)
+    // The first arg is a Kysely sql template — just check the value matches
+    expect(whereCalls[1][1]).toBe("=")
+    expect(whereCalls[1][2]).toBe("agent-111")
+  })
+
+  it("combines multiple filters", async () => {
+    const { db, whereCalls } = buildAuditMockDb()
+    const service = new CredentialService(db, AUTH_CONFIG)
+
+    await service.getAuditLog(ADMIN_USER_ID, {
+      credentialId: CRED_ID,
+      eventType: "credential_accessed",
+      agentId: "agent-111",
+    })
+
+    // user_account_id + credentialId + eventType + agentId = 4 where clauses
+    expect(whereCalls).toHaveLength(4)
+  })
+
+  it("respects custom limit", async () => {
+    const { db } = buildAuditMockDb()
+    const service = new CredentialService(db, AUTH_CONFIG)
+
+    await service.getAuditLog(ADMIN_USER_ID, { limit: 10 })
+
+    // Verify the query was built (no errors)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(db.selectFrom).toHaveBeenCalledWith("credential_audit_log")
   })
 })

--- a/packages/control-plane/src/auth/credential-service.ts
+++ b/packages/control-plane/src/auth/credential-service.ts
@@ -12,7 +12,7 @@
  *   - Credential status tracking + audit logging
  */
 
-import type { Kysely } from "kysely"
+import { type Kysely, sql } from "kysely"
 
 import type { AuthOAuthConfig, OAuthProviderConfig } from "../config.js"
 import type {
@@ -34,6 +34,13 @@ import {
 } from "./credential-encryption.js"
 import { CODE_PASTE_PROVIDERS } from "./oauth-providers.js"
 import { refreshAccessToken, type TokenResponse } from "./oauth-service.js"
+
+/** Execution context passed by callers for audit enrichment. */
+export interface AuditContext {
+  agentId?: string
+  jobId?: string
+  toolName?: string
+}
 
 /** Provider metadata for the "Connected Providers" UI. */
 export interface ProviderInfo {
@@ -441,6 +448,7 @@ export class CredentialService {
    */
   async getToolSecret(
     toolName: string,
+    context?: AuditContext,
   ): Promise<{ token: string; credentialId: string; provider: string } | null> {
     const cred = await this.db
       .selectFrom("provider_credential")
@@ -456,9 +464,13 @@ export class CredentialService {
     const userKey = await this.ensureUserKey(cred.user_account_id)
     const token = decryptCredential(cred.api_key_enc, userKey)
 
-    // Audit log each access
+    // Audit log each access with execution context
     await this.auditLog(cred.user_account_id, cred.id, "credential_accessed", cred.provider, {
+      flow: "injection",
       tool_name: toolName,
+      ...(context?.agentId && { agent_id: context.agentId }),
+      ...(context?.jobId && { job_id: context.jobId }),
+      ...(context?.toolName && { tool_name: context.toolName }),
     })
 
     await this.markUsed(cred.id)
@@ -492,6 +504,7 @@ export class CredentialService {
   async getAccessToken(
     userId: string,
     provider: string,
+    context?: AuditContext,
   ): Promise<{ token: string; credentialId: string } | null> {
     const cred = await this.db
       .selectFrom("provider_credential")
@@ -509,6 +522,7 @@ export class CredentialService {
     // For API keys, just decrypt and return
     if (cred.credential_type === "api_key" && cred.api_key_enc) {
       const token = decryptCredential(cred.api_key_enc, userKey)
+      await this.auditAccess(cred, context)
       await this.markUsed(cred.id)
       return { token, credentialId: cred.id }
     }
@@ -522,12 +536,14 @@ export class CredentialService {
       if (isExpired && cred.refresh_token_enc) {
         const refreshed = await this.refreshToken(cred, userKey)
         if (refreshed) {
+          await this.auditAccess(cred, context)
           return { token: refreshed, credentialId: cred.id }
         }
         // Refresh failed — fall through to return current token
       }
 
       const token = decryptCredential(cred.access_token_enc, userKey)
+      await this.auditAccess(cred, context)
       await this.markUsed(cred.id)
       return { token, credentialId: cred.id }
     }
@@ -641,18 +657,37 @@ export class CredentialService {
 
   /**
    * Get audit log entries for a user's credentials.
+   * Supports optional filters for compliance queries.
    */
   async getAuditLog(
     userId: string,
-    limit = 50,
+    opts: {
+      limit?: number
+      credentialId?: string
+      agentId?: string
+      eventType?: string
+    } = {},
   ): Promise<import("../db/types.js").CredentialAuditLog[]> {
-    return this.db
+    const limit = opts.limit ?? 50
+
+    let query = this.db
       .selectFrom("credential_audit_log")
       .selectAll()
       .where("user_account_id", "=", userId)
-      .orderBy("created_at", "desc")
-      .limit(limit)
-      .execute()
+
+    if (opts.credentialId) {
+      query = query.where("provider_credential_id", "=", opts.credentialId)
+    }
+
+    if (opts.eventType) {
+      query = query.where("event_type", "=", opts.eventType)
+    }
+
+    if (opts.agentId) {
+      query = query.where(sql`details->>'agent_id'`, "=", opts.agentId)
+    }
+
+    return query.orderBy("created_at", "desc").limit(limit).execute()
   }
 
   /**
@@ -773,6 +808,16 @@ export class CredentialService {
     }
 
     return staleSecrets.length
+  }
+
+  private async auditAccess(cred: ProviderCredential, context?: AuditContext): Promise<void> {
+    if (!context?.agentId) return
+    await this.auditLog(cred.user_account_id, cred.id, "credential_accessed", cred.provider, {
+      flow: "injection",
+      ...(context.agentId && { agent_id: context.agentId }),
+      ...(context.jobId && { job_id: context.jobId }),
+      ...(context.toolName && { tool_name: context.toolName }),
+    })
   }
 
   private async auditLog(

--- a/packages/control-plane/src/routes/agent-credentials.ts
+++ b/packages/control-plane/src/routes/agent-credentials.ts
@@ -158,7 +158,7 @@ export function agentCredentialRoutes(deps: AgentCredentialRouteDeps) {
             provider_credential_id: credentialId,
             event_type: "credential_bound",
             provider: credential.provider,
-            details: { agent_id: agentId, binding_id: binding.id },
+            details: { agent_id: agentId, binding_id: binding.id, granted_by: principal.userId },
           })
           .execute()
 

--- a/packages/control-plane/src/routes/credentials.ts
+++ b/packages/control-plane/src/routes/credentials.ts
@@ -129,12 +129,29 @@ export function credentialRoutes(deps: CredentialRouteDeps) {
     )
 
     /**
-     * GET /credentials/audit — credential audit log
+     * GET /credentials/audit — credential audit log with optional filters
      */
-    app.get<{ Querystring: { limit?: string } }>(
+    app.get<{
+      Querystring: {
+        limit?: string
+        credentialId?: string
+        agentId?: string
+        eventType?: string
+      }
+    }>(
       "/credentials/audit",
       { preHandler: [requireAuth] },
-      async (request: FastifyRequest<{ Querystring: { limit?: string } }>, reply: FastifyReply) => {
+      async (
+        request: FastifyRequest<{
+          Querystring: {
+            limit?: string
+            credentialId?: string
+            agentId?: string
+            eventType?: string
+          }
+        }>,
+        reply: FastifyReply,
+      ) => {
         const principal = (request as AuthenticatedRequest).principal
         if (!principal) {
           reply.status(401).send({ error: "unauthorized" })
@@ -142,7 +159,12 @@ export function credentialRoutes(deps: CredentialRouteDeps) {
         }
 
         const limit = request.query.limit ? parseInt(request.query.limit, 10) : 50
-        const entries = await credentialService.getAuditLog(principal.userId, Math.min(limit, 200))
+        const entries = await credentialService.getAuditLog(principal.userId, {
+          limit: Math.min(limit, 200),
+          credentialId: request.query.credentialId,
+          agentId: request.query.agentId,
+          eventType: request.query.eventType,
+        })
         return { entries }
       },
     )

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -222,7 +222,7 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
           }
 
           // Build a credential resolver for tool credential injection
-          credentialResolver = buildCredentialResolver(credentialService, db, agent.id)
+          credentialResolver = buildCredentialResolver(credentialService, db, agent.id, job.id)
         }
 
         // Inject trace context into task environment for downstream propagation
@@ -750,11 +750,14 @@ function buildCredentialResolver(
   credentialService: CredentialService,
   db: Kysely<Database>,
   agentId: string,
+  jobId: string,
 ): CredentialResolver {
   return async (ref) => {
     try {
+      const auditContext = { agentId, jobId, toolName: ref.provider }
+
       if (ref.credentialClass === "tool_specific") {
-        const secret = await credentialService.getToolSecret(ref.provider)
+        const secret = await credentialService.getToolSecret(ref.provider, auditContext)
         if (!secret) return null
 
         const key = ref.headerName ?? "Authorization"
@@ -782,6 +785,7 @@ function buildCredentialResolver(
         const result = await credentialService.getAccessToken(
           binding.user_account_id,
           binding.provider,
+          auditContext,
         )
         if (!result) return null
 


### PR DESCRIPTION
## Summary
- Enriched `credential_accessed` audit events with `agent_id`, `job_id`, `tool_name` execution context via new `AuditContext` interface
- Extended `GET /credentials/audit` with `?credentialId=`, `?agentId=`, `?eventType=` filter params for compliance queries
- Added `granted_by` to `credential_bound` audit events in agent-credentials route
- Wired execution context through `buildCredentialResolver` in agent-execute task

Closes #279

## Test plan
- [x] 24 credential-service tests pass (8 new: context enrichment + audit query filters)
- [x] Full suite: 1062 tests pass across 63 files
- [x] Lint, typecheck, build all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced credential audit logs to include agent, job, and tool context when credentials are accessed.
  * Added filtering capabilities to audit log retrieval by credential ID, agent ID, and event type.
  * Audit trail now tracks "injection" flow events for credential access activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->