### PR TITLE
feat(control): dry run — simulate agent turn without tool execution (#329)

### DIFF
--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -27,6 +27,7 @@ import { McpToolRouter } from "./mcp/tool-router.js"
 import { loadAuthConfig } from "./middleware/api-keys.js"
 import { BrowserObservationService } from "./observation/service.js"
 import { agentChannelRoutes } from "./routes/agent-channels.js"
+import { agentControlRoutes } from "./routes/agent-control.js"
 import { agentCredentialRoutes } from "./routes/agent-credentials.js"
 import { agentRoutes } from "./routes/agents.js"
 import { approvalRoutes } from "./routes/approval.js"
@@ -191,6 +192,16 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
       enqueueJob: async (jobId: string) => {
         await workerUtils.addJob("agent_execute", { jobId }, { jobKey: `exec:${jobId}` })
       },
+    }),
+  )
+
+  // Register agent control routes (dry run, etc.)
+  await app.register(
+    agentControlRoutes({
+      db,
+      authConfig,
+      sessionService,
+      mcpToolRouter,
     }),
   )
 

--- a/packages/control-plane/src/observability/__tests__/dry-run.test.ts
+++ b/packages/control-plane/src/observability/__tests__/dry-run.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { ToolRegistry } from "../../backends/tool-executor.js"
+import {
+  type ConversationTurn,
+  estimateCost,
+  loadConversationContext,
+  type PlannedAction,
+  stubTools,
+} from "../dry-run.js"
+
+// ---------------------------------------------------------------------------
+// stubTools
+// ---------------------------------------------------------------------------
+
+describe("stubTools", () => {
+  function createRegistry(): ToolRegistry {
+    const registry = new ToolRegistry()
+    registry.register({
+      name: "search",
+      description: "Search the web",
+      inputSchema: { type: "object", properties: { query: { type: "string" } } },
+      execute: vi.fn().mockResolvedValue("real search result"),
+    })
+    registry.register({
+      name: "write_file",
+      description: "Write a file",
+      inputSchema: { type: "object", properties: { path: { type: "string" } } },
+      execute: vi.fn().mockResolvedValue("file written"),
+    })
+    return registry
+  }
+
+  it("returns tool definitions with stubbed execute()", () => {
+    const registry = createRegistry()
+    const actions: PlannedAction[] = []
+
+    const stubbed = stubTools(registry, ["search", "write_file"], [], actions)
+
+    expect(stubbed).toHaveLength(2)
+    expect(stubbed[0]!.name).toBe("search")
+    expect(stubbed[1]!.name).toBe("write_file")
+  })
+
+  it("stub execute() records planned action and returns dry-run message", async () => {
+    const registry = createRegistry()
+    const actions: PlannedAction[] = []
+
+    const stubbed = stubTools(registry, ["search"], [], actions)
+    const result = await stubbed[0]!.execute({ query: "hello" })
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toEqual({
+      type: "tool_call",
+      toolRef: "search",
+      input: { query: "hello" },
+    })
+    expect(result).toBe('[DRY RUN] Tool search would be called with: {"query":"hello"}')
+  })
+
+  it("does not call the original execute()", async () => {
+    const registry = createRegistry()
+    const originalExecute = registry.get("search")!.execute as ReturnType<typeof vi.fn>
+    const actions: PlannedAction[] = []
+
+    const stubbed = stubTools(registry, ["search"], [], actions)
+    await stubbed[0]!.execute({ query: "test" })
+
+    expect(originalExecute).not.toHaveBeenCalled()
+  })
+
+  it("preserves tool metadata (description, inputSchema)", () => {
+    const registry = createRegistry()
+    const original = registry.get("search")!
+    const actions: PlannedAction[] = []
+
+    const stubbed = stubTools(registry, ["search"], [], actions)
+    const stub = stubbed[0]!
+
+    expect(stub.description).toBe(original.description)
+    expect(stub.inputSchema).toEqual(original.inputSchema)
+  })
+
+  it("respects allowedTools/deniedTools filters", () => {
+    const registry = createRegistry()
+    const actions: PlannedAction[] = []
+
+    const stubbed = stubTools(registry, ["search", "write_file"], ["write_file"], actions)
+
+    expect(stubbed).toHaveLength(1)
+    expect(stubbed[0]!.name).toBe("search")
+  })
+
+  it("returns empty array when no tools match", () => {
+    const registry = createRegistry()
+    const actions: PlannedAction[] = []
+
+    const stubbed = stubTools(registry, ["nonexistent"], [], actions)
+
+    expect(stubbed).toHaveLength(0)
+  })
+
+  it("accumulates multiple planned actions across calls", async () => {
+    const registry = createRegistry()
+    const actions: PlannedAction[] = []
+
+    const stubbed = stubTools(registry, ["search", "write_file"], [], actions)
+    await stubbed[0]!.execute({ query: "first" })
+    await stubbed[1]!.execute({ path: "/tmp/file.txt" })
+
+    expect(actions).toHaveLength(2)
+    expect(actions[0]!.toolRef).toBe("search")
+    expect(actions[1]!.toolRef).toBe("write_file")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadConversationContext
+// ---------------------------------------------------------------------------
+
+describe("loadConversationContext", () => {
+  it("returns empty array when no sessionId is provided", async () => {
+    const db = {} as never // not called
+    const result = await loadConversationContext(db)
+    expect(result).toEqual([])
+  })
+
+  it("returns empty array when sessionId is undefined", async () => {
+    const db = {} as never
+    const result = await loadConversationContext(db, undefined)
+    expect(result).toEqual([])
+  })
+
+  it("queries session_message table and maps rows", async () => {
+    const mockRows: Array<{ role: string; content: string }> = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there!" },
+      { role: "user", content: "How are you?" },
+    ]
+
+    const execute = vi.fn().mockResolvedValue(mockRows)
+    const orderBy = vi.fn().mockReturnValue({ execute })
+    const where = vi.fn().mockReturnValue({ orderBy })
+    const select = vi.fn().mockReturnValue({ where })
+    const selectFrom = vi.fn().mockReturnValue({ select })
+    const db = { selectFrom } as never
+
+    const result = await loadConversationContext(db, "session-123")
+
+    expect(selectFrom).toHaveBeenCalledWith("session_message")
+    expect(select).toHaveBeenCalledWith(["role", "content"])
+    expect(where).toHaveBeenCalledWith("session_id", "=", "session-123")
+    expect(orderBy).toHaveBeenCalledWith("created_at", "asc")
+
+    const expected: ConversationTurn[] = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there!" },
+      { role: "user", content: "How are you?" },
+    ]
+    expect(result).toEqual(expected)
+  })
+
+  it("returns empty array when session has no messages", async () => {
+    const execute = vi.fn().mockResolvedValue([])
+    const orderBy = vi.fn().mockReturnValue({ execute })
+    const where = vi.fn().mockReturnValue({ orderBy })
+    const select = vi.fn().mockReturnValue({ where })
+    const selectFrom = vi.fn().mockReturnValue({ select })
+    const db = { selectFrom } as never
+
+    const result = await loadConversationContext(db, "empty-session")
+
+    expect(result).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// estimateCost
+// ---------------------------------------------------------------------------
+
+describe("estimateCost", () => {
+  it("returns 0 for zero token usage", () => {
+    const cost = estimateCost({
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    })
+    expect(cost).toBe(0)
+  })
+
+  it("calculates cost based on input/output tokens", () => {
+    const cost = estimateCost({
+      inputTokens: 1000,
+      outputTokens: 1000,
+      costUsd: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    })
+    // 1000/1000 * 0.003 + 1000/1000 * 0.015 = 0.003 + 0.015 = 0.018
+    expect(cost).toBe(0.018)
+  })
+
+  it("handles large token counts", () => {
+    const cost = estimateCost({
+      inputTokens: 100_000,
+      outputTokens: 10_000,
+      costUsd: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    })
+    // 100 * 0.003 + 10 * 0.015 = 0.3 + 0.15 = 0.45
+    expect(cost).toBe(0.45)
+  })
+
+  it("rounds to 6 decimal places", () => {
+    const cost = estimateCost({
+      inputTokens: 1,
+      outputTokens: 1,
+      costUsd: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    })
+    // 0.001 * 0.003 + 0.001 * 0.015 = 0.000003 + 0.000015 = 0.000018
+    expect(cost).toBe(0.000018)
+  })
+
+  it("ignores the costUsd field from input (recalculates independently)", () => {
+    const cost = estimateCost({
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 999,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    })
+    expect(cost).toBe(0)
+  })
+})

--- a/packages/control-plane/src/observability/dry-run.ts
+++ b/packages/control-plane/src/observability/dry-run.ts
@@ -1,0 +1,112 @@
+/**
+ * Dry Run — simulate an agent turn without real tool execution.
+ *
+ * Builds the execution context as normal (system prompt, tool definitions,
+ * optional conversation history), but replaces every tool `execute()`
+ * function with a stub that returns a synthetic "[DRY RUN]" message.
+ *
+ * The LLM sees real tool definitions and may request tool calls. Those
+ * calls are captured as `plannedActions` without side effects. No session
+ * messages, checkpoints, or agent state changes are persisted.
+ */
+
+import type { TokenUsage } from "@cortex/shared/backends"
+import type { Kysely } from "kysely"
+
+import type { ToolDefinition, ToolRegistry } from "../backends/tool-executor.js"
+import type { Database } from "../db/types.js"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PlannedAction {
+  type: "tool_call"
+  toolRef: string
+  input: Record<string, unknown>
+}
+
+export interface DryRunResult {
+  plannedActions: PlannedAction[]
+  agentResponse: string
+  tokensUsed: { in: number; out: number }
+  estimatedCostUsd: number
+}
+
+// ---------------------------------------------------------------------------
+// Stub replacement
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new ToolRegistry whose tool definitions are clones of the
+ * originals, but with every `execute()` replaced by a dry-run stub.
+ *
+ * Planned actions are pushed into the provided `actions` array as a
+ * side-channel so the caller can inspect them after the LLM turn.
+ */
+export function stubTools(
+  registry: ToolRegistry,
+  allowedTools: string[],
+  deniedTools: string[],
+  actions: PlannedAction[],
+): ToolDefinition[] {
+  const originals = registry.resolve(allowedTools, deniedTools)
+
+  return originals.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    execute: (input: Record<string, unknown>) => {
+      actions.push({ type: "tool_call", toolRef: tool.name, input })
+      return Promise.resolve(
+        `[DRY RUN] Tool ${tool.name} would be called with: ${JSON.stringify(input)}`,
+      )
+    },
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// Conversation context loader
+// ---------------------------------------------------------------------------
+
+export interface ConversationTurn {
+  role: "user" | "assistant"
+  content: string
+}
+
+/**
+ * Load existing conversation context from the session_message table.
+ * Returns an empty array when no sessionId is provided.
+ */
+export async function loadConversationContext(
+  db: Kysely<Database>,
+  sessionId?: string,
+): Promise<ConversationTurn[]> {
+  if (!sessionId) return []
+
+  const rows = await db
+    .selectFrom("session_message")
+    .select(["role", "content"])
+    .where("session_id", "=", sessionId)
+    .orderBy("created_at", "asc")
+    .execute()
+
+  return rows.map((r) => ({
+    role: r.role as "user" | "assistant",
+    content: typeof r.content === "string" ? r.content : JSON.stringify(r.content),
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// Cost estimation
+// ---------------------------------------------------------------------------
+
+/** Rough per-1K-token pricing for cost estimation. */
+const DEFAULT_INPUT_COST_PER_1K = 0.003
+const DEFAULT_OUTPUT_COST_PER_1K = 0.015
+
+export function estimateCost(usage: TokenUsage): number {
+  const inCost = (usage.inputTokens / 1000) * DEFAULT_INPUT_COST_PER_1K
+  const outCost = (usage.outputTokens / 1000) * DEFAULT_OUTPUT_COST_PER_1K
+  return parseFloat((inCost + outCost).toFixed(6))
+}

--- a/packages/control-plane/src/routes/agent-control.ts
+++ b/packages/control-plane/src/routes/agent-control.ts
@@ -1,0 +1,222 @@
+/**
+ * Agent Control Routes
+ *
+ * POST /agents/:agentId/dry-run — simulate an agent turn without tool execution
+ */
+
+import Anthropic from "@anthropic-ai/sdk"
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
+import type { Kysely } from "kysely"
+
+import type { SessionService } from "../auth/session-service.js"
+import { createAgentToolRegistry } from "../backends/tool-executor.js"
+import type { Database } from "../db/types.js"
+import type { McpToolRouter } from "../mcp/tool-router.js"
+import {
+  type AuthMiddlewareOptions,
+  createRequireAuth,
+  createRequireRole,
+  type PreHandler,
+} from "../middleware/auth.js"
+import type { AuthConfig } from "../middleware/types.js"
+import {
+  type DryRunResult,
+  estimateCost,
+  loadConversationContext,
+  type PlannedAction,
+} from "../observability/dry-run.js"
+
+// ---------------------------------------------------------------------------
+// Route types
+// ---------------------------------------------------------------------------
+
+interface DryRunParams {
+  agentId: string
+}
+
+interface DryRunBody {
+  message: string
+  sessionId?: string
+  maxTurns?: number
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+export interface AgentControlRouteDeps {
+  db: Kysely<Database>
+  authConfig: AuthConfig
+  sessionService?: SessionService
+  mcpToolRouter?: McpToolRouter
+}
+
+export function agentControlRoutes(deps: AgentControlRouteDeps) {
+  const { db, authConfig, sessionService, mcpToolRouter } = deps
+
+  const authOpts: AuthMiddlewareOptions = { config: authConfig, sessionService }
+  const requireAuth: PreHandler = createRequireAuth(authOpts)
+  const requireOperator: PreHandler = createRequireRole("operator")
+
+  return function register(app: FastifyInstance): void {
+    // -----------------------------------------------------------------
+    // POST /agents/:agentId/dry-run — simulate agent turn
+    // Requires: auth + operator role
+    // -----------------------------------------------------------------
+    app.post<{ Params: DryRunParams; Body: DryRunBody }>(
+      "/agents/:agentId/dry-run",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string" },
+            },
+            required: ["agentId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              message: { type: "string", minLength: 1, maxLength: 50_000 },
+              sessionId: { type: "string" },
+              maxTurns: { type: "number", minimum: 1, maximum: 1 },
+            },
+            required: ["message"],
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: DryRunParams; Body: DryRunBody }>,
+        reply: FastifyReply,
+      ) => {
+        const { agentId } = request.params
+        const { message, sessionId } = request.body
+
+        // Load agent
+        const agent = await db
+          .selectFrom("agent")
+          .selectAll()
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          return reply.status(404).send({ error: "not_found", message: "Agent not found" })
+        }
+
+        if (agent.status !== "ACTIVE") {
+          return reply.status(409).send({
+            error: "conflict",
+            message: `Agent is ${agent.status}, must be ACTIVE for dry run`,
+          })
+        }
+
+        // Resolve tool definitions (same as normal execution)
+        const agentConfig = agent.config ?? {}
+        const skillConfig = agent.skill_config ?? {}
+        const allowedTools: string[] = Array.isArray(skillConfig.allowedTools)
+          ? (skillConfig.allowedTools as string[])
+          : []
+        const deniedTools: string[] = Array.isArray(skillConfig.deniedTools)
+          ? (skillConfig.deniedTools as string[])
+          : []
+
+        const registry = await createAgentToolRegistry(agentConfig, {
+          agentId: agent.id,
+          mcpRouter: mcpToolRouter,
+          allowedTools,
+          deniedTools,
+        })
+
+        // Get tool definitions (for the LLM to see)
+        const toolDefs = registry.resolve(allowedTools, deniedTools)
+        const anthropicTools: Anthropic.Tool[] = toolDefs.map((t) => ({
+          name: t.name,
+          description: t.description,
+          input_schema: t.inputSchema as Anthropic.Tool.InputSchema,
+        }))
+
+        // Load conversation context
+        const conversationHistory = await loadConversationContext(db, sessionId)
+
+        // Build system prompt (mirrors agent-execute.ts)
+        const modelConfig = agent.model_config ?? {}
+        const systemPrompt =
+          typeof modelConfig.systemPrompt === "string"
+            ? modelConfig.systemPrompt
+            : `You are ${agent.name}, a ${agent.role} agent.${agent.description ? ` ${agent.description}` : ""}`
+
+        // Resolve API key
+        const apiKey = process.env.LLM_API_KEY ?? process.env.ANTHROPIC_API_KEY ?? ""
+        if (!apiKey) {
+          return reply.status(503).send({
+            error: "service_unavailable",
+            message: "No LLM API key configured for dry run",
+          })
+        }
+
+        // Build messages
+        const messages: Anthropic.MessageParam[] = []
+        for (const turn of conversationHistory) {
+          messages.push({ role: turn.role, content: turn.content })
+        }
+        messages.push({ role: "user", content: message })
+
+        // Resolve model
+        const model =
+          typeof modelConfig.model === "string" ? modelConfig.model : "claude-sonnet-4-5-20250929"
+
+        // Execute one LLM turn
+        const client = new Anthropic({ apiKey })
+        const plannedActions: PlannedAction[] = []
+        let agentResponse = ""
+
+        try {
+          const response = await client.messages.create({
+            model,
+            max_tokens: 4096,
+            system: systemPrompt,
+            messages,
+            ...(anthropicTools.length > 0 ? { tools: anthropicTools } : {}),
+          })
+
+          // Extract text + tool_use blocks
+          for (const block of response.content) {
+            if (block.type === "text") {
+              agentResponse += block.text
+            } else if (block.type === "tool_use") {
+              plannedActions.push({
+                type: "tool_call",
+                toolRef: block.name,
+                input: block.input as Record<string, unknown>,
+              })
+            }
+          }
+
+          const costUsd = estimateCost({
+            inputTokens: response.usage.input_tokens,
+            outputTokens: response.usage.output_tokens,
+            costUsd: 0,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+          })
+
+          const result: DryRunResult = {
+            plannedActions,
+            agentResponse,
+            tokensUsed: { in: response.usage.input_tokens, out: response.usage.output_tokens },
+            estimatedCostUsd: costUsd,
+          }
+
+          return reply.status(200).send(result)
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : "LLM API error"
+          return reply.status(502).send({
+            error: "llm_error",
+            message: `Dry run LLM call failed: ${errorMsg}`,
+          })
+        }
+      },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Add `POST /agents/:agentId/dry-run` route that executes one LLM turn with tool definitions visible but captures `tool_use` blocks as planned actions without executing them
- New `src/observability/dry-run.ts` module: `stubTools()`, `loadConversationContext()`, and `estimateCost()` helpers
- New `src/routes/agent-control.ts` route file, registered in `app.ts`
- Route requires `operator` or `admin` auth role; returns `plannedActions`, `agentResponse`, `tokensUsed`, and `estimatedCostUsd`
- No session message storage, no checkpoint update, no state changes

Closes #329

## Test plan
- [x] 16 unit tests in `src/observability/__tests__/dry-run.test.ts` covering `stubTools`, `loadConversationContext`, and `estimateCost`
- [x] `npx vitest run` — 1124 tests pass (67 files)
- [x] `npx eslint` — 0 errors (2 pre-existing turbo warnings)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced agent dry-run endpoint enabling preview of agent responses and planned tool calls without executing them.
  * Added automatic cost estimation for agent operations based on token usage and configured pricing rates.

* **Tests**
  * Implemented comprehensive test coverage for dry-run functionality, cost estimation, and conversation context loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->