### PR TITLE
feat(lifecycle): context budget enforcement (#311)

### DIFF
--- a/packages/control-plane/src/lifecycle/__tests__/context-budget.test.ts
+++ b/packages/control-plane/src/lifecycle/__tests__/context-budget.test.ts
@@ -4,6 +4,7 @@ import {
   type BudgetResult,
   type ContextBudgetConfig,
   DEFAULT_CONTEXT_BUDGET,
+  enforceContextBudget,
   type ExecutionContext,
   truncateComponent,
   validateContextBudget,
@@ -174,5 +175,127 @@ describe("validateContextBudget", () => {
     delete ctx.conversationHistory
     const result = validateContextBudget(ctx)
     expect(comp(result, "conversationHistory").chars).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// enforceContextBudget
+// ---------------------------------------------------------------------------
+
+describe("enforceContextBudget", () => {
+  it("returns context unchanged when within budget", () => {
+    const ctx = makeContext()
+    const { budgetResult, enforcedContext } = enforceContextBudget(ctx)
+    expect(budgetResult.valid).toBe(true)
+    expect(budgetResult.warnings).toHaveLength(0)
+    expect(enforcedContext.systemPrompt).toBe(ctx.systemPrompt)
+    expect(enforcedContext.identity).toBe(ctx.identity)
+    expect(enforcedContext.memory).toBe(ctx.memory)
+    expect(enforcedContext.toolDefinitions).toBe(ctx.toolDefinitions)
+  })
+
+  it("truncates oversized system prompt and still passes total check", () => {
+    const ctx = makeContext({ systemPrompt: "x".repeat(10_000) })
+    const { budgetResult, enforcedContext } = enforceContextBudget(ctx)
+    expect(budgetResult.valid).toBe(true)
+    expect(comp(budgetResult, "systemPrompt").truncated).toBe(true)
+    expect(enforcedContext.systemPrompt.length).toBe(DEFAULT_CONTEXT_BUDGET.maxSystemPromptChars)
+    expect(enforcedContext.systemPrompt).toContain("[TRUNCATED]")
+  })
+
+  it("truncates oversized identity with marker, job still valid", () => {
+    const ctx = makeContext({ identity: "x".repeat(6_000) })
+    const { budgetResult, enforcedContext } = enforceContextBudget(ctx)
+    expect(budgetResult.valid).toBe(true)
+    expect(comp(budgetResult, "identity").truncated).toBe(true)
+    expect(enforcedContext.identity.length).toBe(DEFAULT_CONTEXT_BUDGET.maxIdentityChars)
+    expect(enforcedContext.identity).toContain("[TRUNCATED]")
+  })
+
+  it("truncates oversized memory", () => {
+    const ctx = makeContext({ memory: "x".repeat(6_000) })
+    const { budgetResult, enforcedContext } = enforceContextBudget(ctx)
+    expect(budgetResult.valid).toBe(true)
+    expect(comp(budgetResult, "memory").truncated).toBe(true)
+    expect(enforcedContext.memory.length).toBe(DEFAULT_CONTEXT_BUDGET.maxMemoryChars)
+    expect(enforcedContext.memory).toContain("[TRUNCATED]")
+  })
+
+  it("truncates oversized tool definitions", () => {
+    const ctx = makeContext({ toolDefinitions: "x".repeat(20_000) })
+    const { budgetResult, enforcedContext } = enforceContextBudget(ctx)
+    expect(budgetResult.valid).toBe(true)
+    expect(comp(budgetResult, "toolDefinitions").truncated).toBe(true)
+    expect(enforcedContext.toolDefinitions.length).toBe(
+      DEFAULT_CONTEXT_BUDGET.maxToolDefinitionsChars,
+    )
+    expect(enforcedContext.toolDefinitions).toContain("[TRUNCATED]")
+  })
+
+  it("returns valid=false when total exceeds budget even after per-component truncation", () => {
+    const ctx = makeContext({
+      systemPrompt: "x".repeat(8_000),
+      identity: "x".repeat(4_000),
+      memory: "x".repeat(4_000),
+      toolDefinitions: "x".repeat(16_000),
+      conversationHistory: "x".repeat(100_000),
+    })
+    const { budgetResult } = enforceContextBudget(ctx)
+    expect(budgetResult.valid).toBe(false)
+    expect(budgetResult.warnings.some((w) => w.includes("Total context"))).toBe(true)
+  })
+
+  it("does not mutate the original context", () => {
+    const ctx = makeContext({ systemPrompt: "x".repeat(10_000) })
+    const original = ctx.systemPrompt
+    enforceContextBudget(ctx)
+    expect(ctx.systemPrompt).toBe(original)
+  })
+
+  it("never truncates conversation history", () => {
+    const history = "x".repeat(50_000)
+    const ctx = makeContext({ conversationHistory: history })
+    const { enforcedContext } = enforceContextBudget(ctx)
+    expect(enforcedContext.conversationHistory).toBe(history)
+  })
+
+  it("uses custom config for enforcement", () => {
+    const config: ContextBudgetConfig = {
+      maxSystemPromptChars: 50,
+      maxIdentityChars: 50,
+      maxMemoryChars: 50,
+      maxToolDefinitionsChars: 50,
+      maxTotalContextChars: 500,
+      reservedForConversation: 100,
+    }
+    const ctx = makeContext({ systemPrompt: "x".repeat(200) })
+    const { budgetResult, enforcedContext } = enforceContextBudget(ctx, config)
+    expect(comp(budgetResult, "systemPrompt").truncated).toBe(true)
+    expect(enforcedContext.systemPrompt.length).toBe(50)
+  })
+
+  it("truncates multiple components independently", () => {
+    const ctx = makeContext({
+      systemPrompt: "x".repeat(10_000),
+      identity: "x".repeat(6_000),
+      memory: "x".repeat(6_000),
+    })
+    const { budgetResult, enforcedContext } = enforceContextBudget(ctx)
+    expect(budgetResult.valid).toBe(true)
+    expect(comp(budgetResult, "systemPrompt").truncated).toBe(true)
+    expect(comp(budgetResult, "identity").truncated).toBe(true)
+    expect(comp(budgetResult, "memory").truncated).toBe(true)
+    expect(enforcedContext.systemPrompt.length).toBe(DEFAULT_CONTEXT_BUDGET.maxSystemPromptChars)
+    expect(enforcedContext.identity.length).toBe(DEFAULT_CONTEXT_BUDGET.maxIdentityChars)
+    expect(enforcedContext.memory.length).toBe(DEFAULT_CONTEXT_BUDGET.maxMemoryChars)
+  })
+
+  it("applies system defaults when no config provided", () => {
+    const ctx = makeContext({
+      systemPrompt: "x".repeat(DEFAULT_CONTEXT_BUDGET.maxSystemPromptChars + 100),
+    })
+    const { budgetResult, enforcedContext } = enforceContextBudget(ctx)
+    expect(comp(budgetResult, "systemPrompt").truncated).toBe(true)
+    expect(enforcedContext.systemPrompt.length).toBe(DEFAULT_CONTEXT_BUDGET.maxSystemPromptChars)
   })
 })

--- a/packages/control-plane/src/lifecycle/context-budget.ts
+++ b/packages/control-plane/src/lifecycle/context-budget.ts
@@ -137,3 +137,57 @@ export function validateContextBudget(
 
   return { valid, components, totalChars, warnings }
 }
+
+// ---------------------------------------------------------------------------
+// Enforcement (validate + truncate)
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of context budget enforcement.
+ * Contains the validation result and the context with oversized components
+ * truncated to fit their individual budgets.
+ */
+export interface EnforcementResult {
+  budgetResult: BudgetResult
+  enforcedContext: ExecutionContext
+}
+
+/**
+ * Validate context against the budget and truncate oversized components.
+ *
+ * Each component that exceeds its individual limit is truncated via
+ * `truncateComponent()`. If the total (post-truncation) still exceeds
+ * `maxTotalContextChars`, `budgetResult.valid` will be `false` and the
+ * caller should refuse the job.
+ */
+export function enforceContextBudget(
+  context: ExecutionContext,
+  config: ContextBudgetConfig = DEFAULT_CONTEXT_BUDGET,
+): EnforcementResult {
+  const budgetResult = validateContextBudget(context, config)
+
+  // Start with a shallow copy so callers keep the original intact
+  const enforced: ExecutionContext = { ...context }
+
+  if (budgetResult.components["systemPrompt"]?.truncated) {
+    enforced.systemPrompt = truncateComponent(
+      context.systemPrompt,
+      config.maxSystemPromptChars,
+    ).result
+  }
+  if (budgetResult.components["identity"]?.truncated) {
+    enforced.identity = truncateComponent(context.identity, config.maxIdentityChars).result
+  }
+  if (budgetResult.components["memory"]?.truncated) {
+    enforced.memory = truncateComponent(context.memory, config.maxMemoryChars).result
+  }
+  if (budgetResult.components["toolDefinitions"]?.truncated) {
+    enforced.toolDefinitions = truncateComponent(
+      context.toolDefinitions,
+      config.maxToolDefinitionsChars,
+    ).result
+  }
+  // conversationHistory is never truncated by the platform
+
+  return { budgetResult, enforcedContext: enforced }
+}

--- a/packages/control-plane/src/lifecycle/index.ts
+++ b/packages/control-plane/src/lifecycle/index.ts
@@ -11,6 +11,8 @@ export {
   type ComponentBudget,
   type ContextBudgetConfig,
   DEFAULT_CONTEXT_BUDGET,
+  enforceContextBudget,
+  type EnforcementResult,
   type ExecutionContext,
   truncateComponent,
   validateContextBudget,

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -27,7 +27,14 @@ import type { Kysely } from "kysely"
 import type { CredentialService } from "../../auth/credential-service.js"
 import type { CredentialResolver } from "../../backends/tools/webhook.js"
 import type { Database, Job } from "../../db/types.js"
+import {
+  type ContextBudgetConfig,
+  DEFAULT_CONTEXT_BUDGET,
+  enforceContextBudget,
+  type ExecutionContext,
+} from "../../lifecycle/context-budget.js"
 import type { AgentLifecycleManager, SteerMessage } from "../../lifecycle/manager.js"
+import { recordContextBudgetExceeded } from "../../lifecycle/metrics.js"
 import type { McpClientPool } from "../../mcp/client-pool.js"
 import type { McpToolRouter } from "../../mcp/tool-router.js"
 import type { SSEConnectionManager } from "../../streaming/manager.js"
@@ -185,6 +192,79 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
 
         // ── Step 4: Build ExecutionTask (needed for routing) ──
         const task = buildExecutionTask(job, agent, agentConfig, resolvedSkills)
+
+        // ── Step 4a: Enforce context budget ──
+        {
+          const rawBudget = agent.resource_limits.contextBudget
+          const budgetConfig: ContextBudgetConfig =
+            typeof rawBudget === "object" && rawBudget !== null
+              ? (rawBudget as ContextBudgetConfig)
+              : DEFAULT_CONTEXT_BUDGET
+
+          const identity = agent.description ?? ""
+          const execCtx: ExecutionContext = {
+            systemPrompt: task.context.systemPrompt,
+            identity,
+            memory: task.context.memories.join("\n"),
+            toolDefinitions: task.context.skillInstructions ?? "",
+            conversationHistory: task.instruction.conversationHistory
+              ? JSON.stringify(task.instruction.conversationHistory)
+              : undefined,
+          }
+
+          const { budgetResult, enforcedContext } = enforceContextBudget(execCtx, budgetConfig)
+
+          if (!budgetResult.valid) {
+            // Total context exceeds budget — refuse to dispatch
+            for (const [comp, budget] of Object.entries(budgetResult.components)) {
+              if (budget.truncated) recordContextBudgetExceeded(agent.id, comp)
+            }
+            rootSpan.addEvent("context_budget_exceeded")
+
+            await db
+              .updateTable("job")
+              .set({
+                status: "FAILED",
+                error: {
+                  category: "CONTEXT_BUDGET_EXCEEDED",
+                  message: budgetResult.warnings.join("; "),
+                  attempt: job.attempt + 1,
+                },
+                completed_at: new Date(),
+              })
+              .where("id", "=", jobId)
+              .where("status", "=", "RUNNING")
+              .execute()
+
+            return
+          }
+
+          // Apply truncated values back to the task
+          task.context.systemPrompt = enforcedContext.systemPrompt
+          if (enforcedContext.memory) {
+            task.context.memories = [enforcedContext.memory]
+          } else {
+            task.context.memories = []
+          }
+          if (task.context.skillInstructions != null) {
+            task.context.skillInstructions = enforcedContext.toolDefinitions
+          }
+
+          // If identity was truncated and we used auto-generated systemPrompt,
+          // rebuild it with the truncated description
+          if (
+            budgetResult.components["identity"]?.truncated &&
+            typeof agentConfig.systemPrompt !== "string"
+          ) {
+            const desc = enforcedContext.identity
+            task.context.systemPrompt = `You are ${agent.name}, a ${agent.role} agent.${desc ? ` ${desc}` : ""}`
+          }
+
+          // Log truncation warnings (job still proceeds)
+          for (const [comp, budget] of Object.entries(budgetResult.components)) {
+            if (budget.truncated) recordContextBudgetExceeded(agent.id, comp)
+          }
+        }
 
         // ── Step 4b: Resolve LLM credential from agent_credential_binding ──
         let credentialResolver: CredentialResolver | undefined


### PR DESCRIPTION
## Summary
- Add `enforceContextBudget()` to `context-budget.ts` — validates all context components against budget limits, then truncates oversized components with `[TRUNCATED]` marker
- Wire enforcement into `agent-execute.ts` Step 4a: after `buildExecutionTask()`, before credential resolution
- On per-component exceed: truncate and continue (job still dispatches)
- On total exceed: fail job with `CONTEXT_BUDGET_EXCEEDED` error category
- Export new `enforceContextBudget` + `EnforcementResult` from barrel

## Test plan
- [x] 11 new tests for `enforceContextBudget` (context unchanged within budget, truncation per component, total exceed → invalid, immutability, custom config, multiple components, defaults)
- [x] All 28 context-budget tests pass
- [x] Full suite: 1277 tests pass, 0 failures
- [x] Lint clean, typecheck clean, build clean

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context budget enforcement to prevent execution tasks from exceeding memory limits.
  * System now truncates context components when approaching budget thresholds while preserving conversation history.
  * Tasks fail gracefully with detailed status when budget constraints cannot be satisfied.

* **Tests**
  * Added comprehensive test coverage for context budget enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->