### PR TITLE
feat(lifecycle): observability — metrics + structured lifecycle logs (#319)

### DIFF
--- a/packages/control-plane/src/__tests__/lifecycle-metrics.test.ts
+++ b/packages/control-plane/src/__tests__/lifecycle-metrics.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  emitLifecycleLog,
+  recordCheckpointWrite,
+  recordCircuitBreakerTrip,
+  recordContextBudgetExceeded,
+  recordOutputValidationRejected,
+  recordStateTransition,
+  recordTokenUsage,
+} from "../lifecycle/metrics.js"
+import type { LifecycleTransitionEvent } from "../lifecycle/state-machine.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Capture structured log lines written to stdout. */
+function captureStdout(): { lines: string[]; restore: () => void } {
+  const lines: string[] = []
+  const original = process.stdout.write.bind(process.stdout)
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+    if (typeof chunk === "string") lines.push(chunk.trim())
+    else original(chunk)
+    return true
+  })
+  return { lines, restore: () => spy.mockRestore() }
+}
+
+function parseLogLine(line: string): Record<string, unknown> {
+  return JSON.parse(line) as Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("lifecycle metrics", () => {
+  let capture: ReturnType<typeof captureStdout>
+
+  beforeEach(() => {
+    capture = captureStdout()
+  })
+
+  afterEach(() => {
+    capture.restore()
+  })
+
+  // -------------------------------------------------------------------------
+  // emitLifecycleLog
+  // -------------------------------------------------------------------------
+
+  describe("emitLifecycleLog", () => {
+    it("emits structured JSON with required fields", () => {
+      emitLifecycleLog({
+        event: "agent.test",
+        agentId: "a-1",
+        from: "BOOTING",
+        to: "HYDRATING",
+        reason: "test reason",
+      })
+
+      expect(capture.lines).toHaveLength(1)
+      const log = parseLogLine(capture.lines[0]!)
+      expect(log.level).toBe("info")
+      expect(log.service).toBe("cortex-lifecycle")
+      expect(log.event).toBe("agent.test")
+      expect(log.agentId).toBe("a-1")
+      expect(log.from).toBe("BOOTING")
+      expect(log.to).toBe("HYDRATING")
+      expect(log.reason).toBe("test reason")
+      expect(log.time).toBeDefined()
+    })
+
+    it("includes metadata when provided", () => {
+      emitLifecycleLog({
+        event: "agent.custom",
+        agentId: "a-1",
+        metadata: { foo: "bar" },
+      })
+
+      const log = parseLogLine(capture.lines[0]!)
+      expect(log.metadata).toEqual({ foo: "bar" })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // recordStateTransition
+  // -------------------------------------------------------------------------
+
+  describe("recordStateTransition", () => {
+    it("emits state transition log with event, agentId, from, to, reason", () => {
+      const event: LifecycleTransitionEvent = {
+        from: "BOOTING",
+        to: "HYDRATING",
+        timestamp: new Date(),
+        agentId: "agent-42",
+        reason: "Config loaded",
+      }
+
+      recordStateTransition(event)
+
+      expect(capture.lines).toHaveLength(1)
+      const log = parseLogLine(capture.lines[0]!)
+      expect(log.event).toBe("agent.state_transition")
+      expect(log.agentId).toBe("agent-42")
+      expect(log.from).toBe("BOOTING")
+      expect(log.to).toBe("HYDRATING")
+      expect(log.reason).toBe("Config loaded")
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // recordCircuitBreakerTrip
+  // -------------------------------------------------------------------------
+
+  describe("recordCircuitBreakerTrip", () => {
+    it("emits circuit breaker trip log", () => {
+      recordCircuitBreakerTrip("agent-7", "consecutive failures exceeded threshold")
+
+      expect(capture.lines).toHaveLength(1)
+      const log = parseLogLine(capture.lines[0]!)
+      expect(log.event).toBe("agent.circuit_breaker.tripped")
+      expect(log.agentId).toBe("agent-7")
+      expect(log.reason).toBe("consecutive failures exceeded threshold")
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // recordContextBudgetExceeded
+  // -------------------------------------------------------------------------
+
+  describe("recordContextBudgetExceeded", () => {
+    it("emits context budget exceeded log with component", () => {
+      recordContextBudgetExceeded("agent-3", "qdrant-context")
+
+      const log = parseLogLine(capture.lines[0]!)
+      expect(log.event).toBe("agent.context_budget.exceeded")
+      expect(log.agentId).toBe("agent-3")
+      expect(log.metadata).toEqual({ component: "qdrant-context" })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // recordOutputValidationRejected
+  // -------------------------------------------------------------------------
+
+  describe("recordOutputValidationRejected", () => {
+    it("emits output validation rejected log with content_type", () => {
+      recordOutputValidationRejected("agent-5", "memory")
+
+      const log = parseLogLine(capture.lines[0]!)
+      expect(log.event).toBe("agent.output_validation.rejected")
+      expect(log.agentId).toBe("agent-5")
+      expect(log.metadata).toEqual({ contentType: "memory" })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // recordCheckpointWrite
+  // -------------------------------------------------------------------------
+
+  describe("recordCheckpointWrite", () => {
+    it("emits checkpoint write log with trigger", () => {
+      recordCheckpointWrite("agent-9", "drain")
+
+      const log = parseLogLine(capture.lines[0]!)
+      expect(log.event).toBe("agent.checkpoint.written")
+      expect(log.agentId).toBe("agent-9")
+      expect(log.metadata).toEqual({ trigger: "drain" })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // recordTokenUsage
+  // -------------------------------------------------------------------------
+
+  describe("recordTokenUsage", () => {
+    it("emits token usage log with jobId and token count", () => {
+      recordTokenUsage("agent-11", "job-99", 1500)
+
+      const log = parseLogLine(capture.lines[0]!)
+      expect(log.event).toBe("agent.token_usage")
+      expect(log.agentId).toBe("agent-11")
+      expect(log.jobId).toBe("job-99")
+      expect(log.metadata).toEqual({ tokens: 1500 })
+    })
+  })
+})

--- a/packages/control-plane/src/lifecycle/index.ts
+++ b/packages/control-plane/src/lifecycle/index.ts
@@ -35,6 +35,24 @@ export {
   type SteerMessage,
 } from "./manager.js"
 export {
+  checkpointWritesTotal,
+  circuitBreakerTripsTotal,
+  contextBudgetExceededTotal,
+  emitLifecycleLog,
+  healthProbeDurationSeconds,
+  type LifecycleLogEntry,
+  outputValidationRejectedTotal,
+  quarantineDurationSeconds,
+  recordCheckpointWrite,
+  recordCircuitBreakerTrip,
+  recordContextBudgetExceeded,
+  recordOutputValidationRejected,
+  recordStateTransition,
+  recordTokenUsage,
+  stateTransitionsTotal,
+  tokenUsageTotal,
+} from "./metrics.js"
+export {
   computeCheckpointCrc,
   DEFAULT_CHECKPOINT_MAX_BYTES,
   DEFAULT_MEMORY_MAX_CHARS,

--- a/packages/control-plane/src/lifecycle/manager.ts
+++ b/packages/control-plane/src/lifecycle/manager.ts
@@ -25,6 +25,7 @@ import type { AgentDeploymentConfig } from "../k8s/types.js"
 import { type AgentHeartbeat, CrashLoopDetector, HeartbeatReceiver } from "./health.js"
 import { hydrateAgent, type HydrationResult, type QdrantClient } from "./hydration.js"
 import { IdleDetector } from "./idle-detector.js"
+import { recordStateTransition } from "./metrics.js"
 import {
   type AgentLifecycleState,
   AgentLifecycleStateMachine,
@@ -114,6 +115,7 @@ export class AgentLifecycleManager {
     }
 
     const sm = new AgentLifecycleStateMachine(agentId)
+    sm.onTransition(recordStateTransition)
     if (this.onLifecycleEvent) {
       sm.onTransition(this.onLifecycleEvent)
     }

--- a/packages/control-plane/src/lifecycle/metrics.ts
+++ b/packages/control-plane/src/lifecycle/metrics.ts
@@ -1,0 +1,162 @@
+/**
+ * Lifecycle observability — Prometheus-style metrics + structured logs.
+ *
+ * Metrics are created via the OpenTelemetry API (`@opentelemetry/api`).
+ * Without a registered MeterProvider they are no-ops; once a provider is
+ * configured (e.g. Prometheus exporter) the counters and histograms
+ * automatically start recording.
+ *
+ * Every `record*` helper also emits a structured JSON log line for
+ * log-based observability (ELK / CloudWatch / etc.).
+ */
+
+import { metrics } from "@opentelemetry/api"
+
+import type { LifecycleTransitionEvent } from "./state-machine.js"
+
+// ---------------------------------------------------------------------------
+// Meter
+// ---------------------------------------------------------------------------
+
+const meter = metrics.getMeter("cortex-lifecycle")
+
+// ---------------------------------------------------------------------------
+// Counters
+// ---------------------------------------------------------------------------
+
+export const stateTransitionsTotal = meter.createCounter("cortex_agent_state_transitions_total", {
+  description: "Total number of agent state transitions",
+})
+
+export const circuitBreakerTripsTotal = meter.createCounter(
+  "cortex_agent_circuit_breaker_trips_total",
+  { description: "Total circuit breaker trips" },
+)
+
+export const contextBudgetExceededTotal = meter.createCounter(
+  "cortex_agent_context_budget_exceeded_total",
+  { description: "Total context budget exceeded events" },
+)
+
+export const outputValidationRejectedTotal = meter.createCounter(
+  "cortex_agent_output_validation_rejected_total",
+  { description: "Total output validation rejections" },
+)
+
+export const checkpointWritesTotal = meter.createCounter("cortex_agent_checkpoint_writes_total", {
+  description: "Total checkpoint writes",
+})
+
+export const tokenUsageTotal = meter.createCounter("cortex_agent_token_usage_total", {
+  description: "Total token usage",
+})
+
+// ---------------------------------------------------------------------------
+// Histograms
+// ---------------------------------------------------------------------------
+
+export const quarantineDurationSeconds = meter.createHistogram(
+  "cortex_agent_quarantine_duration_seconds",
+  { description: "Duration agents spend in quarantine", unit: "s" },
+)
+
+export const healthProbeDurationSeconds = meter.createHistogram(
+  "cortex_agent_health_probe_duration_seconds",
+  { description: "Duration of agent health probes", unit: "s" },
+)
+
+// ---------------------------------------------------------------------------
+// Structured lifecycle log
+// ---------------------------------------------------------------------------
+
+export interface LifecycleLogEntry {
+  event: string
+  agentId: string
+  jobId?: string
+  from?: string
+  to?: string
+  reason?: string
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Emit a structured JSON log line to stdout.
+ *
+ * The format is compatible with the existing `TracingLogger` output so
+ * downstream consumers (Pino transports, log aggregators) can ingest it
+ * without special configuration.
+ */
+export function emitLifecycleLog(entry: LifecycleLogEntry): void {
+  const log: Record<string, unknown> = {
+    level: "info",
+    time: new Date().toISOString(),
+    service: "cortex-lifecycle",
+    ...entry,
+  }
+  process.stdout.write(JSON.stringify(log) + "\n")
+}
+
+// ---------------------------------------------------------------------------
+// Record helpers — increment metric + emit structured log
+// ---------------------------------------------------------------------------
+
+export function recordStateTransition(event: LifecycleTransitionEvent): void {
+  stateTransitionsTotal.add(1, {
+    agent_id: event.agentId,
+    from: event.from,
+    to: event.to,
+  })
+  emitLifecycleLog({
+    event: "agent.state_transition",
+    agentId: event.agentId,
+    from: event.from,
+    to: event.to,
+    reason: event.reason,
+  })
+}
+
+export function recordCircuitBreakerTrip(agentId: string, reason: string): void {
+  circuitBreakerTripsTotal.add(1, { agent_id: agentId, reason })
+  emitLifecycleLog({
+    event: "agent.circuit_breaker.tripped",
+    agentId,
+    reason,
+  })
+}
+
+export function recordContextBudgetExceeded(agentId: string, component: string): void {
+  contextBudgetExceededTotal.add(1, { agent_id: agentId, component })
+  emitLifecycleLog({
+    event: "agent.context_budget.exceeded",
+    agentId,
+    metadata: { component },
+  })
+}
+
+export function recordOutputValidationRejected(agentId: string, contentType: string): void {
+  outputValidationRejectedTotal.add(1, { agent_id: agentId, content_type: contentType })
+  emitLifecycleLog({
+    event: "agent.output_validation.rejected",
+    agentId,
+    metadata: { contentType },
+  })
+}
+
+export function recordCheckpointWrite(agentId: string, trigger: string): void {
+  checkpointWritesTotal.add(1, { agent_id: agentId, trigger })
+  emitLifecycleLog({
+    event: "agent.checkpoint.written",
+    agentId,
+    metadata: { trigger },
+  })
+}
+
+export function recordTokenUsage(agentId: string, jobId: string, tokens: number): void {
+  tokenUsageTotal.add(tokens, { agent_id: agentId, job_id: jobId })
+  emitLifecycleLog({
+    event: "agent.token_usage",
+    agentId,
+    jobId,
+    metadata: { tokens },
+  })
+}

--- a/packages/shared/src/tracing/spans.ts
+++ b/packages/shared/src/tracing/spans.ts
@@ -29,6 +29,10 @@ export const CortexAttributes = {
   ERROR_CATEGORY: "cortex.error.category",
   EXECUTION_STATUS: "cortex.execution.status",
   EXECUTION_DURATION_MS: "cortex.execution.duration_ms",
+  LIFECYCLE_STATE: "cortex.agent.lifecycle_state",
+  CIRCUIT_BREAKER_STATE: "cortex.agent.circuit_breaker_state",
+  CONTEXT_BUDGET_USAGE_PCT: "cortex.agent.context_budget_usage_pct",
+  TOKEN_BUDGET_REMAINING: "cortex.agent.token_budget_remaining",
 } as const
 
 // ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `packages/control-plane/src/lifecycle/metrics.ts` with 8 Prometheus-named OTel metrics (6 counters + 2 histograms) and structured JSON log emission
- Extend `CortexAttributes` in `packages/shared/src/tracing/spans.ts` with 4 new lifecycle attribute constants (`lifecycle_state`, `circuit_breaker_state`, `context_budget_usage_pct`, `token_budget_remaining`)
- Wire `recordStateTransition` as an `onTransition` listener in `AgentLifecycleManager.boot()` so every state change increments `cortex_agent_state_transitions_total` and emits a structured log

Closes #319

## Test plan
- [x] 8 new tests in `lifecycle-metrics.test.ts` covering all `record*` helpers and structured log output
- [x] All 1105 existing tests pass (`npx vitest run`)
- [x] ESLint clean on changed files
- [x] TypeScript typecheck passes
- [x] Full monorepo build passes (6/6 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive lifecycle metrics collection with counters for state transitions, circuit breaker trips, context budget exceedances, validation rejections, checkpoint writes, and token usage.
  * Added duration histograms for quarantine and health probe monitoring.
  * Introduced structured JSON logging for lifecycle events with standardized fields.
  * Added new tracing attributes for enhanced agent observability (lifecycle state, circuit breaker state, context budget usage, token budget).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->