### PR TITLE
feat(db): migration 020 — agent_checkpoint table (#315)

### DIFF
--- a/packages/control-plane/migrations/020_agent_checkpoint.down.sql
+++ b/packages/control-plane/migrations/020_agent_checkpoint.down.sql
@@ -1,0 +1,3 @@
+-- 020 down: Drop agent_checkpoint table.
+
+DROP TABLE IF EXISTS agent_checkpoint;

--- a/packages/control-plane/migrations/020_agent_checkpoint.up.sql
+++ b/packages/control-plane/migrations/020_agent_checkpoint.up.sql
@@ -1,0 +1,16 @@
+-- 020: Create agent_checkpoint table for persisting agent state snapshots.
+--      Part of the agent lifecycle and resilience epic (#266-T6).
+
+CREATE TABLE agent_checkpoint (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id          UUID NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
+  job_id            UUID REFERENCES job(id) ON DELETE SET NULL,
+  label             TEXT,
+  state             JSONB NOT NULL,
+  state_crc         INTEGER NOT NULL,
+  context_snapshot  JSONB,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by        TEXT NOT NULL DEFAULT 'system'
+);
+
+CREATE INDEX idx_acp_agent ON agent_checkpoint(agent_id, created_at DESC);

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -609,6 +609,28 @@ export type ToolCategoryMembership = Selectable<ToolCategoryMembershipTable>
 export type NewToolCategoryMembership = Insertable<ToolCategoryMembershipTable>
 
 // ---------------------------------------------------------------------------
+// Table: agent_checkpoint
+// ---------------------------------------------------------------------------
+export interface AgentCheckpointTable {
+  id: Generated<string>
+  agent_id: string
+  job_id: string | null
+  label: string | null
+  state: ColumnType<Record<string, unknown>, Record<string, unknown>, Record<string, unknown>>
+  state_crc: number
+  context_snapshot: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  created_at: ColumnType<Date, Date | undefined, never>
+  created_by: ColumnType<string, string | undefined, string>
+}
+
+export type AgentCheckpoint = Selectable<AgentCheckpointTable>
+export type NewAgentCheckpoint = Insertable<AgentCheckpointTable>
+
+// ---------------------------------------------------------------------------
 // Database interface — register all tables here.
 // ---------------------------------------------------------------------------
 export interface Database {
@@ -635,4 +657,5 @@ export interface Database {
   capability_audit_log: CapabilityAuditLogTable
   tool_category: ToolCategoryTable
   tool_category_membership: ToolCategoryMembershipTable
+  agent_checkpoint: AgentCheckpointTable
 }


### PR DESCRIPTION
## Summary
- Adds migration 020 (`agent_checkpoint` table) with `agent_id` FK cascading deletes and `job_id` FK SET NULL, plus composite index on `(agent_id, created_at DESC)`
- Adds down migration to cleanly drop the table
- Registers `AgentCheckpointTable` Kysely types (`AgentCheckpoint`, `NewAgentCheckpoint`) in the `Database` interface

Closes #315

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `npx eslint src/db/types.ts` clean
- [x] `npx vitest run` — all 1097 tests pass (65 files)
- [ ] CI (`ci` check) passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database infrastructure for agent checkpoint storage, enabling state persistence and management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->