### PR TITLE
feat(routes): agent tool binding CRUD + effective tools (#305)

### DIFF
--- a/packages/control-plane/src/__tests__/agent-tool-binding-routes.test.ts
+++ b/packages/control-plane/src/__tests__/agent-tool-binding-routes.test.ts
@@ -1,0 +1,595 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+import Fastify from "fastify"
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import type { Database } from "../db/types.js"
+import type { AuthConfig } from "../middleware/types.js"
+import { agentToolBindingRoutes } from "../routes/agent-tool-bindings.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEV_AUTH_CONFIG: AuthConfig = {
+  requireAuth: false,
+  apiKeys: [],
+}
+
+const AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+const BINDING_ID = "bbbbbbbb-1111-2222-3333-444444444444"
+const SERVER_ID = "ssssssss-1111-2222-3333-444444444444"
+
+function makeBinding(overrides: Record<string, unknown> = {}) {
+  return {
+    id: BINDING_ID,
+    agent_id: AGENT_ID,
+    tool_ref: "mcp:slack:chat_postMessage",
+    approval_policy: "auto",
+    approval_condition: null,
+    rate_limit: null,
+    cost_budget: null,
+    data_scope: null,
+    enabled: true,
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  }
+}
+
+function makeAuditEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "eeeeeeee-1111-2222-3333-444444444444",
+    agent_id: AGENT_ID,
+    tool_ref: "mcp:slack:chat_postMessage",
+    event_type: "binding_created",
+    actor_user_id: "dev-user",
+    job_id: null,
+    details: {},
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  }
+}
+
+/**
+ * Build a mock Kysely database that supports the query patterns used by
+ * agentToolBindingRoutes.
+ */
+function mockDb(
+  opts: {
+    agentExists?: boolean
+    existingBinding?: Record<string, unknown> | null
+    insertedBinding?: Record<string, unknown>
+    updatedBinding?: Record<string, unknown> | null
+    bindings?: Record<string, unknown>[]
+    bindingForDelete?: Record<string, unknown> | null
+    serverExists?: boolean
+    serverTools?: { qualified_name: string }[]
+    bulkInserted?: Record<string, unknown>[]
+    auditEntries?: Record<string, unknown>[]
+    totalCount?: number
+  } = {},
+) {
+  const {
+    agentExists = true,
+    existingBinding = null,
+    insertedBinding = makeBinding(),
+    updatedBinding = makeBinding(),
+    bindings = [makeBinding()],
+    bindingForDelete = null as Record<string, unknown> | null,
+    serverExists = true,
+    serverTools = [{ qualified_name: "mcp:slack:chat_postMessage" }],
+    bulkInserted = [makeBinding()],
+    auditEntries = [makeAuditEntry()],
+    totalCount = 1,
+  } = opts
+
+  const auditInsertValues = vi.fn().mockReturnValue({
+    execute: vi.fn().mockResolvedValue([]),
+  })
+
+  const deleteExecute = vi.fn().mockResolvedValue([])
+
+  const db = {
+    selectFrom: vi.fn().mockImplementation((table: string) => {
+      if (table === "agent") {
+        const row = agentExists ? { id: AGENT_ID } : null
+        return {
+          select: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              executeTakeFirst: vi.fn().mockResolvedValue(row),
+            }),
+          }),
+        }
+      }
+
+      if (table === "agent_tool_binding") {
+        // Universal chainable node — every method returns itself so
+        // any Kysely chain pattern (select/selectAll/where/orderBy/
+        // limit/offset/execute/executeTakeFirst/executeTakeFirstOrThrow)
+        // works without needing exact call-order matching.
+        const listExecute = vi.fn().mockResolvedValue(bindings)
+
+        const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+        const self = () => chain
+        chain.where = vi.fn().mockImplementation(self)
+        chain.orderBy = vi.fn().mockImplementation(self)
+        chain.limit = vi.fn().mockImplementation(self)
+        chain.offset = vi.fn().mockImplementation(self)
+        chain.execute = listExecute
+        chain.executeTakeFirst = vi.fn().mockResolvedValue(existingBinding ?? bindingForDelete)
+        chain.executeTakeFirstOrThrow = vi.fn().mockResolvedValue({ total: totalCount })
+
+        return {
+          select: vi.fn().mockReturnValue(chain),
+          selectAll: vi.fn().mockReturnValue(chain),
+        }
+      }
+
+      if (table === "mcp_server") {
+        const row = serverExists ? { id: SERVER_ID } : null
+        return {
+          select: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              executeTakeFirst: vi.fn().mockResolvedValue(row),
+            }),
+          }),
+        }
+      }
+
+      if (table === "mcp_server_tool") {
+        return {
+          select: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              execute: vi.fn().mockResolvedValue(serverTools),
+            }),
+          }),
+        }
+      }
+
+      if (table === "capability_audit_log") {
+        const auditExecute = vi.fn().mockResolvedValue(auditEntries)
+        const auditOffset = vi.fn().mockReturnValue({ execute: auditExecute })
+        const auditLimit = vi.fn().mockReturnValue({ offset: auditOffset })
+        const auditOrderBy = vi.fn().mockReturnValue({ limit: auditLimit })
+
+        const auditWhere: ReturnType<typeof vi.fn> = vi.fn()
+        auditWhere.mockReturnValue({
+          where: auditWhere,
+          orderBy: auditOrderBy,
+          executeTakeFirstOrThrow: vi.fn().mockResolvedValue({ total: totalCount }),
+        })
+        const auditSelectAll = vi.fn().mockReturnValue({ where: auditWhere })
+
+        const auditCountWhere: ReturnType<typeof vi.fn> = vi.fn()
+        auditCountWhere.mockReturnValue({
+          where: auditCountWhere,
+          executeTakeFirstOrThrow: vi.fn().mockResolvedValue({ total: totalCount }),
+        })
+
+        return {
+          selectAll: auditSelectAll,
+          select: vi.fn().mockReturnValue({ where: auditCountWhere }),
+        }
+      }
+
+      // Fallback
+      return {
+        select: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            executeTakeFirst: vi.fn().mockResolvedValue(null),
+          }),
+        }),
+      }
+    }),
+
+    insertInto: vi.fn().mockImplementation((table: string) => {
+      if (table === "agent_tool_binding") {
+        return {
+          values: vi.fn().mockReturnValue({
+            returningAll: vi.fn().mockReturnValue({
+              executeTakeFirstOrThrow: vi.fn().mockResolvedValue(insertedBinding),
+            }),
+            onConflict: vi.fn().mockReturnValue({
+              returningAll: vi.fn().mockReturnValue({
+                execute: vi.fn().mockResolvedValue(bulkInserted),
+              }),
+            }),
+          }),
+        }
+      }
+
+      if (table === "capability_audit_log") {
+        return { values: auditInsertValues }
+      }
+
+      return {
+        values: vi.fn().mockReturnValue({
+          execute: vi.fn().mockResolvedValue([]),
+        }),
+      }
+    }),
+
+    updateTable: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returningAll: vi.fn().mockReturnValue({
+              executeTakeFirst: vi.fn().mockResolvedValue(updatedBinding),
+            }),
+          }),
+        }),
+      }),
+    }),
+
+    deleteFrom: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          execute: deleteExecute,
+        }),
+      }),
+    }),
+
+    fn: {
+      countAll: vi.fn().mockReturnValue({
+        as: vi.fn().mockReturnValue("count_expr"),
+      }),
+    },
+  } as unknown as Kysely<Database>
+
+  return { db, auditInsertValues, deleteExecute }
+}
+
+async function buildTestApp(dbOpts: Parameters<typeof mockDb>[0] = {}) {
+  const app = Fastify({ logger: false })
+  const { db, auditInsertValues, deleteExecute } = mockDb(dbOpts)
+
+  await app.register(agentToolBindingRoutes({ db, authConfig: DEV_AUTH_CONFIG }))
+
+  return { app, db, auditInsertValues, deleteExecute }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/tool-bindings
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/tool-bindings", () => {
+  it("creates a tool binding", async () => {
+    const { app, auditInsertValues } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+      payload: {
+        toolRef: "mcp:slack:chat_postMessage",
+        approvalPolicy: "auto",
+      },
+    })
+
+    expect(res.statusCode).toBe(201)
+    const body = res.json()
+    expect(body.id).toBe(BINDING_ID)
+    expect(body.agentId).toBe(AGENT_ID)
+    expect(body.toolRef).toBe("mcp:slack:chat_postMessage")
+    expect(body.approvalPolicy).toBe("auto")
+
+    // Verify audit log was written
+    expect(auditInsertValues).toHaveBeenCalled()
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const { app } = await buildTestApp({ agentExists: false })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+      payload: { toolRef: "web_search" },
+    })
+
+    expect(res.statusCode).toBe(404)
+    const body = res.json()
+    expect(body.message).toContain("Agent")
+  })
+
+  it("returns 409 on duplicate (agentId, toolRef)", async () => {
+    const { app } = await buildTestApp({
+      existingBinding: makeBinding(),
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+      payload: { toolRef: "mcp:slack:chat_postMessage" },
+    })
+
+    expect(res.statusCode).toBe(409)
+    const body = res.json()
+    expect(body.message).toContain("already exists")
+  })
+
+  it("validates required toolRef field", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+
+  it("accepts optional rateLimit and dataScope", async () => {
+    const binding = makeBinding({
+      rate_limit: { maxCalls: 100, windowSeconds: 3600 },
+      data_scope: { channels: ["#general"] },
+    })
+    const { app } = await buildTestApp({ insertedBinding: binding })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+      payload: {
+        toolRef: "mcp:slack:chat_postMessage",
+        rateLimit: { maxCalls: 100, windowSeconds: 3600 },
+        dataScope: { channels: ["#general"] },
+      },
+    })
+
+    expect(res.statusCode).toBe(201)
+    const body = res.json()
+    expect(body.rateLimit).toEqual({ maxCalls: 100, windowSeconds: 3600 })
+    expect(body.dataScope).toEqual({ channels: ["#general"] })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: GET /agents/:agentId/tool-bindings
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/:agentId/tool-bindings", () => {
+  it("returns list of bindings", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.bindings).toBeDefined()
+    expect(Array.isArray(body.bindings)).toBe(true)
+    expect(typeof body.total).toBe("number")
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const { app } = await buildTestApp({ agentExists: false })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/tool-bindings`,
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: PUT /agents/:agentId/tool-bindings/:bindingId
+// ---------------------------------------------------------------------------
+
+describe("PUT /agents/:agentId/tool-bindings/:bindingId", () => {
+  it("updates a binding", async () => {
+    const updated = makeBinding({
+      approval_policy: "always_approve",
+      enabled: false,
+    })
+    const { app } = await buildTestApp({ updatedBinding: updated })
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/agents/${AGENT_ID}/tool-bindings/${BINDING_ID}`,
+      payload: {
+        approvalPolicy: "always_approve",
+        enabled: false,
+      },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.approvalPolicy).toBe("always_approve")
+    expect(body.enabled).toBe(false)
+  })
+
+  it("returns 404 when binding does not exist", async () => {
+    const { app } = await buildTestApp({ updatedBinding: null })
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/agents/${AGENT_ID}/tool-bindings/${BINDING_ID}`,
+      payload: { enabled: false },
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+
+  it("returns 400 when no fields provided", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/agents/${AGENT_ID}/tool-bindings/${BINDING_ID}`,
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+    const body = res.json()
+    expect(body.message).toContain("No fields")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: DELETE /agents/:agentId/tool-bindings/:bindingId
+// ---------------------------------------------------------------------------
+
+describe("DELETE /agents/:agentId/tool-bindings/:bindingId", () => {
+  it("removes a binding and writes audit log", async () => {
+    const { app, auditInsertValues } = await buildTestApp({
+      bindingForDelete: makeBinding(),
+    })
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/agents/${AGENT_ID}/tool-bindings/${BINDING_ID}`,
+    })
+
+    expect(res.statusCode).toBe(204)
+    expect(auditInsertValues).toHaveBeenCalled()
+  })
+
+  it("returns 404 when binding does not exist", async () => {
+    const { app } = await buildTestApp({ bindingForDelete: null })
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/agents/${AGENT_ID}/tool-bindings/${BINDING_ID}`,
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/tool-bindings/bulk
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/tool-bindings/bulk", () => {
+  it("bulk-creates bindings from MCP server", async () => {
+    const { app, auditInsertValues } = await buildTestApp({
+      bulkInserted: [makeBinding()],
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings/bulk`,
+      payload: {
+        mcpServerId: SERVER_ID,
+        approvalPolicy: "auto",
+      },
+    })
+
+    expect(res.statusCode).toBe(201)
+    const body = res.json()
+    expect(body.created).toBe(1)
+    expect(body.bindings).toHaveLength(1)
+    expect(auditInsertValues).toHaveBeenCalled()
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const { app } = await buildTestApp({ agentExists: false })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings/bulk`,
+      payload: { mcpServerId: SERVER_ID },
+    })
+
+    expect(res.statusCode).toBe(404)
+    const body = res.json()
+    expect(body.message).toContain("Agent")
+  })
+
+  it("returns 404 when MCP server does not exist", async () => {
+    const { app } = await buildTestApp({ serverExists: false })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings/bulk`,
+      payload: { mcpServerId: SERVER_ID },
+    })
+
+    expect(res.statusCode).toBe(404)
+    const body = res.json()
+    expect(body.message).toContain("MCP server")
+  })
+
+  it("accepts explicit toolRefs list", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/tool-bindings/bulk`,
+      payload: {
+        mcpServerId: SERVER_ID,
+        toolRefs: ["mcp:slack:chat_postMessage"],
+      },
+    })
+
+    expect(res.statusCode).toBe(201)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: GET /agents/:agentId/effective-tools
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/:agentId/effective-tools", () => {
+  it("returns effective tools for an agent", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/effective-tools`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.tools).toBeDefined()
+    expect(Array.isArray(body.tools)).toBe(true)
+    expect(body.assembledAt).toBeDefined()
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const { app } = await buildTestApp({ agentExists: false })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/effective-tools`,
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: GET /agents/:agentId/capability-audit
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/:agentId/capability-audit", () => {
+  it("returns audit log entries", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/capability-audit`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.entries).toBeDefined()
+    expect(Array.isArray(body.entries)).toBe(true)
+    expect(typeof body.total).toBe("number")
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const { app } = await buildTestApp({ agentExists: false })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/capability-audit`,
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+})

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -29,6 +29,7 @@ import { BrowserObservationService } from "./observation/service.js"
 import { agentChannelRoutes } from "./routes/agent-channels.js"
 import { agentControlRoutes } from "./routes/agent-control.js"
 import { agentCredentialRoutes } from "./routes/agent-credentials.js"
+import { agentToolBindingRoutes } from "./routes/agent-tool-bindings.js"
 import { agentRoutes } from "./routes/agents.js"
 import { approvalRoutes } from "./routes/approval.js"
 import { authRoutes } from "./routes/auth.js"
@@ -218,6 +219,15 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
   // Register agent credential binding routes
   await app.register(
     agentCredentialRoutes({
+      db,
+      authConfig,
+      sessionService,
+    }),
+  )
+
+  // Register agent tool binding routes
+  await app.register(
+    agentToolBindingRoutes({
       db,
       authConfig,
       sessionService,

--- a/packages/control-plane/src/routes/agent-tool-bindings.ts
+++ b/packages/control-plane/src/routes/agent-tool-bindings.ts
@@ -1,0 +1,738 @@
+/**
+ * Agent Tool Binding Routes
+ *
+ * Endpoints for managing tool bindings on agents:
+ *   POST   /agents/:agentId/tool-bindings              — create a tool binding
+ *   GET    /agents/:agentId/tool-bindings              — list bindings (optional filters)
+ *   PUT    /agents/:agentId/tool-bindings/:bindingId   — update a binding
+ *   DELETE /agents/:agentId/tool-bindings/:bindingId   — remove a binding
+ *   POST   /agents/:agentId/tool-bindings/bulk         — bulk-create from MCP server
+ *   GET    /agents/:agentId/effective-tools             — computed effective tool set
+ *   GET    /agents/:agentId/capability-audit            — query capability audit log
+ */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
+import type { Kysely } from "kysely"
+
+import type { SessionService } from "../auth/session-service.js"
+import type { Database, ToolApprovalPolicy } from "../db/types.js"
+import { createRequireAuth, createRequireRole, type PreHandler } from "../middleware/auth.js"
+import type { AuthConfig, AuthenticatedRequest } from "../middleware/types.js"
+
+// ============================================================================
+// Route types
+// ============================================================================
+
+interface AgentParams {
+  agentId: string
+}
+
+interface BindingParams {
+  agentId: string
+  bindingId: string
+}
+
+interface CreateBindingBody {
+  toolRef: string
+  approvalPolicy?: ToolApprovalPolicy
+  approvalCondition?: Record<string, unknown> | null
+  rateLimit?: Record<string, unknown> | null
+  costBudget?: Record<string, unknown> | null
+  dataScope?: Record<string, unknown> | null
+}
+
+interface UpdateBindingBody {
+  approvalPolicy?: ToolApprovalPolicy
+  approvalCondition?: Record<string, unknown> | null
+  rateLimit?: Record<string, unknown> | null
+  costBudget?: Record<string, unknown> | null
+  dataScope?: Record<string, unknown> | null
+  enabled?: boolean
+}
+
+interface ListBindingsQuery {
+  enabled?: boolean
+  category?: string
+  limit?: number
+  offset?: number
+}
+
+interface BulkBindBody {
+  mcpServerId: string
+  toolRefs?: string[]
+  approvalPolicy?: ToolApprovalPolicy
+}
+
+interface AuditQuery {
+  toolRef?: string
+  eventType?: string
+  limit?: number
+  offset?: number
+}
+
+// ============================================================================
+// Plugin interface & factory
+// ============================================================================
+
+export interface AgentToolBindingRouteDeps {
+  db: Kysely<Database>
+  authConfig: AuthConfig
+  sessionService?: SessionService
+}
+
+export function agentToolBindingRoutes(deps: AgentToolBindingRouteDeps) {
+  const { db, authConfig, sessionService } = deps
+
+  const requireAuth: PreHandler = createRequireAuth({
+    config: authConfig,
+    sessionService,
+  })
+  const requireOperator: PreHandler = createRequireRole("operator")
+
+  return function register(app: FastifyInstance): void {
+    // ------------------------------------------------------------------
+    // POST /agents/:agentId/tool-bindings — create a tool binding
+    // ------------------------------------------------------------------
+    app.post<{ Params: AgentParams; Body: CreateBindingBody }>(
+      "/agents/:agentId/tool-bindings",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string", minLength: 1 },
+            },
+            required: ["agentId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              toolRef: { type: "string", minLength: 1 },
+              approvalPolicy: {
+                type: "string",
+                enum: ["auto", "always_approve", "conditional"],
+              },
+              approvalCondition: { type: ["object", "null"] },
+              rateLimit: { type: ["object", "null"] },
+              costBudget: { type: ["object", "null"] },
+              dataScope: { type: ["object", "null"] },
+            },
+            required: ["toolRef"],
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: AgentParams; Body: CreateBindingBody }>,
+        reply: FastifyReply,
+      ) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          return reply.status(401).send({ error: "unauthorized" })
+        }
+
+        const { agentId } = request.params
+        const body = request.body
+
+        // Verify agent exists
+        const agent = await db
+          .selectFrom("agent")
+          .select("id")
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          return reply.status(404).send({ error: "not_found", message: "Agent not found" })
+        }
+
+        // Check for duplicate (agentId, toolRef)
+        const existing = await db
+          .selectFrom("agent_tool_binding")
+          .select("id")
+          .where("agent_id", "=", agentId)
+          .where("tool_ref", "=", body.toolRef)
+          .executeTakeFirst()
+
+        if (existing) {
+          return reply.status(409).send({
+            error: "conflict",
+            message: `Tool binding for '${body.toolRef}' already exists on this agent`,
+          })
+        }
+
+        // Create the binding
+        const binding = await db
+          .insertInto("agent_tool_binding")
+          .values({
+            agent_id: agentId,
+            tool_ref: body.toolRef,
+            approval_policy: body.approvalPolicy ?? "auto",
+            approval_condition: body.approvalCondition ?? null,
+            rate_limit: body.rateLimit ?? null,
+            cost_budget: body.costBudget ?? null,
+            data_scope: body.dataScope ?? null,
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow()
+
+        // Audit log
+        await db
+          .insertInto("capability_audit_log")
+          .values({
+            agent_id: agentId,
+            tool_ref: body.toolRef,
+            event_type: "binding_created",
+            actor_user_id: principal.userId,
+            details: { binding_id: binding.id },
+          })
+          .execute()
+
+        return reply.status(201).send({
+          id: binding.id,
+          agentId: binding.agent_id,
+          toolRef: binding.tool_ref,
+          approvalPolicy: binding.approval_policy,
+          approvalCondition: binding.approval_condition,
+          rateLimit: binding.rate_limit,
+          costBudget: binding.cost_budget,
+          dataScope: binding.data_scope,
+          enabled: binding.enabled,
+          createdAt: binding.created_at,
+          updatedAt: binding.updated_at,
+        })
+      },
+    )
+
+    // ------------------------------------------------------------------
+    // GET /agents/:agentId/tool-bindings — list bindings
+    // ------------------------------------------------------------------
+    app.get<{ Params: AgentParams; Querystring: ListBindingsQuery }>(
+      "/agents/:agentId/tool-bindings",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string", minLength: 1 },
+            },
+            required: ["agentId"],
+          },
+          querystring: {
+            type: "object",
+            properties: {
+              enabled: { type: "boolean" },
+              category: { type: "string" },
+              limit: { type: "number", minimum: 1, maximum: 100 },
+              offset: { type: "number", minimum: 0 },
+            },
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: AgentParams; Querystring: ListBindingsQuery }>,
+        reply: FastifyReply,
+      ) => {
+        const { agentId } = request.params
+        const { enabled, category, limit = 50, offset = 0 } = request.query
+
+        // Verify agent exists
+        const agent = await db
+          .selectFrom("agent")
+          .select("id")
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          return reply.status(404).send({ error: "not_found", message: "Agent not found" })
+        }
+
+        let query = db.selectFrom("agent_tool_binding").selectAll().where("agent_id", "=", agentId)
+        let countQuery = db
+          .selectFrom("agent_tool_binding")
+          .select(db.fn.countAll<number>().as("total"))
+          .where("agent_id", "=", agentId)
+
+        if (enabled !== undefined) {
+          query = query.where("enabled", "=", enabled)
+          countQuery = countQuery.where("enabled", "=", enabled)
+        }
+
+        if (category) {
+          // Filter by tool_category_membership join
+          query = query.where(
+            "tool_ref",
+            "in",
+            db
+              .selectFrom("tool_category_membership")
+              .select("tool_ref")
+              .innerJoin(
+                "tool_category",
+                "tool_category.id",
+                "tool_category_membership.category_id",
+              )
+              .where("tool_category.name", "=", category),
+          )
+          countQuery = countQuery.where(
+            "tool_ref",
+            "in",
+            db
+              .selectFrom("tool_category_membership")
+              .select("tool_ref")
+              .innerJoin(
+                "tool_category",
+                "tool_category.id",
+                "tool_category_membership.category_id",
+              )
+              .where("tool_category.name", "=", category),
+          )
+        }
+
+        const [bindings, countResult] = await Promise.all([
+          query.orderBy("created_at", "desc").limit(limit).offset(offset).execute(),
+          countQuery.executeTakeFirstOrThrow(),
+        ])
+
+        const total = Number(countResult.total)
+
+        return reply.status(200).send({
+          bindings: bindings.map((b) => ({
+            id: b.id,
+            agentId: b.agent_id,
+            toolRef: b.tool_ref,
+            approvalPolicy: b.approval_policy,
+            approvalCondition: b.approval_condition,
+            rateLimit: b.rate_limit,
+            costBudget: b.cost_budget,
+            dataScope: b.data_scope,
+            enabled: b.enabled,
+            createdAt: b.created_at,
+            updatedAt: b.updated_at,
+          })),
+          total,
+        })
+      },
+    )
+
+    // ------------------------------------------------------------------
+    // PUT /agents/:agentId/tool-bindings/:bindingId — update a binding
+    // ------------------------------------------------------------------
+    app.put<{ Params: BindingParams; Body: UpdateBindingBody }>(
+      "/agents/:agentId/tool-bindings/:bindingId",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string", minLength: 1 },
+              bindingId: { type: "string", minLength: 1 },
+            },
+            required: ["agentId", "bindingId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              approvalPolicy: {
+                type: "string",
+                enum: ["auto", "always_approve", "conditional"],
+              },
+              approvalCondition: { type: ["object", "null"] },
+              rateLimit: { type: ["object", "null"] },
+              costBudget: { type: ["object", "null"] },
+              dataScope: { type: ["object", "null"] },
+              enabled: { type: "boolean" },
+            },
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: BindingParams; Body: UpdateBindingBody }>,
+        reply: FastifyReply,
+      ) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          return reply.status(401).send({ error: "unauthorized" })
+        }
+
+        const { agentId, bindingId } = request.params
+        const body = request.body
+
+        // Build the update set — only include provided fields
+        const updates: Record<string, unknown> = {}
+        if (body.approvalPolicy !== undefined) updates.approval_policy = body.approvalPolicy
+        if (body.approvalCondition !== undefined)
+          updates.approval_condition = body.approvalCondition
+        if (body.rateLimit !== undefined) updates.rate_limit = body.rateLimit
+        if (body.costBudget !== undefined) updates.cost_budget = body.costBudget
+        if (body.dataScope !== undefined) updates.data_scope = body.dataScope
+        if (body.enabled !== undefined) updates.enabled = body.enabled
+
+        if (Object.keys(updates).length === 0) {
+          return reply.status(400).send({
+            error: "bad_request",
+            message: "No fields to update",
+          })
+        }
+
+        const updated = await db
+          .updateTable("agent_tool_binding")
+          .set(updates)
+          .where("id", "=", bindingId)
+          .where("agent_id", "=", agentId)
+          .returningAll()
+          .executeTakeFirst()
+
+        if (!updated) {
+          return reply.status(404).send({ error: "not_found", message: "Binding not found" })
+        }
+
+        return reply.status(200).send({
+          id: updated.id,
+          agentId: updated.agent_id,
+          toolRef: updated.tool_ref,
+          approvalPolicy: updated.approval_policy,
+          approvalCondition: updated.approval_condition,
+          rateLimit: updated.rate_limit,
+          costBudget: updated.cost_budget,
+          dataScope: updated.data_scope,
+          enabled: updated.enabled,
+          createdAt: updated.created_at,
+          updatedAt: updated.updated_at,
+        })
+      },
+    )
+
+    // ------------------------------------------------------------------
+    // DELETE /agents/:agentId/tool-bindings/:bindingId — remove a binding
+    // ------------------------------------------------------------------
+    app.delete<{ Params: BindingParams }>(
+      "/agents/:agentId/tool-bindings/:bindingId",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string", minLength: 1 },
+              bindingId: { type: "string", minLength: 1 },
+            },
+            required: ["agentId", "bindingId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: BindingParams }>, reply: FastifyReply) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          return reply.status(401).send({ error: "unauthorized" })
+        }
+
+        const { agentId, bindingId } = request.params
+
+        // Look up binding to get tool_ref for audit log
+        const binding = await db
+          .selectFrom("agent_tool_binding")
+          .select(["id", "tool_ref"])
+          .where("id", "=", bindingId)
+          .where("agent_id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!binding) {
+          return reply.status(404).send({ error: "not_found", message: "Binding not found" })
+        }
+
+        await db
+          .deleteFrom("agent_tool_binding")
+          .where("id", "=", bindingId)
+          .where("agent_id", "=", agentId)
+          .execute()
+
+        // Audit log
+        await db
+          .insertInto("capability_audit_log")
+          .values({
+            agent_id: agentId,
+            tool_ref: binding.tool_ref,
+            event_type: "binding_removed",
+            actor_user_id: principal.userId,
+            details: { binding_id: bindingId },
+          })
+          .execute()
+
+        return reply.status(204).send()
+      },
+    )
+
+    // ------------------------------------------------------------------
+    // POST /agents/:agentId/tool-bindings/bulk — bulk-create from MCP server
+    // ------------------------------------------------------------------
+    app.post<{ Params: AgentParams; Body: BulkBindBody }>(
+      "/agents/:agentId/tool-bindings/bulk",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string", minLength: 1 },
+            },
+            required: ["agentId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              mcpServerId: { type: "string", minLength: 1 },
+              toolRefs: {
+                type: "array",
+                items: { type: "string", minLength: 1 },
+              },
+              approvalPolicy: {
+                type: "string",
+                enum: ["auto", "always_approve", "conditional"],
+              },
+            },
+            required: ["mcpServerId"],
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: AgentParams; Body: BulkBindBody }>,
+        reply: FastifyReply,
+      ) => {
+        const principal = (request as AuthenticatedRequest).principal
+        if (!principal) {
+          return reply.status(401).send({ error: "unauthorized" })
+        }
+
+        const { agentId } = request.params
+        const { mcpServerId, toolRefs, approvalPolicy = "auto" } = request.body
+
+        // Verify agent exists
+        const agent = await db
+          .selectFrom("agent")
+          .select("id")
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          return reply.status(404).send({ error: "not_found", message: "Agent not found" })
+        }
+
+        // Verify MCP server exists
+        const server = await db
+          .selectFrom("mcp_server")
+          .select("id")
+          .where("id", "=", mcpServerId)
+          .executeTakeFirst()
+
+        if (!server) {
+          return reply.status(404).send({ error: "not_found", message: "MCP server not found" })
+        }
+
+        // Resolve tool refs — either from request body or all tools for the server
+        let resolvedRefs: string[]
+
+        if (toolRefs && toolRefs.length > 0) {
+          resolvedRefs = toolRefs
+        } else {
+          const serverTools = await db
+            .selectFrom("mcp_server_tool")
+            .select("qualified_name")
+            .where("mcp_server_id", "=", mcpServerId)
+            .execute()
+
+          resolvedRefs = serverTools.map((t) => t.qualified_name)
+        }
+
+        if (resolvedRefs.length === 0) {
+          return reply.status(200).send({ created: 0, bindings: [] })
+        }
+
+        // Insert bindings, skipping duplicates
+        const values = resolvedRefs.map((ref) => ({
+          agent_id: agentId,
+          tool_ref: ref,
+          approval_policy: approvalPolicy as "auto" | "always_approve" | "conditional",
+        }))
+
+        const created = await db
+          .insertInto("agent_tool_binding")
+          .values(values)
+          .onConflict((oc) => oc.columns(["agent_id", "tool_ref"]).doNothing())
+          .returningAll()
+          .execute()
+
+        // Audit log for each created binding
+        if (created.length > 0) {
+          await db
+            .insertInto("capability_audit_log")
+            .values(
+              created.map((b) => ({
+                agent_id: agentId,
+                tool_ref: b.tool_ref,
+                event_type: "binding_created",
+                actor_user_id: principal.userId,
+                details: { binding_id: b.id, bulk: true, mcp_server_id: mcpServerId },
+              })),
+            )
+            .execute()
+        }
+
+        return reply.status(201).send({
+          created: created.length,
+          bindings: created.map((b) => ({
+            id: b.id,
+            agentId: b.agent_id,
+            toolRef: b.tool_ref,
+            approvalPolicy: b.approval_policy,
+            enabled: b.enabled,
+            createdAt: b.created_at,
+          })),
+        })
+      },
+    )
+
+    // ------------------------------------------------------------------
+    // GET /agents/:agentId/effective-tools — computed effective tool set
+    // ------------------------------------------------------------------
+    app.get<{ Params: AgentParams }>(
+      "/agents/:agentId/effective-tools",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string", minLength: 1 },
+            },
+            required: ["agentId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: AgentParams }>, reply: FastifyReply) => {
+        const { agentId } = request.params
+
+        // Verify agent exists
+        const agent = await db
+          .selectFrom("agent")
+          .select("id")
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          return reply.status(404).send({ error: "not_found", message: "Agent not found" })
+        }
+
+        // Return enabled bindings as effective tools.
+        // When CapabilityAssembler (#302) is integrated, this will call
+        // assembler.resolveEffectiveTools(agentId) instead.
+        const bindings = await db
+          .selectFrom("agent_tool_binding")
+          .selectAll()
+          .where("agent_id", "=", agentId)
+          .where("enabled", "=", true)
+          .orderBy("created_at", "asc")
+          .execute()
+
+        return reply.status(200).send({
+          tools: bindings.map((b) => ({
+            toolRef: b.tool_ref,
+            bindingId: b.id,
+            approvalPolicy: b.approval_policy,
+            approvalCondition: b.approval_condition,
+            rateLimit: b.rate_limit,
+            costBudget: b.cost_budget,
+            dataScope: b.data_scope,
+          })),
+          assembledAt: new Date().toISOString(),
+        })
+      },
+    )
+
+    // ------------------------------------------------------------------
+    // GET /agents/:agentId/capability-audit — query capability audit log
+    // ------------------------------------------------------------------
+    app.get<{ Params: AgentParams; Querystring: AuditQuery }>(
+      "/agents/:agentId/capability-audit",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string", minLength: 1 },
+            },
+            required: ["agentId"],
+          },
+          querystring: {
+            type: "object",
+            properties: {
+              toolRef: { type: "string" },
+              eventType: { type: "string" },
+              limit: { type: "number", minimum: 1, maximum: 100 },
+              offset: { type: "number", minimum: 0 },
+            },
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: AgentParams; Querystring: AuditQuery }>,
+        reply: FastifyReply,
+      ) => {
+        const { agentId } = request.params
+        const { toolRef, eventType, limit = 50, offset = 0 } = request.query
+
+        // Verify agent exists
+        const agent = await db
+          .selectFrom("agent")
+          .select("id")
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          return reply.status(404).send({ error: "not_found", message: "Agent not found" })
+        }
+
+        let query = db
+          .selectFrom("capability_audit_log")
+          .selectAll()
+          .where("agent_id", "=", agentId)
+        let countQuery = db
+          .selectFrom("capability_audit_log")
+          .select(db.fn.countAll<number>().as("total"))
+          .where("agent_id", "=", agentId)
+
+        if (toolRef) {
+          query = query.where("tool_ref", "=", toolRef)
+          countQuery = countQuery.where("tool_ref", "=", toolRef)
+        }
+
+        if (eventType) {
+          query = query.where("event_type", "=", eventType)
+          countQuery = countQuery.where("event_type", "=", eventType)
+        }
+
+        const [entries, countResult] = await Promise.all([
+          query.orderBy("created_at", "desc").limit(limit).offset(offset).execute(),
+          countQuery.executeTakeFirstOrThrow(),
+        ])
+
+        const total = Number(countResult.total)
+
+        return reply.status(200).send({
+          entries: entries.map((e) => ({
+            id: e.id,
+            agentId: e.agent_id,
+            toolRef: e.tool_ref,
+            eventType: e.event_type,
+            actorUserId: e.actor_user_id,
+            jobId: e.job_id,
+            details: e.details,
+            createdAt: e.created_at,
+          })),
+          total,
+        })
+      },
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- Adds 7 REST endpoints for agent tool binding management (CRUD, bulk bind, effective tools, capability audit)
- `POST /agents/:agentId/tool-bindings` — create binding with audit log (`binding_created`)
- `GET /agents/:agentId/tool-bindings` — list with `?enabled=true&category=communication` filters
- `PUT /agents/:agentId/tool-bindings/:bindingId` — partial update (approval policy, rate limit, data scope, enabled)
- `DELETE /agents/:agentId/tool-bindings/:bindingId` — remove with audit log (`binding_removed`)
- `POST /agents/:agentId/tool-bindings/bulk` — bulk-create from MCP server (supports explicit `toolRefs` or all server tools)
- `GET /agents/:agentId/effective-tools` — returns enabled bindings as effective tool set (CapabilityAssembler integration deferred to #302)
- `GET /agents/:agentId/capability-audit` — paginated audit log with `?toolRef=&eventType=&limit=&offset=` filters
- All routes require `operator` role via `preHandler: [requireAuth, requireOperator]`
- 20 unit tests covering happy paths, 404/409/400 errors, audit log writes, and bulk operations

Closes #305

## Test plan

- [x] `npx vitest run` — 1266 tests pass (20 new)
- [x] `npx eslint` — clean on new files
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive tool binding management endpoints for agents, including create, read, update, and delete operations
  * Enabled bulk import of tool bindings from MCP servers
  * Added endpoint to retrieve effective tools assigned to an agent
  * Integrated capability audit logging for all tool binding modifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->