### PR TITLE
feat(lifecycle): wire circuit breaker into agent-execute (#314)

### DIFF
--- a/packages/control-plane/migrations/024_quarantined_agent_status.down.sql
+++ b/packages/control-plane/migrations/024_quarantined_agent_status.down.sql
@@ -1,0 +1,4 @@
+-- 024 down: Remove QUARANTINED from agent_status enum
+-- PostgreSQL does not support ALTER TYPE ... DROP VALUE directly.
+-- Downgrade requires a full enum replacement (omitted for safety).
+-- If rollback is needed, replace the enum manually.

--- a/packages/control-plane/migrations/024_quarantined_agent_status.up.sql
+++ b/packages/control-plane/migrations/024_quarantined_agent_status.up.sql
@@ -1,0 +1,2 @@
+-- 024: Add QUARANTINED to agent_status enum (#310 / #314)
+ALTER TYPE agent_status ADD VALUE IF NOT EXISTS 'QUARANTINED';

--- a/packages/control-plane/src/__tests__/agent-execute-circuit-breaker.test.ts
+++ b/packages/control-plane/src/__tests__/agent-execute-circuit-breaker.test.ts
@@ -1,0 +1,563 @@
+/**
+ * Unit tests for the circuit breaker wiring in agent-execute.
+ *
+ * Verifies:
+ * - Pre-dispatch quarantine check hydrates consecutive failure count from DB
+ * - Token budget exceeded mid-job cancels execution
+ * - Successful job resets failure counter (no quarantine)
+ * - Failed job triggers quarantine when threshold reached
+ * - Quarantined agent status check rejects dispatch
+ */
+
+import type {
+  BackendRegistry,
+  ExecutionHandle,
+  ExecutionResult,
+  OutputEvent,
+} from "@cortex/shared/backends"
+import { describe, expect, it, vi } from "vitest"
+
+import { type AgentExecuteDeps, createAgentExecuteTask } from "../worker/tasks/agent-execute.js"
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function createMockResult(overrides: Partial<ExecutionResult> = {}): ExecutionResult {
+  return {
+    taskId: "test-task",
+    status: "completed",
+    exitCode: 0,
+    summary: "done",
+    fileChanges: [],
+    stdout: "",
+    stderr: "",
+    tokenUsage: {
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.001,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    },
+    artifacts: [],
+    durationMs: 500,
+    ...overrides,
+  }
+}
+
+function createMockHandle(
+  result: ExecutionResult = createMockResult(),
+  events: OutputEvent[] = [],
+): ExecutionHandle {
+  let cancelled = false
+  let cancelReason: string | undefined
+  return {
+    taskId: result.taskId,
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async *events() {
+      for (const event of events) {
+        if (cancelled) return
+        yield event
+      }
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async result() {
+      if (cancelled) return { ...result, status: "cancelled" as const }
+      return result
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async cancel(reason: string) {
+      cancelled = true
+      cancelReason = reason
+    },
+    get _cancelReason() {
+      return cancelReason
+    },
+  }
+}
+
+interface MockDbReturns {
+  /** selectFrom("job").selectAll().where().executeTakeFirst() — returns the job record */
+  job?: Record<string, unknown> | null
+  /** selectFrom("agent").selectAll().where().executeTakeFirst() — returns the agent record */
+  agent?: Record<string, unknown> | null
+  /** selectFrom("job").select("status").where("agent_id",...).orderBy(...).limit(...).execute() — recent jobs */
+  recentJobs?: Array<{ status: string }>
+}
+
+function makeMockDb(returns: MockDbReturns = {}) {
+  const defaultJob = {
+    id: "job-1",
+    agent_id: "agent-1",
+    status: "SCHEDULED",
+    attempt: 0,
+    max_attempts: 3,
+    timeout_seconds: 300,
+    session_id: null,
+    payload: { prompt: "test task", goalType: "code_edit" },
+    error: null,
+    result: null,
+    started_at: null,
+    completed_at: null,
+    heartbeat_at: null,
+    approval_expires_at: null,
+  }
+
+  const defaultAgent = {
+    id: "agent-1",
+    name: "TestAgent",
+    slug: "test-agent",
+    role: "developer",
+    description: null,
+    status: "ACTIVE",
+    model_config: {},
+    skill_config: {},
+    resource_limits: {},
+    config: null,
+  }
+
+  const job = returns.job !== undefined ? returns.job : defaultJob
+  const agent = returns.agent !== undefined ? returns.agent : defaultAgent
+  const recentJobs = returns.recentJobs ?? []
+
+  // Track all set() calls for verification
+  const setCalls: Array<{ table: string; values: Record<string, unknown> }> = []
+
+  function createChain(tableName: string, isSelect: boolean) {
+    const chain: Record<string, unknown> = {}
+
+    for (const method of [
+      "select",
+      "selectAll",
+      "set",
+      "where",
+      "innerJoin",
+      "returning",
+      "orderBy",
+      "limit",
+    ]) {
+      if (method === "set") {
+        chain[method] = vi.fn((values: Record<string, unknown>) => {
+          setCalls.push({ table: tableName, values })
+          return chain
+        })
+      } else {
+        chain[method] = vi.fn().mockReturnValue(chain)
+      }
+    }
+
+    chain.executeTakeFirst = vi.fn().mockImplementation(() => {
+      if (tableName === "job") return Promise.resolve(job)
+      if (tableName === "agent") return Promise.resolve(agent)
+      if (tableName === "agent_credential_binding") return Promise.resolve(null)
+      if (tableName === "approval_request") return Promise.resolve(null)
+      return Promise.resolve(null)
+    })
+
+    chain.executeTakeFirstOrThrow = vi.fn().mockImplementation(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return (chain.executeTakeFirst as ReturnType<typeof vi.fn>)()
+    })
+
+    chain.execute = vi.fn().mockImplementation(() => {
+      // For selectFrom("job")...orderBy(...).limit(...).execute() — recent jobs query
+      if (isSelect && tableName === "job") {
+        return Promise.resolve(recentJobs)
+      }
+      return Promise.resolve([])
+    })
+
+    return chain
+  }
+
+  const db = {
+    selectFrom: vi.fn((table: string) => createChain(table, true)),
+    updateTable: vi.fn((table: string) => createChain(table, false)),
+    _setCalls: setCalls,
+  }
+
+  return db
+}
+
+function makeMockRegistry(handle: ExecutionHandle = createMockHandle()) {
+  return {
+    routeTask: vi.fn().mockReturnValue({
+      backend: {
+        backendId: "mock-backend",
+        executeTask: vi.fn().mockResolvedValue(handle),
+      },
+      providerId: "mock-provider",
+    }),
+    acquirePermit: vi.fn().mockResolvedValue({ release: vi.fn() }),
+    recordOutcome: vi.fn(),
+  } as unknown as BackendRegistry
+}
+
+function makeMockHelpers() {
+  return {
+    addJob: vi.fn(),
+    job: { id: "worker-job-1" },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    withPgClient: vi.fn(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("agent-execute circuit breaker wiring", () => {
+  it("quarantines agent pre-dispatch when 3 consecutive failed jobs in DB", async () => {
+    const db = makeMockDb({
+      recentJobs: [{ status: "FAILED" }, { status: "FAILED" }, { status: "FAILED" }],
+    })
+
+    const registry = makeMockRegistry()
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // Verify agent status was set to QUARANTINED
+    const agentUpdate = db._setCalls.find(
+      (c) => c.table === "agent" && c.values.status === "QUARANTINED",
+    )
+    expect(agentUpdate).toBeDefined()
+
+    // Verify job was failed with QUARANTINED category
+    const jobFail = db._setCalls.find(
+      (c) =>
+        c.table === "job" &&
+        c.values.status === "FAILED" &&
+        (c.values.error as Record<string, unknown>)?.category === "QUARANTINED",
+    )
+    expect(jobFail).toBeDefined()
+
+    // Backend should NOT have been called
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(registry.routeTask).not.toHaveBeenCalled()
+  })
+
+  it("does not quarantine when fewer than 3 consecutive failures", async () => {
+    const handle = createMockHandle()
+    const db = makeMockDb({
+      recentJobs: [{ status: "FAILED" }, { status: "FAILED" }],
+    })
+
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // Agent should NOT be quarantined
+    const agentQuarantine = db._setCalls.find(
+      (c) => c.table === "agent" && c.values.status === "QUARANTINED",
+    )
+    expect(agentQuarantine).toBeUndefined()
+
+    // Backend SHOULD have been called
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(registry.routeTask).toHaveBeenCalled()
+  })
+
+  it("rejects dispatch when agent status is not ACTIVE (already quarantined)", async () => {
+    const db = makeMockDb({
+      agent: {
+        id: "agent-1",
+        name: "TestAgent",
+        slug: "test-agent",
+        role: "developer",
+        description: null,
+        status: "QUARANTINED",
+        model_config: {},
+        skill_config: {},
+        resource_limits: {},
+        config: null,
+      },
+    })
+
+    const registry = makeMockRegistry()
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    // Should throw because agent is QUARANTINED
+    await expect(task({ jobId: "job-1" }, makeMockHelpers() as never)).rejects.toThrow(
+      "QUARANTINED",
+    )
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(registry.routeTask).not.toHaveBeenCalled()
+  })
+
+  it("cancels execution when token budget is exceeded mid-job", async () => {
+    // Use a very low token budget
+    const db = makeMockDb({
+      agent: {
+        id: "agent-1",
+        name: "TestAgent",
+        slug: "test-agent",
+        role: "developer",
+        description: null,
+        status: "ACTIVE",
+        model_config: {},
+        skill_config: {},
+        resource_limits: {
+          circuitBreaker: { tokenBudgetPerJob: 100 },
+        },
+        config: null,
+      },
+      recentJobs: [],
+    })
+
+    // Create events that exceed the token budget
+    const events: OutputEvent[] = [
+      {
+        type: "usage",
+        timestamp: new Date().toISOString(),
+        tokenUsage: {
+          inputTokens: 80,
+          outputTokens: 30,
+          costUsd: 0.001,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+        },
+      },
+      {
+        type: "text",
+        timestamp: new Date().toISOString(),
+        content: "still going...",
+      },
+    ]
+
+    const handle = createMockHandle(createMockResult(), events)
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // The handle should have been cancelled due to token budget
+    expect((handle as unknown as { _cancelReason: string })._cancelReason).toBe(
+      "token_budget_exceeded",
+    )
+  })
+
+  it("records job success and does not quarantine after successful execution", async () => {
+    const db = makeMockDb({
+      recentJobs: [{ status: "FAILED" }, { status: "FAILED" }], // 2 failures, just below threshold
+    })
+
+    const events: OutputEvent[] = [
+      {
+        type: "text",
+        timestamp: new Date().toISOString(),
+        content: "Done!",
+      },
+    ]
+
+    const handle = createMockHandle(createMockResult(), events)
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // Agent should NOT be quarantined (success resets counter)
+    const agentQuarantine = db._setCalls.find(
+      (c) => c.table === "agent" && c.values.status === "QUARANTINED",
+    )
+    expect(agentQuarantine).toBeUndefined()
+
+    // Job should be COMPLETED
+    const jobComplete = db._setCalls.find(
+      (c) => c.table === "job" && c.values.status === "COMPLETED",
+    )
+    expect(jobComplete).toBeDefined()
+  })
+
+  it("quarantines agent after failed execution when at failure threshold", async () => {
+    // 2 prior failures + this one = 3 total → quarantine
+    const db = makeMockDb({
+      recentJobs: [{ status: "FAILED" }, { status: "FAILED" }],
+    })
+
+    const events: OutputEvent[] = [
+      { type: "text", timestamp: new Date().toISOString(), content: "Working..." },
+    ]
+
+    const failedResult = createMockResult({
+      status: "failed",
+      error: { message: "Agent crashed", classification: "permanent", partialExecution: false },
+    })
+    const handle = createMockHandle(failedResult, events)
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // After the failed result, the CB has 2 (hydrated) + 1 (this job) = 3 failures
+    // Step 11b should quarantine the agent
+    const agentQuarantine = db._setCalls.find(
+      (c) => c.table === "agent" && c.values.status === "QUARANTINED",
+    )
+    expect(agentQuarantine).toBeDefined()
+  })
+
+  it("monitors tool_use events for rate limiting", async () => {
+    const db = makeMockDb({
+      agent: {
+        id: "agent-1",
+        name: "TestAgent",
+        slug: "test-agent",
+        role: "developer",
+        description: null,
+        status: "ACTIVE",
+        model_config: {},
+        skill_config: {},
+        resource_limits: {
+          circuitBreaker: {
+            toolCallRateLimit: { maxCalls: 2, windowSeconds: 300 },
+          },
+        },
+        config: null,
+      },
+      recentJobs: [],
+    })
+
+    // 3 tool_use events — exceeds limit of 2
+    const events: OutputEvent[] = [
+      { type: "tool_use", timestamp: new Date().toISOString(), toolName: "grep", toolInput: {} },
+      { type: "tool_use", timestamp: new Date().toISOString(), toolName: "read", toolInput: {} },
+      { type: "tool_use", timestamp: new Date().toISOString(), toolName: "write", toolInput: {} },
+    ]
+
+    const handle = createMockHandle(createMockResult(), events)
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // The handle should have been cancelled due to tool call rate
+    expect((handle as unknown as { _cancelReason: string })._cancelReason).toBe(
+      "tool_call_rate_exceeded",
+    )
+  })
+
+  it("records tool errors from tool_result events", async () => {
+    const db = makeMockDb({
+      agent: {
+        id: "agent-1",
+        name: "TestAgent",
+        slug: "test-agent",
+        role: "developer",
+        description: null,
+        status: "ACTIVE",
+        model_config: {},
+        skill_config: {},
+        resource_limits: {
+          circuitBreaker: { maxToolErrorsPerJob: 2 },
+        },
+        config: null,
+      },
+      recentJobs: [],
+    })
+
+    // 2 tool_result errors — should still proceed (shouldAbortJob checks, but we don't abort inline)
+    // The circuit breaker tracks them for potential future use
+    const events: OutputEvent[] = [
+      {
+        type: "tool_result",
+        timestamp: new Date().toISOString(),
+        toolName: "grep",
+        output: "error",
+        isError: true,
+      },
+      {
+        type: "tool_result",
+        timestamp: new Date().toISOString(),
+        toolName: "read",
+        output: "not found",
+        isError: true,
+      },
+      {
+        type: "text",
+        timestamp: new Date().toISOString(),
+        content: "Done",
+      },
+    ]
+
+    const handle = createMockHandle(createMockResult(), events)
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    // Should complete without error — tool errors are tracked but don't cancel by default
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    const jobComplete = db._setCalls.find(
+      (c) => c.table === "job" && c.values.status === "COMPLETED",
+    )
+    expect(jobComplete).toBeDefined()
+  })
+
+  it("respects custom circuit breaker config from agent resource_limits", async () => {
+    // Custom threshold of 5 failures — 3 prior failures should NOT quarantine
+    const db = makeMockDb({
+      agent: {
+        id: "agent-1",
+        name: "TestAgent",
+        slug: "test-agent",
+        role: "developer",
+        description: null,
+        status: "ACTIVE",
+        model_config: {},
+        skill_config: {},
+        resource_limits: {
+          circuitBreaker: { maxConsecutiveFailures: 5 },
+        },
+        config: null,
+      },
+      recentJobs: [{ status: "FAILED" }, { status: "FAILED" }, { status: "FAILED" }],
+    })
+
+    const events: OutputEvent[] = [
+      { type: "text", timestamp: new Date().toISOString(), content: "Done" },
+    ]
+    const handle = createMockHandle(createMockResult(), events)
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // Should NOT quarantine (3 < 5 threshold)
+    const agentQuarantine = db._setCalls.find(
+      (c) => c.table === "agent" && c.values.status === "QUARANTINED",
+    )
+    expect(agentQuarantine).toBeUndefined()
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(registry.routeTask).toHaveBeenCalled()
+  })
+})

--- a/packages/control-plane/src/__tests__/lifecycle-quarantine.test.ts
+++ b/packages/control-plane/src/__tests__/lifecycle-quarantine.test.ts
@@ -1,0 +1,232 @@
+import type { Kysely } from "kysely"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { Database } from "../db/types.js"
+import type { AgentDeployer } from "../k8s/agent-deployer.js"
+import { AgentLifecycleManager, type LifecycleManagerDeps } from "../lifecycle/manager.js"
+import type { LifecycleTransitionEvent } from "../lifecycle/state-machine.js"
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+function makeMockDb() {
+  const mockResult = {
+    executeTakeFirst: vi.fn(),
+    execute: vi.fn(),
+  }
+
+  const mockChain = {
+    select: vi.fn().mockReturnThis(),
+    selectAll: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    executeTakeFirst: mockResult.executeTakeFirst,
+    execute: mockResult.execute,
+  }
+
+  const db = {
+    selectFrom: vi.fn().mockReturnValue(mockChain),
+    updateTable: vi.fn().mockReturnValue(mockChain),
+    _mockChain: mockChain,
+    _mockResult: mockResult,
+  }
+
+  return db as unknown as Kysely<Database> & {
+    _mockChain: typeof mockChain
+    _mockResult: typeof mockResult
+  }
+}
+
+function makeMockDeployer() {
+  return {
+    deployAgent: vi.fn().mockResolvedValue(undefined),
+    deleteAgent: vi.fn().mockResolvedValue(undefined),
+    getAgentStatus: vi.fn().mockResolvedValue(null),
+    listAgents: vi.fn().mockResolvedValue([]),
+  } as unknown as AgentDeployer & {
+    deployAgent: ReturnType<typeof vi.fn>
+    deleteAgent: ReturnType<typeof vi.fn>
+  }
+}
+
+function configureDbForBoot(db: ReturnType<typeof makeMockDb>) {
+  let callCount = 0
+  db._mockResult.executeTakeFirst.mockImplementation(() => {
+    callCount++
+    if (callCount === 1) {
+      return {
+        checkpoint: { step: 0 },
+        checkpoint_crc: 123,
+        status: "RUNNING",
+        attempt: 1,
+        payload: { task: "test task" },
+      }
+    }
+    return {
+      id: "agent-1",
+      name: "Test Agent",
+      slug: "test-agent",
+      role: "devops",
+      description: "A test agent",
+      model_config: {},
+      skill_config: {},
+      resource_limits: {},
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Quarantine / Release tests
+// ---------------------------------------------------------------------------
+
+describe("AgentLifecycleManager quarantine/release", () => {
+  let db: ReturnType<typeof makeMockDb>
+  let deployer: ReturnType<typeof makeMockDeployer>
+  let manager: AgentLifecycleManager
+  let events: LifecycleTransitionEvent[]
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    db = makeMockDb()
+    deployer = makeMockDeployer()
+    events = []
+
+    manager = new AgentLifecycleManager({
+      db: db as unknown as Kysely<Database>,
+      deployer: deployer as unknown as AgentDeployer,
+      onLifecycleEvent: (event) => events.push(event),
+    } satisfies LifecycleManagerDeps)
+  })
+
+  afterEach(() => {
+    manager.shutdown()
+    vi.useRealTimers()
+  })
+
+  it("quarantine transitions EXECUTING → QUARANTINED and fails the running job", async () => {
+    configureDbForBoot(db)
+    await manager.boot("agent-1", "job-1")
+    manager.run("agent-1", "job-1")
+
+    expect(manager.getAgentState("agent-1")).toBe("EXECUTING")
+
+    await manager.quarantine("agent-1", "3 consecutive failures")
+
+    expect(manager.getAgentState("agent-1")).toBe("QUARANTINED")
+
+    // Should have called updateTable twice: once for job (FAILED), once for agent (QUARANTINED)
+    const updateCalls = (db.updateTable as ReturnType<typeof vi.fn>).mock.calls
+    expect(updateCalls.length).toBeGreaterThanOrEqual(2)
+    expect(updateCalls.some((c: string[]) => c[0] === "job")).toBe(true)
+    expect(updateCalls.some((c: string[]) => c[0] === "agent")).toBe(true)
+  })
+
+  it("quarantine emits lifecycle transition event", async () => {
+    configureDbForBoot(db)
+    await manager.boot("agent-1", "job-1")
+    manager.run("agent-1", "job-1")
+
+    const eventsBefore = events.length
+    await manager.quarantine("agent-1", "too many failures")
+
+    const quarantineEvent = events.slice(eventsBefore).find((e) => e.to === "QUARANTINED")
+    expect(quarantineEvent).toBeDefined()
+    expect(quarantineEvent!.from).toBe("EXECUTING")
+    expect(quarantineEvent!.reason).toBe("too many failures")
+  })
+
+  it("quarantine throws if agent is not in valid source state", async () => {
+    configureDbForBoot(db)
+    await manager.boot("agent-1", "job-1")
+    // Agent is in READY state, not EXECUTING or DEGRADED
+    await expect(manager.quarantine("agent-1", "bad")).rejects.toThrow(
+      "Invalid lifecycle transition",
+    )
+  })
+
+  it("quarantine throws if agent is not managed", async () => {
+    await expect(manager.quarantine("unknown-agent", "reason")).rejects.toThrow("not managed")
+  })
+
+  it("release transitions QUARANTINED → DRAINING", async () => {
+    configureDbForBoot(db)
+    await manager.boot("agent-1", "job-1")
+    manager.run("agent-1", "job-1")
+    await manager.quarantine("agent-1", "failures")
+
+    expect(manager.getAgentState("agent-1")).toBe("QUARANTINED")
+
+    await manager.release("agent-1")
+
+    expect(manager.getAgentState("agent-1")).toBe("DRAINING")
+  })
+
+  it("release restores DB agent status to ACTIVE", async () => {
+    configureDbForBoot(db)
+    await manager.boot("agent-1", "job-1")
+    manager.run("agent-1", "job-1")
+    await manager.quarantine("agent-1", "failures")
+
+    // Reset mock to track release calls
+    ;(db.updateTable as ReturnType<typeof vi.fn>).mockClear()
+    db._mockChain.set.mockClear()
+
+    await manager.release("agent-1")
+
+    const updateCalls = (db.updateTable as ReturnType<typeof vi.fn>).mock.calls
+    expect(updateCalls.some((c: string[]) => c[0] === "agent")).toBe(true)
+  })
+
+  it("release with resetCrashDetector clears crash history", async () => {
+    configureDbForBoot(db)
+    await manager.boot("agent-1", "job-1")
+    manager.run("agent-1", "job-1")
+
+    // Record a crash so crash detector has state
+    manager.crashDetector.recordCrash("agent-1")
+    expect(manager.crashDetector.getCrashRecord("agent-1")).toBeDefined()
+
+    // Need a fresh boot to get back to EXECUTING → QUARANTINED path
+    // First clean up the terminated agent from the crash
+    vi.advanceTimersByTime(61_000)
+    let bootCallCount = 0
+    db._mockResult.executeTakeFirst.mockImplementation(() => {
+      bootCallCount++
+      if (bootCallCount === 1) {
+        return {
+          checkpoint: { step: 0 },
+          checkpoint_crc: 123,
+          status: "RUNNING",
+          attempt: 1,
+          payload: { task: "test" },
+        }
+      }
+      return {
+        id: "agent-1",
+        name: "Test Agent",
+        slug: "test-agent",
+        role: "devops",
+        description: null,
+        model_config: {},
+        skill_config: {},
+        resource_limits: {},
+      }
+    })
+    await manager.boot("agent-1", "job-2")
+    manager.run("agent-1", "job-2")
+    await manager.quarantine("agent-1", "test")
+
+    await manager.release("agent-1", true)
+
+    expect(manager.crashDetector.getCrashRecord("agent-1")).toBeUndefined()
+  })
+
+  it("release throws if agent is not in QUARANTINED state", async () => {
+    configureDbForBoot(db)
+    await manager.boot("agent-1", "job-1")
+    manager.run("agent-1", "job-1")
+    // release() should reject if not in QUARANTINED state
+    await expect(manager.release("agent-1")).rejects.toThrow("not in QUARANTINED state")
+  })
+})

--- a/packages/control-plane/src/lifecycle/manager.ts
+++ b/packages/control-plane/src/lifecycle/manager.ts
@@ -25,7 +25,7 @@ import type { AgentDeploymentConfig } from "../k8s/types.js"
 import { type AgentHeartbeat, CrashLoopDetector, HeartbeatReceiver } from "./health.js"
 import { hydrateAgent, type HydrationResult, type QdrantClient } from "./hydration.js"
 import { IdleDetector } from "./idle-detector.js"
-import { recordStateTransition } from "./metrics.js"
+import { recordCircuitBreakerTrip, recordStateTransition } from "./metrics.js"
 import {
   type AgentLifecycleState,
   AgentLifecycleStateMachine,
@@ -335,6 +335,70 @@ export class AgentLifecycleManager {
     // Only scale-to-zero agents that are READY (idle, not executing)
     if (ctx.stateMachine.state === "READY") {
       await this.drain(agentId, "Idle timeout — scale to zero")
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // quarantine: EXECUTING | DEGRADED → QUARANTINED
+  // -------------------------------------------------------------------------
+
+  /**
+   * Quarantine an agent — freezes execution, fails the running job,
+   * updates the DB agent status to QUARANTINED, and emits a metric.
+   *
+   * Valid source states: EXECUTING, DEGRADED.
+   */
+  async quarantine(agentId: string, reason: string): Promise<void> {
+    const ctx = this.requireContext(agentId)
+    ctx.stateMachine.transition("QUARANTINED", reason)
+
+    recordCircuitBreakerTrip(agentId, reason)
+
+    // Fail the running job with QUARANTINED category
+    await this.db
+      .updateTable("job")
+      .set({
+        status: "FAILED",
+        error: { category: "QUARANTINED", message: reason },
+        completed_at: new Date(),
+      })
+      .where("id", "=", ctx.jobId)
+      .where("status", "=", "RUNNING")
+      .execute()
+
+    // Update the DB agent status so subsequent job dispatches are rejected
+    await this.db
+      .updateTable("agent")
+      .set({ status: "QUARANTINED" })
+      .where("id", "=", agentId)
+      .execute()
+  }
+
+  // -------------------------------------------------------------------------
+  // release: QUARANTINED → DRAINING (triggers re-boot cycle)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Release an agent from quarantine. Transitions QUARANTINED → DRAINING
+   * so the normal drain → re-boot cycle can proceed. Restores the DB
+   * agent status to ACTIVE and optionally resets the crash detector.
+   */
+  async release(agentId: string, resetCrashDetector?: boolean): Promise<void> {
+    const ctx = this.requireContext(agentId)
+
+    if (ctx.stateMachine.state !== "QUARANTINED") {
+      throw new Error(
+        `Cannot release agent ${agentId}: not in QUARANTINED state (current: ${ctx.stateMachine.state})`,
+      )
+    }
+
+    ctx.stateMachine.transition("DRAINING", "Released from quarantine")
+
+    // Restore DB agent status
+    await this.db.updateTable("agent").set({ status: "ACTIVE" }).where("id", "=", agentId).execute()
+
+    if (resetCrashDetector) {
+      this.crashDetector.resetCrashes(agentId)
     }
   }
 

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -27,6 +27,8 @@ import type { Kysely } from "kysely"
 import type { CredentialService } from "../../auth/credential-service.js"
 import type { CredentialResolver } from "../../backends/tools/webhook.js"
 import type { Database, Job } from "../../db/types.js"
+import type { AgentCircuitBreakerConfig } from "../../lifecycle/agent-circuit-breaker.js"
+import { AgentCircuitBreaker } from "../../lifecycle/agent-circuit-breaker.js"
 import {
   type ContextBudgetConfig,
   DEFAULT_CONTEXT_BUDGET,
@@ -34,7 +36,7 @@ import {
   type ExecutionContext,
 } from "../../lifecycle/context-budget.js"
 import type { AgentLifecycleManager, SteerMessage } from "../../lifecycle/manager.js"
-import { recordContextBudgetExceeded } from "../../lifecycle/metrics.js"
+import { recordCircuitBreakerTrip, recordContextBudgetExceeded } from "../../lifecycle/metrics.js"
 import type { McpClientPool } from "../../mcp/client-pool.js"
 import type { McpToolRouter } from "../../mcp/tool-router.js"
 import type { SSEConnectionManager } from "../../streaming/manager.js"
@@ -129,6 +131,10 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
       // Start heartbeat writer (updates heartbeat_at every 30s)
       const heartbeat = startHeartbeat(jobId, db)
 
+      // Circuit breaker + agent ID hoisted for catch-block access
+      let agentCB: AgentCircuitBreaker | undefined
+      let loadedAgentId: string | undefined
+
       try {
         // ── Step 1: Load agent definition ──
         const agent = await db
@@ -146,6 +152,67 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
         }
 
         rootSpan.setAttribute(CortexAttributes.AGENT_NAME, agent.name)
+        loadedAgentId = agent.id
+
+        // ── Step 1b: Instantiate agent-level circuit breaker ──
+        const rawCb = agent.resource_limits.circuitBreaker
+        const cbConfig =
+          typeof rawCb === "object" && rawCb !== null
+            ? (rawCb as Partial<AgentCircuitBreakerConfig>)
+            : undefined
+        agentCB = new AgentCircuitBreaker(agent.id, cbConfig)
+
+        // Hydrate consecutive failure count from recent jobs
+        const recentJobs = await db
+          .selectFrom("job")
+          .select("status")
+          .where("agent_id", "=", agent.id)
+          .where("completed_at", "is not", null)
+          .orderBy("completed_at", "desc")
+          .limit(10)
+          .execute()
+
+        for (const rj of recentJobs) {
+          if (rj.status === "FAILED") agentCB.recordJobFailure()
+          else break
+        }
+
+        // ── Step 1c: Pre-dispatch quarantine check ──
+        const preCheck = agentCB.shouldQuarantine()
+        if (preCheck.quarantine) {
+          rootSpan.addEvent("agent_quarantined_pre_dispatch")
+          recordCircuitBreakerTrip(agent.id, preCheck.reason)
+
+          if (lifecycleManager) {
+            await lifecycleManager.quarantine(agent.id, preCheck.reason).catch(() => {
+              // quarantine is best-effort if lifecycle manager doesn't track this agent
+            })
+          }
+
+          // Update DB agent status directly as a fallback
+          await db
+            .updateTable("agent")
+            .set({ status: "QUARANTINED" })
+            .where("id", "=", agent.id)
+            .execute()
+
+          await db
+            .updateTable("job")
+            .set({
+              status: "FAILED",
+              error: {
+                category: "QUARANTINED",
+                message: `Agent quarantined: ${preCheck.reason}`,
+                attempt: job.attempt + 1,
+              },
+              completed_at: new Date(),
+            })
+            .where("id", "=", jobId)
+            .where("status", "=", "RUNNING")
+            .execute()
+
+          return
+        }
 
         // ── Step 2: Check approval gate ──
         const agentConfig = agent.model_config
@@ -478,6 +545,30 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                 turnCount++
               }
 
+              // ── Circuit breaker: mid-execution monitoring ──
+              if (event.type === "usage") {
+                const totalTokens = event.tokenUsage.inputTokens + event.tokenUsage.outputTokens
+                if (!agentCB.recordTokenUsage(totalTokens)) {
+                  void handle.cancel("token_budget_exceeded")
+                }
+              }
+              if (event.type === "tool_use") {
+                if (!agentCB.recordToolCall()) {
+                  void handle.cancel("tool_call_rate_exceeded")
+                }
+              }
+              if (event.type === "text") {
+                if (!agentCB.recordLlmCall()) {
+                  void handle.cancel("llm_call_rate_exceeded")
+                }
+              }
+              if (event.type === "tool_result" && event.isError) {
+                agentCB.recordToolError()
+              }
+              if (event.type === "error") {
+                agentCB.recordLlmRetry()
+              }
+
               if (job.session_id && event.type === "text" && event.content.trim().length > 0) {
                 await memoryScheduler
                   .recordMessage(
@@ -503,9 +594,35 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
           // ── Step 10: Await final result ──
           const result = await handle.result()
 
-          // ── Step 11: Record outcome for circuit breaker ──
+          // ── Step 11: Record outcome for backend circuit breaker ──
           const success = result.status === "completed"
           registry.recordOutcome(providerId, success, result.error?.classification)
+
+          // ── Step 11b: Record outcome for agent circuit breaker ──
+          if (success) {
+            agentCB.recordJobSuccess()
+          } else {
+            agentCB.recordJobFailure()
+            const postDecision = agentCB.shouldQuarantine()
+            if (postDecision.quarantine) {
+              rootSpan.addEvent("agent_quarantined_post_execution", {
+                "cortex.quarantine.reason": postDecision.reason,
+              })
+              recordCircuitBreakerTrip(agent.id, postDecision.reason)
+
+              if (lifecycleManager) {
+                await lifecycleManager.quarantine(agent.id, postDecision.reason).catch(() => {
+                  // best-effort
+                })
+              }
+
+              await db
+                .updateTable("agent")
+                .set({ status: "QUARANTINED" })
+                .where("id", "=", agent.id)
+                .execute()
+            }
+          }
 
           rootSpan.setAttribute(CortexAttributes.EXECUTION_STATUS, result.status)
           rootSpan.setAttribute(CortexAttributes.EXECUTION_DURATION_MS, result.durationMs)
@@ -612,6 +729,30 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
             .where("id", "=", jobId)
             .where("status", "=", "RUNNING")
             .execute()
+        }
+
+        // ── Circuit breaker: record failure in error path ──
+        if (agentCB && loadedAgentId) {
+          agentCB.recordJobFailure()
+          const errDecision = agentCB.shouldQuarantine()
+          if (errDecision.quarantine) {
+            rootSpan.addEvent("agent_quarantined_on_error", {
+              "cortex.quarantine.reason": errDecision.reason,
+            })
+            recordCircuitBreakerTrip(loadedAgentId, errDecision.reason)
+
+            if (lifecycleManager) {
+              await lifecycleManager.quarantine(loadedAgentId, errDecision.reason).catch(() => {
+                // best-effort
+              })
+            }
+
+            await db
+              .updateTable("agent")
+              .set({ status: "QUARANTINED" })
+              .where("id", "=", loadedAgentId)
+              .execute()
+          }
         }
 
         throw err // re-throw so withSpan marks the span as errored

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -9,7 +9,7 @@ export type JobStatus =
   | "RETRYING"
   | "DEAD_LETTER"
 
-export type AgentStatus = "ACTIVE" | "DISABLED" | "ARCHIVED"
+export type AgentStatus = "ACTIVE" | "DISABLED" | "ARCHIVED" | "QUARANTINED"
 
 export type ApprovalStatus = "PENDING" | "APPROVED" | "REJECTED" | "EXPIRED"
 export type RiskLevel = "P0" | "P1" | "P2" | "P3"


### PR DESCRIPTION
## Summary
- Adds `quarantine()` and `release()` methods to `AgentLifecycleManager` — transitions EXECUTING/DEGRADED → QUARANTINED, fails running job, updates DB agent status
- Wires `AgentCircuitBreaker` into `agent-execute.ts`: pre-dispatch quarantine check (hydrated from recent job history), mid-execution token/rate/tool monitoring, and post-execution failure recording with automatic quarantine
- Adds `QUARANTINED` to `AgentStatus` enum (shared types + DB migration 024)

## Acceptance Criteria
- [x] Agent with 3 consecutive failed jobs is automatically quarantined
- [x] Agent with token budget exceeded mid-job: execution cancelled, job set to FAILED
- [x] Successful job resets failure counter
- [x] Quarantined agent: new job dispatch is rejected with clear error
- [x] `AgentLifecycleManager.quarantine()` transitions state and cancels job
- [x] `AgentLifecycleManager.release()` transitions QUARANTINED → DRAINING
- [x] `pnpm test` passes (1294 tests, 76 files)

## Test plan
- [x] `lifecycle-quarantine.test.ts` — 8 tests for quarantine/release methods
- [x] `agent-execute-circuit-breaker.test.ts` — 9 tests for CB wiring in agent-execute
- [x] Existing `agent-circuit-breaker.test.ts` — 23 tests continue to pass
- [x] Full test suite: 1294 passed, 0 failed
- [x] Lint, typecheck, build all clean

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added automatic agent quarantine when consecutive job failures exceed configured thresholds, preventing problematic agents from executing further work
* Introduced circuit breaker monitoring for token budgets and tool usage rates with automatic execution cancellation when limits are exceeded
* Added agent release mechanism to restore quarantined agents to active status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->