### PR TITLE
feat(auth): AccessRequestService — approval queue for unknown users (#337)

### DIFF
--- a/packages/control-plane/migrations/023_access_request.down.sql
+++ b/packages/control-plane/migrations/023_access_request.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS access_request;
+DROP TYPE IF EXISTS access_request_status;

--- a/packages/control-plane/migrations/023_access_request.up.sql
+++ b/packages/control-plane/migrations/023_access_request.up.sql
@@ -1,0 +1,27 @@
+-- 023: Access request — approval queue for unknown users.
+--      Part of the channel-authorization epic (#333).
+--      Dependency for AccessRequestService (#337).
+
+-- 1. Enum
+CREATE TYPE access_request_status AS ENUM ('pending', 'approved', 'denied');
+
+-- 2. access_request
+CREATE TABLE access_request (
+  id                 UUID                   PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id           UUID                   NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
+  channel_mapping_id UUID                   NOT NULL REFERENCES channel_mapping(id) ON DELETE CASCADE,
+  user_account_id    UUID                   NOT NULL REFERENCES user_account(id) ON DELETE CASCADE,
+  status             access_request_status  NOT NULL DEFAULT 'pending',
+  message_preview    TEXT,
+  reviewed_by        UUID                   REFERENCES user_account(id) ON DELETE SET NULL,
+  reviewed_at        TIMESTAMPTZ,
+  deny_reason        TEXT,
+  created_at         TIMESTAMPTZ            NOT NULL DEFAULT now(),
+  UNIQUE (agent_id, user_account_id, status)
+);
+
+CREATE INDEX idx_ar_agent_pending
+  ON access_request (agent_id, created_at DESC)
+  WHERE status = 'pending';
+
+CREATE INDEX idx_ar_user ON access_request (user_account_id);

--- a/packages/control-plane/src/auth/__tests__/access-request-service.test.ts
+++ b/packages/control-plane/src/auth/__tests__/access-request-service.test.ts
@@ -1,0 +1,405 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import type { AccessRequest, AgentUserGrant, Database } from "../../db/types.js"
+import { AccessRequestConflictError, AccessRequestService } from "../access-request-service.js"
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const AGENT_ID = "aaaaaaaa-1111-2222-3333-444444444444"
+const AGENT_ID_2 = "aaaaaaaa-2222-3333-4444-555555555555"
+const USER_ID = "bbbbbbbb-1111-2222-3333-444444444444"
+const REVIEWER_ID = "cccccccc-1111-2222-3333-444444444444"
+const REQUEST_ID = "dddddddd-1111-2222-3333-444444444444"
+const GRANT_ID = "eeeeeeee-1111-2222-3333-444444444444"
+const CHANNEL_MAPPING_ID = "ffffffff-1111-2222-3333-444444444444"
+
+const now = new Date()
+
+// ---------------------------------------------------------------------------
+// Row factories
+// ---------------------------------------------------------------------------
+
+function makeRequestRow(overrides: Partial<AccessRequest> = {}): AccessRequest {
+  return {
+    id: REQUEST_ID,
+    agent_id: AGENT_ID,
+    channel_mapping_id: CHANNEL_MAPPING_ID,
+    user_account_id: USER_ID,
+    status: "pending",
+    message_preview: null,
+    reviewed_by: null,
+    reviewed_at: null,
+    deny_reason: null,
+    created_at: now,
+    ...overrides,
+  }
+}
+
+function makeGrantRow(overrides: Partial<AgentUserGrant> = {}): AgentUserGrant {
+  return {
+    id: GRANT_ID,
+    agent_id: AGENT_ID,
+    user_account_id: USER_ID,
+    access_level: "write",
+    origin: "approval",
+    granted_by: REVIEWER_ID,
+    rate_limit: null,
+    token_budget: null,
+    expires_at: null,
+    revoked_at: null,
+    created_at: now,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Chainable Kysely mock helpers
+// ---------------------------------------------------------------------------
+
+function mockSelectChain(result: unknown) {
+  const executeTakeFirst = vi.fn().mockResolvedValue(result)
+  const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(result)
+  const execute = vi
+    .fn()
+    .mockResolvedValue(Array.isArray(result) ? result : result == null ? [] : [result])
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  const selectAllFn = vi.fn()
+  const selectFn: ReturnType<typeof vi.fn> = vi.fn()
+  const orderByFn: ReturnType<typeof vi.fn> = vi.fn()
+  const limitFn: ReturnType<typeof vi.fn> = vi.fn()
+  const offsetFn: ReturnType<typeof vi.fn> = vi.fn()
+  const groupByFn: ReturnType<typeof vi.fn> = vi.fn()
+  const chain = {
+    where: whereFn,
+    selectAll: selectAllFn,
+    select: selectFn,
+    orderBy: orderByFn,
+    limit: limitFn,
+    offset: offsetFn,
+    groupBy: groupByFn,
+    executeTakeFirst,
+    executeTakeFirstOrThrow,
+    execute,
+  }
+  whereFn.mockReturnValue(chain)
+  selectAllFn.mockReturnValue(chain)
+  selectFn.mockReturnValue(chain)
+  orderByFn.mockReturnValue(chain)
+  limitFn.mockReturnValue(chain)
+  offsetFn.mockReturnValue(chain)
+  groupByFn.mockReturnValue(chain)
+  return chain
+}
+
+function mockInsertChain(result: unknown, error?: Error) {
+  const executeTakeFirstOrThrow = error
+    ? vi.fn().mockRejectedValue(error)
+    : vi.fn().mockResolvedValue(result)
+  const valuesFn = vi.fn()
+  const returningAllFn = vi.fn()
+  const chain = { values: valuesFn, returningAll: returningAllFn, executeTakeFirstOrThrow }
+  valuesFn.mockReturnValue(chain)
+  returningAllFn.mockReturnValue(chain)
+  return chain
+}
+
+function mockUpdateChain() {
+  const execute = vi.fn().mockResolvedValue([])
+  const setFn = vi.fn()
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  const chain = { set: setFn, where: whereFn, execute }
+  setFn.mockReturnValue(chain)
+  whereFn.mockReturnValue(chain)
+  return chain
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AccessRequestService", () => {
+  // -----------------------------------------------------------------------
+  // create
+  // -----------------------------------------------------------------------
+  describe("create", () => {
+    it("inserts a new pending request", async () => {
+      const insertChain = mockInsertChain(makeRequestRow())
+      const db = {
+        insertInto: vi.fn().mockReturnValue(insertChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      const result = await svc.create(AGENT_ID, USER_ID, CHANNEL_MAPPING_ID)
+
+      expect(result).toEqual(makeRequestRow())
+      expect(db.insertInto).toHaveBeenCalledWith("access_request")
+    })
+
+    it("stores message_preview when provided", async () => {
+      const row = makeRequestRow({ message_preview: "Hello!" })
+      const insertChain = mockInsertChain(row)
+      const db = {
+        insertInto: vi.fn().mockReturnValue(insertChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      const result = await svc.create(AGENT_ID, USER_ID, CHANNEL_MAPPING_ID, "Hello!")
+
+      expect(result.message_preview).toBe("Hello!")
+      const insertedValues = insertChain.values.mock.calls[0]?.[0] as Record<string, unknown>
+      expect(insertedValues.message_preview).toBe("Hello!")
+    })
+
+    it("returns existing request on duplicate (idempotent)", async () => {
+      const uniqueErr = Object.assign(new Error("unique_violation"), { code: "23505" })
+      const insertChain = mockInsertChain(null, uniqueErr)
+      const selectChain = mockSelectChain(makeRequestRow())
+      const db = {
+        insertInto: vi.fn().mockReturnValue(insertChain),
+        selectFrom: vi.fn().mockReturnValue(selectChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      const result = await svc.create(AGENT_ID, USER_ID, CHANNEL_MAPPING_ID)
+
+      expect(result).toEqual(makeRequestRow())
+      expect(db.selectFrom).toHaveBeenCalledWith("access_request")
+    })
+
+    it("throws on non-unique DB errors", async () => {
+      const otherErr = Object.assign(new Error("connection_error"), { code: "08006" })
+      const insertChain = mockInsertChain(null, otherErr)
+      const db = {
+        insertInto: vi.fn().mockReturnValue(insertChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      await expect(svc.create(AGENT_ID, USER_ID, CHANNEL_MAPPING_ID)).rejects.toThrow(
+        "connection_error",
+      )
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // approve
+  // -----------------------------------------------------------------------
+  describe("approve", () => {
+    it("approves a pending request and creates a grant", async () => {
+      const selectChain = mockSelectChain(makeRequestRow())
+      const updateChain = mockUpdateChain()
+      const insertChain = mockInsertChain(makeGrantRow())
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(selectChain),
+        updateTable: vi.fn().mockReturnValue(updateChain),
+        insertInto: vi.fn().mockReturnValue(insertChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      const grant = await svc.approve(REQUEST_ID, REVIEWER_ID)
+
+      expect(grant).toEqual(makeGrantRow())
+      expect(db.updateTable).toHaveBeenCalledWith("access_request")
+      expect(db.insertInto).toHaveBeenCalledWith("agent_user_grant")
+
+      const setArg = updateChain.set.mock.calls[0]?.[0] as Record<string, unknown>
+      expect(setArg.status).toBe("approved")
+      expect(setArg.reviewed_by).toBe(REVIEWER_ID)
+      expect(setArg.reviewed_at).toBeInstanceOf(Date)
+    })
+
+    it("creates grant with origin 'approval'", async () => {
+      const selectChain = mockSelectChain(makeRequestRow())
+      const updateChain = mockUpdateChain()
+      const insertChain = mockInsertChain(makeGrantRow())
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(selectChain),
+        updateTable: vi.fn().mockReturnValue(updateChain),
+        insertInto: vi.fn().mockReturnValue(insertChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      await svc.approve(REQUEST_ID, REVIEWER_ID)
+
+      const insertedValues = insertChain.values.mock.calls[0]?.[0] as Record<string, unknown>
+      expect(insertedValues.origin).toBe("approval")
+      expect(insertedValues.granted_by).toBe(REVIEWER_ID)
+    })
+
+    it("throws 409 for non-pending request", async () => {
+      const selectChain = mockSelectChain(makeRequestRow({ status: "approved" }))
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(selectChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      await expect(svc.approve(REQUEST_ID, REVIEWER_ID)).rejects.toThrow(AccessRequestConflictError)
+      await expect(svc.approve(REQUEST_ID, REVIEWER_ID)).rejects.toThrow(
+        "Cannot approve request with status 'approved'",
+      )
+    })
+
+    it("throws 409 when request not found", async () => {
+      const selectChain = mockSelectChain(undefined)
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(selectChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      await expect(svc.approve(REQUEST_ID, REVIEWER_ID)).rejects.toThrow(AccessRequestConflictError)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // deny
+  // -----------------------------------------------------------------------
+  describe("deny", () => {
+    it("denies a pending request", async () => {
+      const selectChain = mockSelectChain(makeRequestRow())
+      const updateChain = mockUpdateChain()
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(selectChain),
+        updateTable: vi.fn().mockReturnValue(updateChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      await svc.deny(REQUEST_ID, REVIEWER_ID, "Not authorized")
+
+      expect(db.updateTable).toHaveBeenCalledWith("access_request")
+
+      const setArg = updateChain.set.mock.calls[0]?.[0] as Record<string, unknown>
+      expect(setArg.status).toBe("denied")
+      expect(setArg.reviewed_by).toBe(REVIEWER_ID)
+      expect(setArg.reviewed_at).toBeInstanceOf(Date)
+      expect(setArg.deny_reason).toBe("Not authorized")
+    })
+
+    it("sets deny_reason to null when no reason given", async () => {
+      const selectChain = mockSelectChain(makeRequestRow())
+      const updateChain = mockUpdateChain()
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(selectChain),
+        updateTable: vi.fn().mockReturnValue(updateChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      await svc.deny(REQUEST_ID, REVIEWER_ID)
+
+      const setArg = updateChain.set.mock.calls[0]?.[0] as Record<string, unknown>
+      expect(setArg.deny_reason).toBeNull()
+    })
+
+    it("throws 409 for non-pending request", async () => {
+      const selectChain = mockSelectChain(makeRequestRow({ status: "denied" }))
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(selectChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      await expect(svc.deny(REQUEST_ID, REVIEWER_ID)).rejects.toThrow(AccessRequestConflictError)
+    })
+
+    it("throws 409 when request not found", async () => {
+      const selectChain = mockSelectChain(undefined)
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(selectChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      await expect(svc.deny(REQUEST_ID, REVIEWER_ID)).rejects.toThrow("Access request not found")
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // listPending
+  // -----------------------------------------------------------------------
+  describe("listPending", () => {
+    it("returns pending requests with total count", async () => {
+      const requests = [makeRequestRow(), makeRequestRow({ id: "other-id" })]
+      // baseQuery is one selectFrom call — both branches share the chain.
+      // execute() returns request rows; executeTakeFirstOrThrow() returns count.
+      const chain = mockSelectChain(requests)
+      chain.executeTakeFirstOrThrow.mockResolvedValue({ total: "2" })
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(chain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      const result = await svc.listPending(AGENT_ID)
+
+      expect(result.requests).toHaveLength(2)
+      expect(result.total).toBe(2)
+    })
+
+    it("uses default pagination values", async () => {
+      const chain = mockSelectChain([])
+      chain.executeTakeFirstOrThrow.mockResolvedValue({ total: "0" })
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(chain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      const result = await svc.listPending(AGENT_ID)
+
+      expect(result.requests).toEqual([])
+      expect(result.total).toBe(0)
+      expect(chain.limit).toHaveBeenCalledWith(20)
+      expect(chain.offset).toHaveBeenCalledWith(0)
+    })
+
+    it("respects custom pagination", async () => {
+      const chain = mockSelectChain([makeRequestRow()])
+      chain.executeTakeFirstOrThrow.mockResolvedValue({ total: "5" })
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(chain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      const result = await svc.listPending(AGENT_ID, { limit: 10, offset: 2 })
+
+      expect(result.requests).toHaveLength(1)
+      expect(result.total).toBe(5)
+      expect(chain.limit).toHaveBeenCalledWith(10)
+      expect(chain.offset).toHaveBeenCalledWith(2)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // pendingCounts
+  // -----------------------------------------------------------------------
+  describe("pendingCounts", () => {
+    it("returns per-agent counts", async () => {
+      const rows = [
+        { agent_id: AGENT_ID, cnt: "3" },
+        { agent_id: AGENT_ID_2, cnt: "1" },
+      ]
+      const selectChain = mockSelectChain(rows)
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(selectChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      const result = await svc.pendingCounts()
+
+      expect(result).toBeInstanceOf(Map)
+      expect(result.get(AGENT_ID)).toBe(3)
+      expect(result.get(AGENT_ID_2)).toBe(1)
+    })
+
+    it("returns empty map when no pending requests", async () => {
+      const selectChain = mockSelectChain([])
+      const db = {
+        selectFrom: vi.fn().mockReturnValue(selectChain),
+      } as unknown as Kysely<Database>
+
+      const svc = new AccessRequestService(db)
+      const result = await svc.pendingCounts()
+
+      expect(result).toBeInstanceOf(Map)
+      expect(result.size).toBe(0)
+    })
+  })
+})

--- a/packages/control-plane/src/auth/access-request-service.ts
+++ b/packages/control-plane/src/auth/access-request-service.ts
@@ -1,0 +1,181 @@
+import type { Kysely } from "kysely"
+
+import type { AccessRequest, AgentUserGrant, Database } from "../db/types.js"
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+export class AccessRequestConflictError extends Error {
+  readonly statusCode = 409
+
+  constructor(message: string) {
+    super(message)
+    this.name = "AccessRequestConflictError"
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isUniqueViolation(err: unknown): boolean {
+  return (err as { code?: string }).code === "23505"
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class AccessRequestService {
+  constructor(private readonly db: Kysely<Database>) {}
+
+  /**
+   * Create a pending access request.
+   * If a pending request already exists for the same agent+user, returns it
+   * (idempotent).
+   */
+  async create(
+    agentId: string,
+    userAccountId: string,
+    channelMappingId: string,
+    messagePreview?: string,
+  ): Promise<AccessRequest> {
+    try {
+      return await this.db
+        .insertInto("access_request")
+        .values({
+          agent_id: agentId,
+          user_account_id: userAccountId,
+          channel_mapping_id: channelMappingId,
+          message_preview: messagePreview ?? null,
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+    } catch (err: unknown) {
+      if (!isUniqueViolation(err)) throw err
+
+      // Return the existing pending request (idempotent)
+      const existing = await this.db
+        .selectFrom("access_request")
+        .selectAll()
+        .where("agent_id", "=", agentId)
+        .where("user_account_id", "=", userAccountId)
+        .where("status", "=", "pending")
+        .executeTakeFirst()
+
+      if (existing) return existing
+      throw err
+    }
+  }
+
+  /**
+   * Approve a pending request — creates an agent_user_grant with
+   * origin = 'approval'.
+   */
+  async approve(requestId: string, reviewedBy: string): Promise<AgentUserGrant> {
+    const request = await this.db
+      .selectFrom("access_request")
+      .selectAll()
+      .where("id", "=", requestId)
+      .executeTakeFirst()
+
+    if (!request) throw new AccessRequestConflictError("Access request not found")
+    if (request.status !== "pending") {
+      throw new AccessRequestConflictError(`Cannot approve request with status '${request.status}'`)
+    }
+
+    await this.db
+      .updateTable("access_request")
+      .set({
+        status: "approved",
+        reviewed_by: reviewedBy,
+        reviewed_at: new Date(),
+      })
+      .where("id", "=", requestId)
+      .where("status", "=", "pending")
+      .execute()
+
+    const grant = await this.db
+      .insertInto("agent_user_grant")
+      .values({
+        agent_id: request.agent_id,
+        user_account_id: request.user_account_id,
+        origin: "approval",
+        granted_by: reviewedBy,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    return grant
+  }
+
+  /**
+   * Deny a pending request.
+   */
+  async deny(requestId: string, reviewedBy: string, reason?: string): Promise<void> {
+    const request = await this.db
+      .selectFrom("access_request")
+      .selectAll()
+      .where("id", "=", requestId)
+      .executeTakeFirst()
+
+    if (!request) throw new AccessRequestConflictError("Access request not found")
+    if (request.status !== "pending") {
+      throw new AccessRequestConflictError(`Cannot deny request with status '${request.status}'`)
+    }
+
+    await this.db
+      .updateTable("access_request")
+      .set({
+        status: "denied",
+        reviewed_by: reviewedBy,
+        reviewed_at: new Date(),
+        deny_reason: reason ?? null,
+      })
+      .where("id", "=", requestId)
+      .where("status", "=", "pending")
+      .execute()
+  }
+
+  /**
+   * List pending requests for a given agent with pagination.
+   */
+  async listPending(
+    agentId: string,
+    pagination: { limit?: number; offset?: number } = {},
+  ): Promise<{ requests: AccessRequest[]; total: number }> {
+    const { limit = 20, offset = 0 } = pagination
+
+    const baseQuery = this.db
+      .selectFrom("access_request")
+      .where("agent_id", "=", agentId)
+      .where("status", "=", "pending")
+
+    const [requests, countResult] = await Promise.all([
+      baseQuery.selectAll().orderBy("created_at", "desc").limit(limit).offset(offset).execute(),
+      baseQuery.select((eb) => eb.fn.countAll<string>().as("total")).executeTakeFirstOrThrow(),
+    ])
+
+    return { requests, total: Number(countResult.total) }
+  }
+
+  /**
+   * Return per-agent pending-request counts.
+   */
+  async pendingCounts(): Promise<Map<string, number>> {
+    const rows = await this.db
+      .selectFrom("access_request")
+      .select(["agent_id"])
+      .select((eb) => eb.fn.countAll<string>().as("cnt"))
+      .where("status", "=", "pending")
+      .groupBy("agent_id")
+      .execute()
+
+    const map = new Map<string, number>()
+    for (const row of rows) {
+      map.set(row.agent_id, Number(row.cnt))
+    }
+    return map
+  }
+}

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -694,6 +694,31 @@ export type NewAgentUserGrant = Insertable<AgentUserGrantTable>
 export type AgentUserGrantUpdate = Updateable<AgentUserGrantTable>
 
 // ---------------------------------------------------------------------------
+// Enum: access_request_status
+// ---------------------------------------------------------------------------
+export type AccessRequestStatus = "pending" | "approved" | "denied"
+
+// ---------------------------------------------------------------------------
+// Table: access_request
+// ---------------------------------------------------------------------------
+export interface AccessRequestTable {
+  id: Generated<string>
+  agent_id: string
+  channel_mapping_id: string
+  user_account_id: string
+  status: ColumnType<AccessRequestStatus, AccessRequestStatus | undefined, AccessRequestStatus>
+  message_preview: string | null
+  reviewed_by: string | null
+  reviewed_at: ColumnType<Date | null, Date | null | undefined, Date | null>
+  deny_reason: string | null
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
+export type AccessRequest = Selectable<AccessRequestTable>
+export type NewAccessRequest = Insertable<AccessRequestTable>
+export type AccessRequestUpdate = Updateable<AccessRequestTable>
+
+// ---------------------------------------------------------------------------
 // Table: agent_event
 // ---------------------------------------------------------------------------
 export interface AgentEventTable {
@@ -744,4 +769,5 @@ export interface Database {
   agent_event: AgentEventTable
   pairing_code: PairingCodeTable
   agent_user_grant: AgentUserGrantTable
+  access_request: AccessRequestTable
 }


### PR DESCRIPTION
## Summary

- Adds `AccessRequestService` with `create`, `approve`, `deny`, `listPending`, and `pendingCounts` methods
- Migration 023 creates the `access_request` table with `access_request_status` enum and partial index on pending requests
- Idempotent `create` — duplicate pending request for same agent+user returns existing row
- `approve` creates `agent_user_grant` with `origin = 'approval'`; `deny` records reason
- 409 conflict error on approve/deny of non-pending requests
- 17 unit tests covering all acceptance criteria

Closes #337

## Test plan

- [x] `npx vitest run` — 1166 tests pass (70 files)
- [x] `npx eslint` — clean on changed files
- [x] `npm run typecheck` — clean
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an access request workflow system allowing users to request and manage access approvals.
  * Introduced status tracking for requests (pending, approved, denied) with audit information.
  * Added functionality to list pending requests and view per-agent request counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->