### PR TITLE
feat(auth): PairingService — code generation, validation, and redemption

### DIFF
--- a/packages/control-plane/migrations/022_channel_authorization.down.sql
+++ b/packages/control-plane/migrations/022_channel_authorization.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS agent_user_grant;
+DROP TABLE IF EXISTS pairing_code;
+DROP TYPE IF EXISTS grant_origin;
+DROP TYPE IF EXISTS grant_access_level;

--- a/packages/control-plane/migrations/022_channel_authorization.up.sql
+++ b/packages/control-plane/migrations/022_channel_authorization.up.sql
@@ -1,0 +1,49 @@
+-- 022: Channel authorization — pairing codes and user grants.
+--      Part of the channel-authorization epic (#333).
+--      Dependency for PairingService (#336).
+
+-- 1. Enums
+CREATE TYPE grant_access_level AS ENUM ('read', 'write');
+CREATE TYPE grant_origin AS ENUM (
+  'pairing_code',
+  'dashboard_invite',
+  'auto_team',
+  'auto_open',
+  'approval'
+);
+
+-- 2. pairing_code
+CREATE TABLE pairing_code (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  code        TEXT        NOT NULL UNIQUE,
+  agent_id    UUID        REFERENCES agent(id) ON DELETE CASCADE,
+  created_by  UUID        NOT NULL REFERENCES user_account(id) ON DELETE CASCADE,
+  redeemed_by UUID        REFERENCES user_account(id) ON DELETE SET NULL,
+  redeemed_at TIMESTAMPTZ,
+  revoked_at  TIMESTAMPTZ,
+  expires_at  TIMESTAMPTZ NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_pairing_code_active
+  ON pairing_code (code)
+  WHERE redeemed_at IS NULL AND revoked_at IS NULL;
+
+-- 3. agent_user_grant
+CREATE TABLE agent_user_grant (
+  id              UUID               PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id        UUID               NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
+  user_account_id UUID               NOT NULL REFERENCES user_account(id) ON DELETE CASCADE,
+  access_level    grant_access_level  NOT NULL DEFAULT 'write',
+  origin          grant_origin        NOT NULL,
+  granted_by      UUID               REFERENCES user_account(id) ON DELETE SET NULL,
+  rate_limit      JSONB,
+  token_budget    JSONB,
+  expires_at      TIMESTAMPTZ,
+  revoked_at      TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ        NOT NULL DEFAULT now(),
+  UNIQUE (agent_id, user_account_id)
+);
+
+CREATE INDEX idx_aug_agent ON agent_user_grant (agent_id) WHERE revoked_at IS NULL;
+CREATE INDEX idx_aug_user  ON agent_user_grant (user_account_id) WHERE revoked_at IS NULL;

--- a/packages/control-plane/src/auth/__tests__/pairing-service.test.ts
+++ b/packages/control-plane/src/auth/__tests__/pairing-service.test.ts
@@ -1,0 +1,345 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import type { AgentUserGrant, Database, PairingCode } from "../../db/types.js"
+import { PairingService } from "../pairing-service.js"
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const AGENT_ID = "aaaaaaaa-1111-2222-3333-444444444444"
+const USER_ID = "bbbbbbbb-1111-2222-3333-444444444444"
+const REDEEMER_ID = "cccccccc-1111-2222-3333-444444444444"
+const CODE_ID = "dddddddd-1111-2222-3333-444444444444"
+const GRANT_ID = "eeeeeeee-1111-2222-3333-444444444444"
+const CHANNEL_MAPPING_ID = "ffffffff-1111-2222-3333-444444444444"
+
+const now = new Date()
+const futureDate = new Date(Date.now() + 3_600_000)
+const pastDate = new Date(Date.now() - 3_600_000)
+
+// ---------------------------------------------------------------------------
+// Row factories
+// ---------------------------------------------------------------------------
+
+function makeCodeRow(overrides: Partial<PairingCode> = {}): PairingCode {
+  return {
+    id: CODE_ID,
+    code: "ABC234",
+    agent_id: AGENT_ID,
+    created_by: USER_ID,
+    redeemed_by: null,
+    redeemed_at: null,
+    revoked_at: null,
+    expires_at: futureDate,
+    created_at: now,
+    ...overrides,
+  }
+}
+
+function makeGrantRow(overrides: Partial<AgentUserGrant> = {}): AgentUserGrant {
+  return {
+    id: GRANT_ID,
+    agent_id: AGENT_ID,
+    user_account_id: REDEEMER_ID,
+    access_level: "write",
+    origin: "pairing_code",
+    granted_by: USER_ID,
+    rate_limit: null,
+    token_budget: null,
+    expires_at: null,
+    revoked_at: null,
+    created_at: now,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Chainable Kysely mock helpers
+// ---------------------------------------------------------------------------
+
+function mockSelectChain(result: unknown) {
+  const executeTakeFirst = vi.fn().mockResolvedValue(result)
+  const execute = vi
+    .fn()
+    .mockResolvedValue(Array.isArray(result) ? result : result == null ? [] : [result])
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  const selectAllFn = vi.fn()
+  const chain = { where: whereFn, selectAll: selectAllFn, executeTakeFirst, execute }
+  whereFn.mockReturnValue(chain)
+  selectAllFn.mockReturnValue(chain)
+  return chain
+}
+
+function mockInsertChain(result: unknown, error?: Error) {
+  const executeTakeFirstOrThrow = error
+    ? vi.fn().mockRejectedValue(error)
+    : vi.fn().mockResolvedValue(result)
+  const valuesFn = vi.fn()
+  const returningAllFn = vi.fn()
+  const chain = { values: valuesFn, returningAll: returningAllFn, executeTakeFirstOrThrow }
+  valuesFn.mockReturnValue(chain)
+  returningAllFn.mockReturnValue(chain)
+  return chain
+}
+
+function mockUpdateChain(result: unknown) {
+  const executeTakeFirst = vi.fn().mockResolvedValue(result)
+  const execute = vi
+    .fn()
+    .mockResolvedValue(result == null ? [] : Array.isArray(result) ? result : [result])
+  const setFn = vi.fn()
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  const returningAllFn = vi.fn()
+  const chain = {
+    set: setFn,
+    where: whereFn,
+    returningAll: returningAllFn,
+    executeTakeFirst,
+    execute,
+  }
+  setFn.mockReturnValue(chain)
+  whereFn.mockReturnValue(chain)
+  returningAllFn.mockReturnValue(chain)
+  return chain
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PairingService", () => {
+  // -----------------------------------------------------------------------
+  // generate
+  // -----------------------------------------------------------------------
+  describe("generate", () => {
+    it("creates a 6-character code from the safe alphabet", async () => {
+      const insertChain = mockInsertChain(makeCodeRow())
+      const db = {
+        insertInto: vi.fn().mockReturnValue(insertChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      const result = await svc.generate(AGENT_ID, USER_ID)
+
+      expect(result.code).toHaveLength(6)
+      expect(result.code).toMatch(/^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{6}$/)
+      expect(result.expiresAt).toBeInstanceOf(Date)
+      expect(db.insertInto).toHaveBeenCalledWith("pairing_code")
+    })
+
+    it("respects custom TTL", async () => {
+      const insertChain = mockInsertChain(makeCodeRow())
+      const db = {
+        insertInto: vi.fn().mockReturnValue(insertChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      const before = Date.now()
+      const result = await svc.generate(AGENT_ID, USER_ID, 7200)
+
+      const expectedExpiry = before + 7_200_000
+      expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedExpiry - 1000)
+      expect(result.expiresAt.getTime()).toBeLessThanOrEqual(expectedExpiry + 1000)
+    })
+
+    it("retries on UNIQUE violation", async () => {
+      const uniqueErr = Object.assign(new Error("unique_violation"), { code: "23505" })
+      const failChain = mockInsertChain(null, uniqueErr)
+      const successChain = mockInsertChain(makeCodeRow())
+
+      let callCount = 0
+      const db = {
+        insertInto: vi.fn().mockImplementation(() => {
+          callCount++
+          return callCount === 1 ? failChain : successChain
+        }),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      const result = await svc.generate(AGENT_ID, USER_ID)
+
+      expect(result.code).toHaveLength(6)
+      expect(db.insertInto).toHaveBeenCalledTimes(2)
+    })
+
+    it("throws after exhausting retries", async () => {
+      const uniqueErr = Object.assign(new Error("unique_violation"), { code: "23505" })
+      const failChain = mockInsertChain(null, uniqueErr)
+      const db = {
+        insertInto: vi.fn().mockReturnValue(failChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      await expect(svc.generate(AGENT_ID, USER_ID)).rejects.toThrow("unique_violation")
+      expect(db.insertInto).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // redeem
+  // -----------------------------------------------------------------------
+  describe("redeem", () => {
+    it("rejects an invalid code", async () => {
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(mockSelectChain(undefined)),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      const result = await svc.redeem("XXXXXX", CHANNEL_MAPPING_ID, REDEEMER_ID)
+
+      expect(result).toEqual({ success: false, message: "Invalid pairing code" })
+    })
+
+    it("rejects an expired code", async () => {
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(mockSelectChain(makeCodeRow({ expires_at: pastDate }))),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      const result = await svc.redeem("ABC234", CHANNEL_MAPPING_ID, REDEEMER_ID)
+
+      expect(result).toEqual({ success: false, message: "Code has expired" })
+    })
+
+    it("rejects an already-redeemed code", async () => {
+      const db = {
+        selectFrom: vi
+          .fn()
+          .mockReturnValue(
+            mockSelectChain(makeCodeRow({ redeemed_at: now, redeemed_by: "someone" })),
+          ),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      const result = await svc.redeem("ABC234", CHANNEL_MAPPING_ID, REDEEMER_ID)
+
+      expect(result).toEqual({ success: false, message: "Code already redeemed" })
+    })
+
+    it("rejects a revoked code", async () => {
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(mockSelectChain(makeCodeRow({ revoked_at: now }))),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      const result = await svc.redeem("ABC234", CHANNEL_MAPPING_ID, REDEEMER_ID)
+
+      expect(result).toEqual({ success: false, message: "Code has been revoked" })
+    })
+
+    it("sets redeemed_by and redeemed_at on success", async () => {
+      const updateChain = mockUpdateChain(
+        makeCodeRow({ redeemed_at: now, redeemed_by: REDEEMER_ID }),
+      )
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(mockSelectChain(makeCodeRow({ agent_id: null }))),
+        updateTable: vi.fn().mockReturnValue(updateChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      const result = await svc.redeem("ABC234", CHANNEL_MAPPING_ID, REDEEMER_ID)
+
+      expect(result.success).toBe(true)
+      expect(db.updateTable).toHaveBeenCalledWith("pairing_code")
+
+      const setArg = updateChain.set.mock.calls[0]?.[0] as
+        | { redeemed_by: string; redeemed_at: Date }
+        | undefined
+      expect(setArg?.redeemed_by).toBe(REDEEMER_ID)
+      expect(setArg?.redeemed_at).toBeInstanceOf(Date)
+    })
+
+    it("creates agent_user_grant when agent_id is set", async () => {
+      const updateChain = mockUpdateChain(makeCodeRow({ redeemed_at: now }))
+      const insertChain = mockInsertChain(makeGrantRow())
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(mockSelectChain(makeCodeRow())),
+        updateTable: vi.fn().mockReturnValue(updateChain),
+        insertInto: vi.fn().mockReturnValue(insertChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      const result = await svc.redeem("ABC234", CHANNEL_MAPPING_ID, REDEEMER_ID)
+
+      expect(result).toEqual({
+        success: true,
+        message: "Pairing code redeemed",
+        grantId: GRANT_ID,
+      })
+      expect(db.insertInto).toHaveBeenCalledWith("agent_user_grant")
+    })
+
+    it("does not create grant when agent_id is null", async () => {
+      const updateChain = mockUpdateChain(makeCodeRow({ agent_id: null, redeemed_at: now }))
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(mockSelectChain(makeCodeRow({ agent_id: null }))),
+        updateTable: vi.fn().mockReturnValue(updateChain),
+        insertInto: vi.fn(),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      const result = await svc.redeem("ABC234", CHANNEL_MAPPING_ID, REDEEMER_ID)
+
+      expect(result.success).toBe(true)
+      expect(result.grantId).toBeUndefined()
+      expect(db.insertInto).not.toHaveBeenCalled()
+    })
+
+    it("returns failure on concurrent redemption race", async () => {
+      // update returns null — another process redeemed first
+      const updateChain = mockUpdateChain(null)
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(mockSelectChain(makeCodeRow())),
+        updateTable: vi.fn().mockReturnValue(updateChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      const result = await svc.redeem("ABC234", CHANNEL_MAPPING_ID, REDEEMER_ID)
+
+      expect(result).toEqual({
+        success: false,
+        message: "Code already redeemed or revoked",
+      })
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // listActive
+  // -----------------------------------------------------------------------
+  describe("listActive", () => {
+    it("returns unexpired unredeemed codes for the agent", async () => {
+      const codes = [makeCodeRow(), makeCodeRow({ id: "other-id", code: "XYZ789" })]
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(mockSelectChain(codes)),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      const result = await svc.listActive(AGENT_ID)
+
+      expect(result).toHaveLength(2)
+      expect(db.selectFrom).toHaveBeenCalledWith("pairing_code")
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // revoke
+  // -----------------------------------------------------------------------
+  describe("revoke", () => {
+    it("updates the code with revoked_at", async () => {
+      const updateChain = mockUpdateChain(makeCodeRow({ revoked_at: now }))
+      const db = {
+        updateTable: vi.fn().mockReturnValue(updateChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new PairingService(db)
+      await svc.revoke(CODE_ID)
+
+      expect(db.updateTable).toHaveBeenCalledWith("pairing_code")
+      const setArg = updateChain.set.mock.calls[0]?.[0] as { revoked_at: Date } | undefined
+      expect(setArg?.revoked_at).toBeInstanceOf(Date)
+    })
+  })
+})

--- a/packages/control-plane/src/auth/pairing-service.ts
+++ b/packages/control-plane/src/auth/pairing-service.ts
@@ -1,0 +1,152 @@
+import { randomBytes } from "node:crypto"
+
+import type { Kysely } from "kysely"
+
+import type { Database, PairingCode } from "../db/types.js"
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SAFE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+const CODE_LENGTH = 6
+const MAX_RETRIES = 3
+const DEFAULT_TTL_SECONDS = 3600
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface GenerateResult {
+  code: string
+  expiresAt: Date
+}
+
+export interface RedeemResult {
+  success: boolean
+  message: string
+  grantId?: string
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateCode(): string {
+  const bytes = randomBytes(CODE_LENGTH)
+  return Array.from(bytes)
+    .map((b) => SAFE_ALPHABET[b % SAFE_ALPHABET.length])
+    .join("")
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return (err as { code?: string }).code === "23505"
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class PairingService {
+  constructor(private readonly db: Kysely<Database>) {}
+
+  async generate(
+    agentId: string,
+    createdBy: string,
+    ttlSeconds = DEFAULT_TTL_SECONDS,
+  ): Promise<GenerateResult> {
+    const expiresAt = new Date(Date.now() + ttlSeconds * 1000)
+
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      const code = generateCode()
+      try {
+        await this.db
+          .insertInto("pairing_code")
+          .values({
+            code,
+            agent_id: agentId,
+            created_by: createdBy,
+            expires_at: expiresAt,
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow()
+        return { code, expiresAt }
+      } catch (err: unknown) {
+        if (isUniqueViolation(err) && attempt < MAX_RETRIES) continue
+        throw err
+      }
+    }
+
+    /* istanbul ignore next -- unreachable: loop always returns or throws */
+    throw new Error("Failed to generate unique pairing code")
+  }
+
+  async redeem(
+    code: string,
+    _channelMappingId: string,
+    userAccountId: string,
+  ): Promise<RedeemResult> {
+    const row = await this.db
+      .selectFrom("pairing_code")
+      .selectAll()
+      .where("code", "=", code)
+      .executeTakeFirst()
+
+    if (!row) return { success: false, message: "Invalid pairing code" }
+    if (row.redeemed_at) return { success: false, message: "Code already redeemed" }
+    if (row.revoked_at) return { success: false, message: "Code has been revoked" }
+    if (new Date(row.expires_at) <= new Date())
+      return { success: false, message: "Code has expired" }
+
+    // Atomically mark as redeemed (guard against concurrent redemption)
+    const updated = await this.db
+      .updateTable("pairing_code")
+      .set({ redeemed_by: userAccountId, redeemed_at: new Date() })
+      .where("id", "=", row.id)
+      .where("redeemed_at", "is", null)
+      .where("revoked_at", "is", null)
+      .returningAll()
+      .executeTakeFirst()
+
+    if (!updated) return { success: false, message: "Code already redeemed or revoked" }
+
+    // Create agent_user_grant when agent_id is present
+    let grantId: string | undefined
+    if (row.agent_id) {
+      const grant = await this.db
+        .insertInto("agent_user_grant")
+        .values({
+          agent_id: row.agent_id,
+          user_account_id: userAccountId,
+          origin: "pairing_code",
+          granted_by: row.created_by,
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+      grantId = grant.id
+    }
+
+    return { success: true, message: "Pairing code redeemed", grantId }
+  }
+
+  async listActive(agentId: string): Promise<PairingCode[]> {
+    return this.db
+      .selectFrom("pairing_code")
+      .selectAll()
+      .where("agent_id", "=", agentId)
+      .where("redeemed_at", "is", null)
+      .where("revoked_at", "is", null)
+      .where("expires_at", ">", new Date())
+      .execute()
+  }
+
+  async revoke(codeId: string): Promise<void> {
+    await this.db
+      .updateTable("pairing_code")
+      .set({ revoked_at: new Date() })
+      .where("id", "=", codeId)
+      .where("redeemed_at", "is", null)
+      .where("revoked_at", "is", null)
+      .execute()
+  }
+}

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -631,6 +631,69 @@ export type AgentCheckpoint = Selectable<AgentCheckpointTable>
 export type NewAgentCheckpoint = Insertable<AgentCheckpointTable>
 
 // ---------------------------------------------------------------------------
+// Enum: grant_access_level
+// ---------------------------------------------------------------------------
+export type GrantAccessLevel = "read" | "write"
+
+// ---------------------------------------------------------------------------
+// Enum: grant_origin
+// ---------------------------------------------------------------------------
+export type GrantOrigin =
+  | "pairing_code"
+  | "dashboard_invite"
+  | "auto_team"
+  | "auto_open"
+  | "approval"
+
+// ---------------------------------------------------------------------------
+// Table: pairing_code
+// ---------------------------------------------------------------------------
+export interface PairingCodeTable {
+  id: Generated<string>
+  code: string
+  agent_id: string | null
+  created_by: string
+  redeemed_by: string | null
+  redeemed_at: ColumnType<Date | null, Date | null | undefined, Date | null>
+  revoked_at: ColumnType<Date | null, Date | null | undefined, Date | null>
+  expires_at: Date
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
+export type PairingCode = Selectable<PairingCodeTable>
+export type NewPairingCode = Insertable<PairingCodeTable>
+export type PairingCodeUpdate = Updateable<PairingCodeTable>
+
+// ---------------------------------------------------------------------------
+// Table: agent_user_grant
+// ---------------------------------------------------------------------------
+export interface AgentUserGrantTable {
+  id: Generated<string>
+  agent_id: string
+  user_account_id: string
+  access_level: ColumnType<GrantAccessLevel, GrantAccessLevel | undefined, GrantAccessLevel>
+  origin: GrantOrigin
+  granted_by: string | null
+  rate_limit: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  token_budget: ColumnType<
+    Record<string, unknown> | null,
+    Record<string, unknown> | null | undefined,
+    Record<string, unknown> | null
+  >
+  expires_at: Date | null
+  revoked_at: ColumnType<Date | null, Date | null | undefined, Date | null>
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
+export type AgentUserGrant = Selectable<AgentUserGrantTable>
+export type NewAgentUserGrant = Insertable<AgentUserGrantTable>
+export type AgentUserGrantUpdate = Updateable<AgentUserGrantTable>
+
+// ---------------------------------------------------------------------------
 // Table: agent_event
 // ---------------------------------------------------------------------------
 export interface AgentEventTable {
@@ -679,4 +742,6 @@ export interface Database {
   tool_category_membership: ToolCategoryMembershipTable
   agent_checkpoint: AgentCheckpointTable
   agent_event: AgentEventTable
+  pairing_code: PairingCodeTable
+  agent_user_grant: AgentUserGrantTable
 }


### PR DESCRIPTION
## Summary

- Implements `PairingService` with `generate`, `redeem`, `listActive`, and `revoke` operations per #336
- Adds migration 022 with `pairing_code` and `agent_user_grant` tables (dependency from #334)
- Adds Kysely type definitions for new tables and enums (`GrantAccessLevel`, `GrantOrigin`)
- 14 unit tests covering all acceptance criteria: safe alphabet, expiry, double-redeem, revocation, grant creation, collision retry

## Test plan

- [x] `npx vitest run` — 1149 tests pass (69 files), 14 new pairing-service tests
- [x] `npx eslint src/` — no new lint errors
- [x] `npm run typecheck` — passes cleanly
- [ ] CI pipeline passes

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced channel authorization system enabling users to create and redeem pairing codes for agent access
  * Added granular access control with configurable read/write permissions and token budget management for agent-user relationships
  * Implemented rate limiting and expiration settings for authorized access

* **Tests**
  * Added comprehensive test coverage for pairing code generation, redemption, expiration, and revocation workflows
  * Verified concurrent redemption handling and access grant lifecycle management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->