### PR TITLE
feat(control): enhanced steer — acknowledgment + operator feedback loop (#327)

### DIFF
--- a/packages/control-plane/src/__tests__/browser-orchestration.test.ts
+++ b/packages/control-plane/src/__tests__/browser-orchestration.test.ts
@@ -758,9 +758,9 @@ describe("POST /agents/:agentId/browser/steer", () => {
     })
 
     expect(steerFn).toHaveBeenCalledTimes(1)
-    const msg = steerFn.mock.calls[0]![0] as { message: string }
-    expect(msg.message).toContain("[STEER]")
-    expect(msg.message).toContain("type")
+    const msg = steerFn.mock.calls[0]![0] as { instruction: string }
+    expect(msg.instruction).toContain("[STEER]")
+    expect(msg.instruction).toContain("type")
   })
 
   it("returns 409 when agent is not EXECUTING", async () => {

--- a/packages/control-plane/src/__tests__/lifecycle-steering.test.ts
+++ b/packages/control-plane/src/__tests__/lifecycle-steering.test.ts
@@ -63,7 +63,7 @@ describe("AgentLifecycleManager steering", () => {
     const msg: SteerMessage = {
       id: "steer-1",
       agentId: "agent-1",
-      message: "focus on tests",
+      instruction: "focus on tests",
       priority: "normal",
       timestamp: new Date(),
     }
@@ -81,7 +81,7 @@ describe("AgentLifecycleManager steering", () => {
       manager.steer({
         id: "steer-1",
         agentId: "agent-unknown",
-        message: "test",
+        instruction: "test",
         priority: "normal",
         timestamp: new Date(),
       })
@@ -96,7 +96,7 @@ describe("AgentLifecycleManager steering", () => {
       manager.steer({
         id: "steer-1",
         agentId: "agent-1",
-        message: "test",
+        instruction: "test",
         priority: "normal",
         timestamp: new Date(),
       })
@@ -115,7 +115,7 @@ describe("AgentLifecycleManager steering", () => {
     const msg: SteerMessage = {
       id: "steer-1",
       agentId: "agent-1",
-      message: "test",
+      instruction: "test",
       priority: "normal",
       timestamp: new Date(),
     }
@@ -138,7 +138,7 @@ describe("AgentLifecycleManager steering", () => {
     manager.steer({
       id: "steer-1",
       agentId: "agent-1",
-      message: "test",
+      instruction: "test",
       priority: "normal",
       timestamp: new Date(),
     })
@@ -159,7 +159,7 @@ describe("AgentLifecycleManager steering", () => {
     manager.steer({
       id: "steer-1",
       agentId: "agent-1",
-      message: "test",
+      instruction: "test",
       priority: "normal",
       timestamp: new Date(),
     })
@@ -168,7 +168,7 @@ describe("AgentLifecycleManager steering", () => {
     expect(listener2).not.toHaveBeenCalled()
   })
 
-  it("steer with high priority passes through", () => {
+  it("steer with urgent priority passes through", () => {
     const manager = createTestManager()
     setAgentState(manager, "agent-1", "EXECUTING")
 
@@ -178,12 +178,56 @@ describe("AgentLifecycleManager steering", () => {
     manager.steer({
       id: "steer-1",
       agentId: "agent-1",
-      message: "urgent change",
-      priority: "high",
+      instruction: "urgent change",
+      priority: "urgent",
       timestamp: new Date(),
     })
 
-    expect((listener.mock.calls[0]![0] as { priority: string }).priority).toBe("high")
+    expect((listener.mock.calls[0]![0] as { priority: string }).priority).toBe("urgent")
+  })
+
+  it("steerAsync resolves acknowledged when listener calls acknowledgeSteer", async () => {
+    const manager = createTestManager()
+    setAgentState(manager, "agent-1", "EXECUTING")
+
+    // Simulate an execution loop listener that acknowledges immediately
+    manager.onSteer("agent-1", (msg) => {
+      manager.acknowledgeSteer(msg.id, 3)
+    })
+
+    const ack = await manager.steerAsync(
+      {
+        id: "steer-async-1",
+        agentId: "agent-1",
+        instruction: "focus on tests",
+        priority: "normal",
+        timestamp: new Date(),
+      },
+      5_000,
+    )
+
+    expect(ack.acknowledged).toBe(true)
+    expect(ack.turnNumber).toBe(3)
+  })
+
+  it("steerAsync resolves acknowledged:false on timeout", async () => {
+    const manager = createTestManager()
+    setAgentState(manager, "agent-1", "EXECUTING")
+
+    // No listener registered — nobody to acknowledge
+    const ack = await manager.steerAsync(
+      {
+        id: "steer-timeout-1",
+        agentId: "agent-1",
+        instruction: "hello",
+        priority: "normal",
+        timestamp: new Date(),
+      },
+      50, // very short timeout for test speed
+    )
+
+    expect(ack.acknowledged).toBe(false)
+    expect(ack.turnNumber).toBeUndefined()
   })
 
   it("cleanup removes steer listeners", async () => {
@@ -201,7 +245,7 @@ describe("AgentLifecycleManager steering", () => {
       manager.steer({
         id: "steer-1",
         agentId: "agent-1",
-        message: "test",
+        instruction: "test",
         priority: "normal",
         timestamp: new Date(),
       })

--- a/packages/control-plane/src/__tests__/observation-routes.test.ts
+++ b/packages/control-plane/src/__tests__/observation-routes.test.ts
@@ -545,10 +545,10 @@ describe("POST /agents/:agentId/observe/annotate", () => {
     })
 
     expect(steerFn).toHaveBeenCalledTimes(1)
-    const msg = steerFn.mock.calls[0]![0] as { message: string }
-    expect(msg.message).toContain("[ANNOTATION]")
-    expect(msg.message).toContain("(100, 200)")
-    expect(msg.message).toContain("#btn")
+    const msg = steerFn.mock.calls[0]![0] as { instruction: string }
+    expect(msg.instruction).toContain("[ANNOTATION]")
+    expect(msg.instruction).toContain("(100, 200)")
+    expect(msg.instruction).toContain("#btn")
   })
 
   it("uses custom prompt when provided", async () => {
@@ -566,8 +566,8 @@ describe("POST /agents/:agentId/observe/annotate", () => {
       payload: { type: "click", x: 100, y: 200, prompt: "Click the submit button" },
     })
 
-    const msg = steerFn.mock.calls[0]![0] as { message: string }
-    expect(msg.message).toContain("[ANNOTATION] Click the submit button")
+    const msg = steerFn.mock.calls[0]![0] as { instruction: string }
+    expect(msg.instruction).toContain("[ANNOTATION] Click the submit button")
   })
 
   it("returns 409 when agent is not EXECUTING", async () => {

--- a/packages/control-plane/src/__tests__/stream-routes.test.ts
+++ b/packages/control-plane/src/__tests__/stream-routes.test.ts
@@ -47,12 +47,18 @@ function mockLifecycleManager(
   overrides: {
     getAgentState?: (agentId: string) => AgentLifecycleState | undefined
     steer?: (msg: unknown) => void
+    steerAsync?: (
+      msg: unknown,
+      timeoutMs: number,
+    ) => Promise<{ acknowledged: boolean; turnNumber?: number }>
   } = {},
 ): AgentLifecycleManager {
   return {
     getAgentState: overrides.getAgentState ?? (() => "EXECUTING"),
     getAgentContext: vi.fn(),
     steer: overrides.steer ?? vi.fn(),
+    steerAsync:
+      overrides.steerAsync ?? vi.fn().mockResolvedValue({ acknowledged: true, turnNumber: 1 }),
   } as unknown as AgentLifecycleManager
 }
 
@@ -131,7 +137,7 @@ describe("stream route authentication", () => {
     const res = await app.inject({
       method: "POST",
       url: "/agents/agent-1/steer",
-      payload: { message: "test" },
+      payload: { instruction: "test" },
     })
 
     expect(res.statusCode).toBe(401)
@@ -145,7 +151,7 @@ describe("stream route authentication", () => {
       method: "POST",
       url: "/agents/agent-1/steer",
       headers: { authorization: "Basic abc123" },
-      payload: { message: "test" },
+      payload: { instruction: "test" },
     })
 
     expect(res.statusCode).toBe(401)
@@ -158,7 +164,7 @@ describe("stream route authentication", () => {
       method: "POST",
       url: "/agents/agent-1/steer",
       headers: { authorization: "Bearer " },
-      payload: { message: "test" },
+      payload: { instruction: "test" },
     })
 
     expect(res.statusCode).toBe(401)
@@ -174,7 +180,7 @@ describe("stream route authentication", () => {
         authorization: "Bearer nonexistent-token",
         "content-type": "application/json",
       },
-      payload: { message: "test" },
+      payload: { instruction: "test" },
     })
 
     expect(res.statusCode).toBe(401)
@@ -192,7 +198,7 @@ describe("stream route authentication", () => {
         authorization: "Bearer session-123",
         "content-type": "application/json",
       },
-      payload: { message: "test" },
+      payload: { instruction: "test" },
     })
 
     expect(res.statusCode).toBe(403)
@@ -259,7 +265,7 @@ describe("POST /agents/:agentId/steer", () => {
     const res = await app.inject({
       method: "POST",
       url: "/agents/agent-1/steer",
-      payload: { message: "focus on tests" },
+      payload: { instruction: "focus on tests" },
     })
 
     expect(res.statusCode).toBe(401)
@@ -278,7 +284,7 @@ describe("POST /agents/:agentId/steer", () => {
         authorization: "Bearer session-123",
         "content-type": "application/json",
       },
-      payload: { message: "focus on tests" },
+      payload: { instruction: "focus on tests" },
     })
 
     expect(res.statusCode).toBe(404)
@@ -297,18 +303,18 @@ describe("POST /agents/:agentId/steer", () => {
         authorization: "Bearer session-123",
         "content-type": "application/json",
       },
-      payload: { message: "focus on tests" },
+      payload: { instruction: "focus on tests" },
     })
 
     expect(res.statusCode).toBe(409)
     expect(res.json<{ error: string }>().error).toBe("conflict")
   })
 
-  it("returns 202 with steerMessageId on success", async () => {
-    const steerFn = vi.fn()
+  it("returns 200 with steerEventId and acknowledged on success", async () => {
+    const steerAsyncFn = vi.fn().mockResolvedValue({ acknowledged: true, turnNumber: 1 })
     const lifecycle = mockLifecycleManager({
       getAgentState: () => "EXECUTING",
-      steer: steerFn,
+      steerAsync: steerAsyncFn,
     })
     const { app } = await buildTestApp({ lifecycleManager: lifecycle })
 
@@ -319,27 +325,25 @@ describe("POST /agents/:agentId/steer", () => {
         authorization: "Bearer session-123",
         "content-type": "application/json",
       },
-      payload: { message: "focus on tests" },
+      payload: { instruction: "focus on tests" },
     })
 
-    expect(res.statusCode).toBe(202)
+    expect(res.statusCode).toBe(200)
     const body = res.json<{
-      status: string
-      steerMessageId: string
-      agentId: string
-      priority: string
+      steerEventId: string
+      acknowledged: boolean
+      incorporatedAtTurn?: number
     }>()
-    expect(body.status).toBe("accepted")
-    expect(body.steerMessageId).toBeDefined()
-    expect(body.agentId).toBe("agent-1")
-    expect(body.priority).toBe("normal")
+    expect(body.steerEventId).toBeDefined()
+    expect(body.acknowledged).toBe(true)
+    expect(body.incorporatedAtTurn).toBe(1)
   })
 
-  it("passes steering message to lifecycle manager", async () => {
-    const steerFn = vi.fn()
+  it("passes steering message to lifecycle manager via steerAsync", async () => {
+    const steerAsyncFn = vi.fn().mockResolvedValue({ acknowledged: true, turnNumber: 2 })
     const lifecycle = mockLifecycleManager({
       getAgentState: () => "EXECUTING",
-      steer: steerFn,
+      steerAsync: steerAsyncFn,
     })
     const { app } = await buildTestApp({ lifecycleManager: lifecycle })
 
@@ -350,29 +354,27 @@ describe("POST /agents/:agentId/steer", () => {
         authorization: "Bearer session-123",
         "content-type": "application/json",
       },
-      payload: { message: "focus on tests", priority: "high" },
+      payload: { instruction: "focus on tests", priority: "urgent" },
     })
 
-    expect(steerFn).toHaveBeenCalledTimes(1)
-    const msg = steerFn.mock.calls[0]![0] as {
+    expect(steerAsyncFn).toHaveBeenCalledTimes(1)
+    const msg = steerAsyncFn.mock.calls[0]![0] as {
       agentId: string
-      message: string
+      instruction: string
       priority: string
       id: string
     }
     expect(msg.agentId).toBe("agent-1")
-    expect(msg.message).toBe("focus on tests")
-    expect(msg.priority).toBe("high")
+    expect(msg.instruction).toBe("focus on tests")
+    expect(msg.priority).toBe("urgent")
     expect(msg.id).toBeDefined()
   })
 
-  it("returns 409 if lifecycle.steer throws", async () => {
-    const steerFn = vi.fn().mockImplementation(() => {
-      throw new Error("Agent not in EXECUTING state")
-    })
+  it("returns 409 if lifecycle.steerAsync throws", async () => {
+    const steerAsyncFn = vi.fn().mockRejectedValue(new Error("Agent not in EXECUTING state"))
     const lifecycle = mockLifecycleManager({
       getAgentState: () => "EXECUTING",
-      steer: steerFn,
+      steerAsync: steerAsyncFn,
     })
     const { app } = await buildTestApp({ lifecycleManager: lifecycle })
 
@@ -383,13 +385,13 @@ describe("POST /agents/:agentId/steer", () => {
         authorization: "Bearer session-123",
         "content-type": "application/json",
       },
-      payload: { message: "focus on tests" },
+      payload: { instruction: "focus on tests" },
     })
 
     expect(res.statusCode).toBe(409)
   })
 
-  it("validates message is required", async () => {
+  it("validates instruction is required", async () => {
     const { app } = await buildTestApp({})
 
     const res = await app.inject({
@@ -405,11 +407,11 @@ describe("POST /agents/:agentId/steer", () => {
     expect(res.statusCode).toBe(400)
   })
 
-  it("uses default priority when not specified", async () => {
-    const steerFn = vi.fn()
+  it("uses default priority normal and returns acknowledged", async () => {
+    const steerAsyncFn = vi.fn().mockResolvedValue({ acknowledged: true, turnNumber: 1 })
     const lifecycle = mockLifecycleManager({
       getAgentState: () => "EXECUTING",
-      steer: steerFn,
+      steerAsync: steerAsyncFn,
     })
     const { app } = await buildTestApp({ lifecycleManager: lifecycle })
 
@@ -420,18 +422,18 @@ describe("POST /agents/:agentId/steer", () => {
         authorization: "Bearer session-123",
         "content-type": "application/json",
       },
-      payload: { message: "focus on tests" },
+      payload: { instruction: "focus on tests" },
     })
 
-    expect(res.json<{ priority: string }>().priority).toBe("normal")
-    expect((steerFn.mock.calls[0]![0] as { priority: string }).priority).toBe("normal")
+    expect(res.json<{ acknowledged: boolean }>().acknowledged).toBe(true)
+    expect((steerAsyncFn.mock.calls[0]![0] as { priority: string }).priority).toBe("normal")
   })
 
-  it("broadcasts steer:ack and agent:output events on success", async () => {
-    const steerFn = vi.fn()
+  it("broadcasts steer:injected and steer:acknowledged events on success", async () => {
+    const steerAsyncFn = vi.fn().mockResolvedValue({ acknowledged: true, turnNumber: 1 })
     const lifecycle = mockLifecycleManager({
       getAgentState: () => "EXECUTING",
-      steer: steerFn,
+      steerAsync: steerAsyncFn,
     })
     const { app, sseManager } = await buildTestApp({ lifecycleManager: lifecycle })
 
@@ -444,20 +446,48 @@ describe("POST /agents/:agentId/steer", () => {
         authorization: "Bearer session-123",
         "content-type": "application/json",
       },
-      payload: { message: "focus on tests" },
+      payload: { instruction: "focus on tests" },
     })
 
-    // Should have broadcast steer:ack and agent:output
+    // Should have broadcast steer:injected and steer:acknowledged
     expect(broadcastSpy).toHaveBeenCalledTimes(2)
-    expect(broadcastSpy.mock.calls[0]![1]).toBe("steer:ack")
-    expect(broadcastSpy.mock.calls[1]![1]).toBe("agent:output")
+    expect(broadcastSpy.mock.calls[0]![1]).toBe("steer:injected")
+    expect(broadcastSpy.mock.calls[1]![1]).toBe("steer:acknowledged")
 
-    // Verify the output event contains the steering message
-    const outputPayload = broadcastSpy.mock.calls[1]![2] as Record<string, unknown>
-    const output = outputPayload.output as Record<string, unknown>
-    expect(output.content).toContain("[STEER] focus on tests")
+    // Verify the injected event contains operator info
+    const injectedPayload = broadcastSpy.mock.calls[0]![2] as Record<string, unknown>
+    expect(injectedPayload.operatorUserId).toBe("user-1")
+    expect(injectedPayload.instruction).toBe("focus on tests")
 
     broadcastSpy.mockRestore()
+  })
+
+  it("returns acknowledged:false when steer times out", async () => {
+    const steerAsyncFn = vi.fn().mockResolvedValue({ acknowledged: false })
+    const lifecycle = mockLifecycleManager({
+      getAgentState: () => "EXECUTING",
+      steerAsync: steerAsyncFn,
+    })
+    const { app } = await buildTestApp({ lifecycleManager: lifecycle })
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/steer",
+      headers: {
+        authorization: "Bearer session-123",
+        "content-type": "application/json",
+      },
+      payload: { instruction: "focus on tests" },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json<{
+      steerEventId: string
+      acknowledged: boolean
+      incorporatedAtTurn?: number
+    }>()
+    expect(body.acknowledged).toBe(false)
+    expect(body.incorporatedAtTurn).toBeUndefined()
   })
 })
 
@@ -482,10 +512,10 @@ describe("stream route cookie authentication", () => {
         cookie: "cortex_session=dash-session-1",
         "content-type": "application/json",
       },
-      payload: { message: "cookie auth test" },
+      payload: { instruction: "cookie auth test" },
     })
 
-    expect(res.statusCode).toBe(202)
+    expect(res.statusCode).toBe(200)
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(sessionService.validateSession).toHaveBeenCalledWith("dash-session-1")
   })
@@ -501,10 +531,10 @@ describe("stream route cookie authentication", () => {
         authorization: "Bearer session-123",
         "content-type": "application/json",
       },
-      payload: { message: "bearer fallback" },
+      payload: { instruction: "bearer fallback" },
     })
 
-    expect(res.statusCode).toBe(202)
+    expect(res.statusCode).toBe(200)
   })
 
   it("returns 401 when cookie session is invalid and no Bearer provided", async () => {
@@ -518,7 +548,7 @@ describe("stream route cookie authentication", () => {
         cookie: "cortex_session=invalid-session",
         "content-type": "application/json",
       },
-      payload: { message: "test" },
+      payload: { instruction: "test" },
     })
 
     expect(res.statusCode).toBe(401)

--- a/packages/control-plane/src/lifecycle/manager.ts
+++ b/packages/control-plane/src/lifecycle/manager.ts
@@ -56,9 +56,15 @@ export interface AgentContext {
 export interface SteerMessage {
   id: string
   agentId: string
-  message: string
-  priority: "normal" | "high"
+  instruction: string
+  priority: "normal" | "urgent"
   timestamp: Date
+}
+
+/** Acknowledgment returned after a steer is consumed by the execution loop. */
+export interface SteerAck {
+  acknowledged: boolean
+  turnNumber?: number
 }
 
 export type SteerListener = (msg: SteerMessage) => void
@@ -78,6 +84,11 @@ export class AgentLifecycleManager {
   private readonly onLifecycleEvent?: (event: LifecycleTransitionEvent) => void
   /** agentId → listeners for steering messages */
   private readonly steerListeners = new Map<string, Set<SteerListener>>()
+  /** steerMessageId → pending ack resolver (for steerAsync) */
+  private readonly pendingAcks = new Map<
+    string,
+    { resolve: (ack: SteerAck) => void; timer: ReturnType<typeof setTimeout> }
+  >()
 
   constructor(deps: LifecycleManagerDeps) {
     this.db = deps.db
@@ -370,6 +381,37 @@ export class AgentLifecycleManager {
       if (this.steerListeners.get(agentId)?.size === 0) {
         this.steerListeners.delete(agentId)
       }
+    }
+  }
+
+  /**
+   * Inject a steering message and wait for acknowledgment from the
+   * execution loop. Returns `{ acknowledged: false }` if not consumed
+   * within `timeoutMs`.
+   */
+  steerAsync(msg: SteerMessage, timeoutMs: number): Promise<SteerAck> {
+    return new Promise<SteerAck>((resolve) => {
+      const timer = setTimeout(() => {
+        this.pendingAcks.delete(msg.id)
+        resolve({ acknowledged: false })
+      }, timeoutMs)
+
+      this.pendingAcks.set(msg.id, { resolve, timer })
+
+      // Fire listeners (which may call acknowledgeSteer synchronously)
+      this.steer(msg)
+    })
+  }
+
+  /**
+   * Called by the execution loop to acknowledge consumption of a steer.
+   */
+  acknowledgeSteer(steerMessageId: string, turnNumber: number): void {
+    const pending = this.pendingAcks.get(steerMessageId)
+    if (pending) {
+      clearTimeout(pending.timer)
+      this.pendingAcks.delete(steerMessageId)
+      pending.resolve({ acknowledged: true, turnNumber })
     }
   }
 

--- a/packages/control-plane/src/routes/observation.ts
+++ b/packages/control-plane/src/routes/observation.ts
@@ -469,7 +469,7 @@ export function observationRoutes(deps: ObservationRouteDeps) {
           lifecycleManager?.steer({
             id: steerMessageId,
             agentId,
-            message: `[ANNOTATION] ${prompt}`,
+            instruction: `[ANNOTATION] ${prompt}`,
             priority: "normal",
             timestamp: new Date(),
           })
@@ -559,7 +559,7 @@ export function observationRoutes(deps: ObservationRouteDeps) {
           lifecycleManager?.steer({
             id: steerMessageId,
             agentId,
-            message: `[STEER] ${prompt}`,
+            instruction: `[STEER] ${prompt}`,
             priority: "normal",
             timestamp: new Date(),
           })

--- a/packages/control-plane/src/routes/stream.ts
+++ b/packages/control-plane/src/routes/stream.ts
@@ -29,8 +29,8 @@ interface StreamParams {
 }
 
 interface SteerBody {
-  message: string
-  priority?: "normal" | "high"
+  instruction: string
+  priority?: "normal" | "urgent"
 }
 
 // ---------------------------------------------------------------------------
@@ -134,10 +134,10 @@ export function streamRoutes(deps: StreamRouteDeps) {
           body: {
             type: "object",
             properties: {
-              message: { type: "string", minLength: 1, maxLength: 10_000 },
-              priority: { type: "string", enum: ["normal", "high"] },
+              instruction: { type: "string", minLength: 1, maxLength: 10_000 },
+              priority: { type: "string", enum: ["normal", "urgent"] },
             },
-            required: ["message"],
+            required: ["instruction"],
           },
         },
       },
@@ -146,14 +146,14 @@ export function streamRoutes(deps: StreamRouteDeps) {
         reply: FastifyReply,
       ) => {
         const { agentId } = request.params
-        const { message, priority } = request.body
+        const { instruction, priority } = request.body
         const authContext = (request as AuthenticatedRequest).authContext
 
-        const steerMessageId = randomUUID()
+        const steerEventId = randomUUID()
         const steerPriority = priority ?? "normal"
 
         request.log.info(
-          { agentId, steerMessageId, priority: steerPriority, sessionId: authContext.sessionId },
+          { agentId, steerEventId, priority: steerPriority, sessionId: authContext.sessionId },
           "Steering message received",
         )
 
@@ -174,13 +174,41 @@ export function streamRoutes(deps: StreamRouteDeps) {
             })
           }
 
+          // Emit steer_injected event with operator user ID
+          sseManager.broadcast(agentId, "steer:injected", {
+            agentId,
+            steerEventId,
+            operatorUserId: authContext.userAccountId,
+            instruction,
+            priority: steerPriority,
+            timestamp: new Date().toISOString(),
+          })
+
           try {
-            lifecycleManager.steer({
-              id: steerMessageId,
-              agentId,
-              message,
-              priority: steerPriority,
-              timestamp: new Date(),
+            const ack = await lifecycleManager.steerAsync(
+              {
+                id: steerEventId,
+                agentId,
+                instruction,
+                priority: steerPriority,
+                timestamp: new Date(),
+              },
+              30_000,
+            )
+
+            if (ack.acknowledged) {
+              sseManager.broadcast(agentId, "steer:acknowledged", {
+                agentId,
+                steerEventId,
+                incorporatedAtTurn: ack.turnNumber,
+                timestamp: new Date().toISOString(),
+              })
+            }
+
+            return reply.status(200).send({
+              steerEventId,
+              acknowledged: ack.acknowledged,
+              incorporatedAtTurn: ack.turnNumber,
             })
           } catch (error) {
             return reply.status(409).send({
@@ -191,31 +219,10 @@ export function streamRoutes(deps: StreamRouteDeps) {
           }
         }
 
-        // Broadcast steer acknowledgment to SSE clients
-        sseManager.broadcast(agentId, "steer:ack", {
-          agentId,
-          steerMessageId,
-          timestamp: new Date().toISOString(),
-          status: "accepted",
-        })
-
-        // Broadcast the steering message as an agent output event
-        // so all connected clients see the injection
-        sseManager.broadcast(agentId, "agent:output", {
-          agentId,
-          timestamp: new Date().toISOString(),
-          output: {
-            type: "text",
-            timestamp: new Date().toISOString(),
-            content: `[STEER] ${message}`,
-          },
-        })
-
-        return reply.status(202).send({
-          steerMessageId,
-          status: "accepted",
-          agentId,
-          priority: steerPriority,
+        // No lifecycle manager — accept without acknowledgment
+        return reply.status(200).send({
+          steerEventId,
+          acknowledged: false,
         })
       },
     )

--- a/packages/control-plane/src/streaming/index.ts
+++ b/packages/control-plane/src/streaming/index.ts
@@ -18,7 +18,9 @@ export type {
   SSEConnectionInfo,
   SSEEvent,
   SSEEventType,
+  SteerAcknowledgedPayload,
   SteerAckPayload,
+  SteerInjectedPayload,
   SteerRequest,
 } from "./types.js"
 export { DEFAULT_BUFFER_CONFIG } from "./types.js"

--- a/packages/control-plane/src/streaming/types.ts
+++ b/packages/control-plane/src/streaming/types.ts
@@ -18,6 +18,8 @@ export type SSEEventType =
   | "agent:error"
   | "agent:complete"
   | "steer:ack"
+  | "steer:injected"
+  | "steer:acknowledged"
   | "heartbeat"
   | "approval:created"
   | "approval:decided"
@@ -78,9 +80,9 @@ export interface AgentCompletePayload {
 
 export interface SteerRequest {
   /** Natural language instruction to inject. */
-  message: string
-  /** Optional priority hint. Higher = more urgent. */
-  priority?: "normal" | "high"
+  instruction: string
+  /** Optional priority hint. */
+  priority?: "normal" | "urgent"
 }
 
 export interface SteerAckPayload {
@@ -89,6 +91,22 @@ export interface SteerAckPayload {
   timestamp: string
   status: "accepted" | "rejected"
   reason?: string
+}
+
+export interface SteerInjectedPayload {
+  agentId: string
+  steerEventId: string
+  operatorUserId: string
+  instruction: string
+  priority: "normal" | "urgent"
+  timestamp: string
+}
+
+export interface SteerAcknowledgedPayload {
+  agentId: string
+  steerEventId: string
+  incorporatedAtTurn: number
+  timestamp: string
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -27,6 +27,7 @@ import type { Kysely } from "kysely"
 import type { CredentialService } from "../../auth/credential-service.js"
 import type { CredentialResolver } from "../../backends/tools/webhook.js"
 import type { Database, Job } from "../../db/types.js"
+import type { AgentLifecycleManager, SteerMessage } from "../../lifecycle/manager.js"
 import type { McpClientPool } from "../../mcp/client-pool.js"
 import type { McpToolRouter } from "../../mcp/tool-router.js"
 import type { SSEConnectionManager } from "../../streaming/manager.js"
@@ -54,6 +55,8 @@ export interface AgentExecuteDeps {
   mcpClientPool?: McpClientPool
   /** Optional credential service for resolving per-job credentials. */
   credentialService?: CredentialService
+  /** Optional lifecycle manager for steer consumption during execution. */
+  lifecycleManager?: AgentLifecycleManager
 }
 
 /** Polling interval (ms) for checking cancellation. */
@@ -77,6 +80,7 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
     mcpToolRouter,
     mcpClientPool,
     credentialService,
+    lifecycleManager,
   } = deps
   const memoryScheduler = createMemoryScheduler({ db, threshold: memoryExtractThreshold })
 
@@ -340,6 +344,38 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
           // ── Step 9: Stream events ──
           const cancelChecker = startCancelChecker(db, jobId, handle)
 
+          // Track LLM turn count (each text event = 1 turn)
+          let turnCount = 0
+
+          // Register steer listener so mid-execution steers are consumed
+          const unsubSteer = lifecycleManager
+            ? lifecycleManager.onSteer(agent.id, (msg: SteerMessage) => {
+                turnCount++
+
+                // Apply urgent prefix
+                const displayInstruction =
+                  msg.priority === "urgent"
+                    ? `[URGENT OPERATOR INSTRUCTION] ${msg.instruction}`
+                    : msg.instruction
+
+                // Broadcast the steering message as agent output
+                if (streamManager) {
+                  streamManager.broadcast(agent.id, "agent:output", {
+                    agentId: agent.id,
+                    timestamp: new Date().toISOString(),
+                    output: {
+                      type: "text",
+                      timestamp: new Date().toISOString(),
+                      content: `[STEER] ${displayInstruction}`,
+                    },
+                  })
+                }
+
+                // Acknowledge consumption
+                lifecycleManager.acknowledgeSteer(msg.id, turnCount)
+              })
+            : undefined
+
           try {
             for await (const event of handle.events()) {
               // Write to JSONL session buffer
@@ -355,6 +391,11 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                   output: event,
                 }
                 streamManager.broadcast(agent.id, "agent:output", ssePayload)
+              }
+
+              // Track LLM turns (text events from the model)
+              if (event.type === "text") {
+                turnCount++
               }
 
               if (job.session_id && event.type === "text" && event.content.trim().length > 0) {
@@ -376,6 +417,7 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
             }
           } finally {
             cancelChecker.stop()
+            unsubSteer?.()
           }
 
           // ── Step 10: Await final result ──


### PR DESCRIPTION
## Summary

- **Rename** steer body field `message` → `instruction` and priority enum value `high` → `urgent` per updated API contract
- **Add** `steerAsync()` + `acknowledgeSteer()` to `AgentLifecycleManager` — the route now waits up to 30 s for the execution loop to acknowledge consumption, returning `acknowledged: true/false`
- **Emit** `steer:injected` SSE event with operator user ID on steer receipt, and `steer:acknowledged` event when consumed with turn number
- **Wire** steer consumption in `agent-execute.ts` — registers `onSteer` listener that tracks LLM turn count, applies `[URGENT OPERATOR INSTRUCTION]` prefix for urgent steers, and acknowledges
- **Return** `200 { steerEventId, acknowledged, incorporatedAtTurn? }` (was `202 { steerMessageId, status }`)

## Files changed

| File | Change |
|------|--------|
| `src/streaming/types.ts` | Add `steer:injected`, `steer:acknowledged` SSE events + payload types; rename field/enum |
| `src/streaming/index.ts` | Re-export new payload types |
| `src/lifecycle/manager.ts` | `SteerMessage.instruction`, `SteerAck`, `steerAsync()`, `acknowledgeSteer()` |
| `src/routes/stream.ts` | New API contract with ack wait; emit `steer:injected`/`steer:acknowledged` |
| `src/worker/tasks/agent-execute.ts` | Register `onSteer` listener, turn tracking, urgent prefix, `acknowledgeSteer()` |
| `src/routes/observation.ts` | Update 2 call-sites for renamed `instruction` field |
| `src/__tests__/stream-routes.test.ts` | Updated for new response shape, priority, SSE events |
| `src/__tests__/lifecycle-steering.test.ts` | Updated + 2 new tests for `steerAsync`/`acknowledgeSteer` |
| `src/__tests__/observation-routes.test.ts` | Updated field references |
| `src/__tests__/browser-orchestration.test.ts` | Updated field references |

## Test plan

- [x] `npx vitest run` — 1108 tests pass (0 failures)
- [x] `npx eslint src/` — no new lint errors
- [x] `npm run typecheck` — passes cleanly
- [ ] CI (`ci` check) passes on this PR

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added asynchronous steering with acknowledgment tracking and configurable timeouts.
  * Added real-time event broadcasts for steering injection and acknowledgment with operator and incorporation details.
  * Enhanced steering responses to include event identifiers and incorporation turn tracking.

* **Updates**
  * Steering instruction payload field renamed from `message` to `instruction`.
  * Priority levels updated from "high" to "urgent".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->