### PR TITLE
feat(db): migration 025 — operator visibility schema (#321)

### DIFF
--- a/packages/control-plane/migrations/025_operator_visibility.down.sql
+++ b/packages/control-plane/migrations/025_operator_visibility.down.sql
@@ -1,0 +1,40 @@
+-- 025 down: Revert operator visibility schema changes.
+
+-- 5. Drop session cost columns.
+ALTER TABLE session
+  DROP COLUMN IF EXISTS total_tokens_in,
+  DROP COLUMN IF EXISTS total_tokens_out,
+  DROP COLUMN IF EXISTS total_cost_usd;
+
+-- 4. Drop job cost + delegation columns.
+ALTER TABLE job
+  DROP COLUMN IF EXISTS tokens_in,
+  DROP COLUMN IF EXISTS tokens_out,
+  DROP COLUMN IF EXISTS cost_usd,
+  DROP COLUMN IF EXISTS tool_call_count,
+  DROP COLUMN IF EXISTS llm_call_count,
+  DROP COLUMN IF EXISTS parent_job_id,
+  DROP COLUMN IF EXISTS delegation_depth;
+
+-- 3. Drop additional indexes.
+DROP INDEX IF EXISTS idx_ae_session;
+DROP INDEX IF EXISTS idx_ae_job;
+DROP INDEX IF EXISTS idx_ae_event_type;
+DROP INDEX IF EXISTS idx_ae_cost;
+
+-- 2. Rename payload back to details.
+ALTER TABLE agent_event RENAME COLUMN payload TO details;
+
+-- 2. Drop new agent_event columns.
+ALTER TABLE agent_event
+  DROP COLUMN IF EXISTS session_id,
+  DROP COLUMN IF EXISTS parent_event_id,
+  DROP COLUMN IF EXISTS tokens_in,
+  DROP COLUMN IF EXISTS tokens_out,
+  DROP COLUMN IF EXISTS duration_ms,
+  DROP COLUMN IF EXISTS model,
+  DROP COLUMN IF EXISTS tool_ref,
+  DROP COLUMN IF EXISTS actor;
+
+-- 1. Drop enum type.
+DROP TYPE IF EXISTS agent_event_type;

--- a/packages/control-plane/migrations/025_operator_visibility.up.sql
+++ b/packages/control-plane/migrations/025_operator_visibility.up.sql
@@ -1,0 +1,61 @@
+-- 025: Operator visibility — enrich agent_event + add job/session cost columns.
+--      Part of the operator visibility epic (#265-T1, #321).
+
+-- 1. Create agent_event_type enum for reference / Kysely typing.
+CREATE TYPE agent_event_type AS ENUM (
+  'llm_call_start',
+  'llm_call_end',
+  'tool_call_start',
+  'tool_call_end',
+  'tool_denied',
+  'tool_rate_limited',
+  'message_received',
+  'message_sent',
+  'state_transition',
+  'circuit_breaker_trip',
+  'cost_alert',
+  'steer_injected',
+  'steer_acknowledged',
+  'kill_requested',
+  'checkpoint_created',
+  'error',
+  'session_start',
+  'session_end'
+);
+
+-- 2. Enrich agent_event table with columns from the operator visibility spec.
+ALTER TABLE agent_event
+  ADD COLUMN session_id      UUID REFERENCES session(id) ON DELETE SET NULL,
+  ADD COLUMN parent_event_id UUID REFERENCES agent_event(id) ON DELETE SET NULL,
+  ADD COLUMN tokens_in       INTEGER,
+  ADD COLUMN tokens_out      INTEGER,
+  ADD COLUMN duration_ms     INTEGER,
+  ADD COLUMN model           TEXT,
+  ADD COLUMN tool_ref        TEXT,
+  ADD COLUMN actor           TEXT;
+
+-- Rename details → payload (matches spec).
+ALTER TABLE agent_event RENAME COLUMN details TO payload;
+
+-- 3. Additional indexes required by the spec.
+CREATE INDEX idx_ae_session    ON agent_event (session_id, created_at DESC);
+CREATE INDEX idx_ae_job        ON agent_event (job_id, created_at DESC);
+CREATE INDEX idx_ae_event_type ON agent_event (event_type, created_at DESC);
+CREATE INDEX idx_ae_cost       ON agent_event (agent_id, cost_usd)
+  WHERE cost_usd IS NOT NULL;
+
+-- 4. Job cost + delegation columns (defaults preserve existing rows).
+ALTER TABLE job
+  ADD COLUMN tokens_in        INTEGER     NOT NULL DEFAULT 0,
+  ADD COLUMN tokens_out       INTEGER     NOT NULL DEFAULT 0,
+  ADD COLUMN cost_usd         NUMERIC(12, 6) NOT NULL DEFAULT 0,
+  ADD COLUMN tool_call_count  INTEGER     NOT NULL DEFAULT 0,
+  ADD COLUMN llm_call_count   INTEGER     NOT NULL DEFAULT 0,
+  ADD COLUMN parent_job_id    UUID        REFERENCES job(id) ON DELETE SET NULL,
+  ADD COLUMN delegation_depth INTEGER     NOT NULL DEFAULT 0;
+
+-- 5. Session cost columns (defaults preserve existing rows).
+ALTER TABLE session
+  ADD COLUMN total_tokens_in  BIGINT         NOT NULL DEFAULT 0,
+  ADD COLUMN total_tokens_out BIGINT         NOT NULL DEFAULT 0,
+  ADD COLUMN total_cost_usd   NUMERIC(12, 6) NOT NULL DEFAULT 0;

--- a/packages/control-plane/src/__tests__/agent-routes.test.ts
+++ b/packages/control-plane/src/__tests__/agent-routes.test.ts
@@ -66,7 +66,7 @@ function makeAgentEvent(overrides: Record<string, unknown> = {}) {
     job_id: null,
     event_type: "llm_call",
     cost_usd: "0.005000",
-    details: { model: "claude-3-sonnet" },
+    payload: { model: "claude-3-sonnet" },
     created_at: new Date(),
     ...overrides,
   }
@@ -303,11 +303,11 @@ describe("GET /agents/:id", () => {
     const { app } = await buildTestApp({
       agents: [makeAgent()],
       agentEvents: [
-        makeAgentEvent({ cost_usd: "0.010000", details: { model: "claude-3-opus" } }),
+        makeAgentEvent({ cost_usd: "0.010000", payload: { model: "claude-3-opus" } }),
         makeAgentEvent({
           id: "event-2",
           cost_usd: "0.005000",
-          details: { model: "claude-3-sonnet" },
+          payload: { model: "claude-3-sonnet" },
         }),
       ],
       jobs: [makeJob({ status: "RUNNING" })],
@@ -343,10 +343,10 @@ describe("GET /agents/:id", () => {
           id: "e1",
           event_type: "error",
           cost_usd: "0",
-          details: { reason: "timeout" },
+          payload: { reason: "timeout" },
         }),
-        makeAgentEvent({ id: "e2", event_type: "tool_error", cost_usd: "0", details: {} }),
-        makeAgentEvent({ id: "e3", event_type: "error", cost_usd: "0", details: {} }),
+        makeAgentEvent({ id: "e2", event_type: "tool_error", cost_usd: "0", payload: {} }),
+        makeAgentEvent({ id: "e3", event_type: "error", cost_usd: "0", payload: {} }),
       ],
     })
 
@@ -369,9 +369,9 @@ describe("GET /agents/:id", () => {
     const { app } = await buildTestApp({
       agents: [makeAgent()],
       agentEvents: [
-        makeAgentEvent({ id: "e1", cost_usd: "0.010000", details: { model: "claude-3-opus" } }),
-        makeAgentEvent({ id: "e2", cost_usd: "0.002000", details: { model: "claude-3-opus" } }),
-        makeAgentEvent({ id: "e3", cost_usd: "0.005000", details: { model: "claude-3-sonnet" } }),
+        makeAgentEvent({ id: "e1", cost_usd: "0.010000", payload: { model: "claude-3-opus" } }),
+        makeAgentEvent({ id: "e2", cost_usd: "0.002000", payload: { model: "claude-3-opus" } }),
+        makeAgentEvent({ id: "e3", cost_usd: "0.005000", payload: { model: "claude-3-sonnet" } }),
       ],
     })
 

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -154,6 +154,9 @@ export interface SessionTable {
     Record<string, unknown> | null | undefined,
     Record<string, unknown> | null
   >
+  total_tokens_in: ColumnType<number, number | undefined, number>
+  total_tokens_out: ColumnType<number, number | undefined, number>
+  total_cost_usd: ColumnType<string, string | number | undefined, string | number>
   created_at: ColumnType<Date, Date | undefined, never>
   updated_at: ColumnType<Date, Date | undefined, never>
 }
@@ -236,6 +239,13 @@ export interface JobTable {
   completed_at: Date | null
   heartbeat_at: Date | null
   approval_expires_at: Date | null
+  tokens_in: ColumnType<number, number | undefined, number>
+  tokens_out: ColumnType<number, number | undefined, number>
+  cost_usd: ColumnType<string, string | number | undefined, string | number>
+  tool_call_count: ColumnType<number, number | undefined, number>
+  llm_call_count: ColumnType<number, number | undefined, number>
+  parent_job_id: string | null
+  delegation_depth: ColumnType<number, number | undefined, number>
 }
 
 export type Job = Selectable<JobTable>
@@ -719,19 +729,50 @@ export type NewAccessRequest = Insertable<AccessRequestTable>
 export type AccessRequestUpdate = Updateable<AccessRequestTable>
 
 // ---------------------------------------------------------------------------
+// Enum: agent_event_type
+// ---------------------------------------------------------------------------
+export type AgentEventType =
+  | "llm_call_start"
+  | "llm_call_end"
+  | "tool_call_start"
+  | "tool_call_end"
+  | "tool_denied"
+  | "tool_rate_limited"
+  | "message_received"
+  | "message_sent"
+  | "state_transition"
+  | "circuit_breaker_trip"
+  | "cost_alert"
+  | "steer_injected"
+  | "steer_acknowledged"
+  | "kill_requested"
+  | "checkpoint_created"
+  | "error"
+  | "session_start"
+  | "session_end"
+
+// ---------------------------------------------------------------------------
 // Table: agent_event
 // ---------------------------------------------------------------------------
 export interface AgentEventTable {
   id: Generated<string>
   agent_id: string
+  session_id: string | null
   job_id: string | null
+  parent_event_id: string | null
   event_type: string
-  cost_usd: ColumnType<string | null, string | number | null | undefined, string | number | null>
-  details: ColumnType<
+  payload: ColumnType<
     Record<string, unknown>,
     Record<string, unknown> | undefined,
     Record<string, unknown>
   >
+  tokens_in: number | null
+  tokens_out: number | null
+  cost_usd: ColumnType<string | null, string | number | null | undefined, string | number | null>
+  duration_ms: number | null
+  model: string | null
+  tool_ref: string | null
+  actor: string | null
   created_at: ColumnType<Date, Date | undefined, never>
 }
 

--- a/packages/control-plane/src/routes/agent-checkpoints.ts
+++ b/packages/control-plane/src/routes/agent-checkpoints.ts
@@ -328,7 +328,7 @@ export function agentCheckpointRoutes(deps: AgentCheckpointRouteDeps) {
             agent_id: agentId,
             job_id: latestJob?.id ?? null,
             event_type: "rollback",
-            details: {
+            payload: {
               checkpoint_id: checkpointId,
               restored_by: principal.userId,
               restore_context: restoreContext ?? false,

--- a/packages/control-plane/src/routes/agents.ts
+++ b/packages/control-plane/src/routes/agents.ts
@@ -291,7 +291,7 @@ export function agentRoutes(deps: AgentRouteDeps) {
           if (new Date(e.created_at).getTime() >= todayStart.getTime()) {
             totalToday += cost
           }
-          const detailModel = e.details?.model
+          const detailModel = e.payload?.model
           const model = typeof detailModel === "string" ? detailModel : "unknown"
           if (cost > 0) {
             byModel[model] = (byModel[model] ?? 0) + cost
@@ -306,7 +306,7 @@ export function agentRoutes(deps: AgentRouteDeps) {
           if (t === "error" || t === "tool_error" || t === "llm_error") {
             consecutiveFailures++
             if (!tripReason) {
-              const reason = e.details?.reason
+              const reason = e.payload?.reason
               tripReason = typeof reason === "string" ? reason : t
             }
           } else {


### PR DESCRIPTION
## Summary
- Add migration `025_operator_visibility` with `agent_event_type` enum (18 event types), enriched `agent_event` table (session_id, parent_event_id, payload, tokens_in/out, duration_ms, model, tool_ref, actor), cost/delegation columns on `job` and `session` tables, and required indexes.
- Update Kysely types in `db/types.ts` to match the new schema including `AgentEventType`, `AgentEventTable`, `JobTable`, and `SessionTable`.
- Rename `details` → `payload` on `agent_event` across all source and test files.

Closes #321

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `npx eslint` passes on changed files
- [x] `npx vitest run` — 79 test files, 1340 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced operator visibility with comprehensive event tracking including token usage, execution duration, and cost metrics
  * Added session-level aggregation for total tokens and costs
  * Enriched job tracking with delegation depth, call counts, and hierarchical relationships

<!-- end of auto-generated comment: release notes by coderabbit.ai -->