### PR TITLE
feat(routes): kill switch — immediate agent execution cancellation (#326)

### DIFF
--- a/packages/control-plane/src/__tests__/agent-control-kill.test.ts
+++ b/packages/control-plane/src/__tests__/agent-control-kill.test.ts
@@ -1,0 +1,318 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/unbound-method */
+import Fastify from "fastify"
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import type { Database } from "../db/types.js"
+import type { AuthConfig } from "../middleware/types.js"
+import type { AgentEventEmitter } from "../observability/event-emitter.js"
+import { ExecutionRegistry } from "../observability/execution-registry.js"
+import { agentControlRoutes } from "../routes/agent-control.js"
+import type { SSEConnectionManager } from "../streaming/manager.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEV_AUTH_CONFIG: AuthConfig = {
+  requireAuth: false,
+  apiKeys: [],
+}
+
+const AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+const JOB_ID = "job-11111111-2222-3333-4444-555555555555"
+
+function makeMockDb(
+  opts: {
+    agentExists?: boolean
+    agentStatus?: string
+    runningJobId?: string | null
+  } = {},
+) {
+  const { agentExists = true, agentStatus = "ACTIVE", runningJobId = null } = opts
+
+  const agentRow = agentExists ? { id: AGENT_ID, status: agentStatus } : null
+  const jobRow = runningJobId ? { id: runningJobId } : null
+
+  const updateExecute = vi.fn().mockResolvedValue([])
+
+  const db = {
+    selectFrom: vi.fn().mockImplementation((table: string) => {
+      if (table === "agent") {
+        return {
+          select: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              executeTakeFirst: vi.fn().mockResolvedValue(agentRow),
+            }),
+          }),
+          selectAll: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              executeTakeFirst: vi.fn().mockResolvedValue(agentRow),
+            }),
+          }),
+        }
+      }
+      if (table === "job") {
+        return {
+          select: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                executeTakeFirst: vi.fn().mockResolvedValue(jobRow),
+              }),
+            }),
+          }),
+        }
+      }
+      return {
+        select: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            executeTakeFirst: vi.fn().mockResolvedValue(null),
+          }),
+        }),
+      }
+    }),
+
+    updateTable: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            execute: updateExecute,
+          }),
+          execute: updateExecute,
+        }),
+      }),
+    }),
+
+    insertInto: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockReturnValue({
+          executeTakeFirstOrThrow: vi.fn().mockResolvedValue({ id: "event-1" }),
+        }),
+      }),
+    }),
+  } as unknown as Kysely<Database>
+
+  return { db, updateExecute }
+}
+
+function makeMockEventEmitter() {
+  return {
+    emit: vi.fn().mockResolvedValue("event-1"),
+    emitStart: vi.fn(),
+  } as unknown as AgentEventEmitter
+}
+
+function makeMockSseManager() {
+  return {
+    broadcast: vi.fn().mockReturnValue({ id: "sse-1", event: "agent:killed", data: "{}" }),
+  } as unknown as SSEConnectionManager
+}
+
+async function buildTestApp(
+  opts: {
+    agentExists?: boolean
+    agentStatus?: string
+    runningJobId?: string | null
+    executionRegistry?: ExecutionRegistry
+    eventEmitter?: AgentEventEmitter
+    sseManager?: SSEConnectionManager
+  } = {},
+) {
+  const { agentExists = true, agentStatus = "ACTIVE", runningJobId = null } = opts
+
+  const app = Fastify({ logger: false })
+  const { db, updateExecute } = makeMockDb({ agentExists, agentStatus, runningJobId })
+  const executionRegistry = opts.executionRegistry ?? new ExecutionRegistry()
+  const eventEmitter = opts.eventEmitter ?? makeMockEventEmitter()
+  const sseManager = opts.sseManager ?? makeMockSseManager()
+
+  await app.register(
+    agentControlRoutes({
+      db,
+      authConfig: DEV_AUTH_CONFIG,
+      executionRegistry,
+      eventEmitter,
+      sseManager,
+    }),
+  )
+
+  return { app, db, updateExecute, executionRegistry, eventEmitter, sseManager }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/kill
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/kill", () => {
+  it("kills an idle agent (no running job) — agent quarantined", async () => {
+    const { app, updateExecute } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/kill`,
+      payload: { reason: "Emergency shutdown" },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.agentId).toBe(AGENT_ID)
+    expect(body.previousState).toBe("ACTIVE")
+    expect(body.cancelledJobId).toBeNull()
+    expect(body.state).toBe("QUARANTINED")
+    expect(body.killedAt).toBeDefined()
+    expect(updateExecute).toHaveBeenCalled()
+  })
+
+  it("kills an executing agent — running job cancelled, agent quarantined", async () => {
+    const registry = new ExecutionRegistry()
+    const cancelFn = vi.fn().mockResolvedValue(undefined)
+    registry.register(JOB_ID, {
+      taskId: JOB_ID,
+      cancel: cancelFn,
+      events: () => (async function* () {})(),
+      result: () => Promise.resolve({} as never),
+    })
+
+    const { app } = await buildTestApp({
+      runningJobId: JOB_ID,
+      executionRegistry: registry,
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/kill`,
+      payload: { reason: "Cost overrun" },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.agentId).toBe(AGENT_ID)
+    expect(body.previousState).toBe("ACTIVE")
+    expect(body.cancelledJobId).toBe(JOB_ID)
+    expect(body.state).toBe("QUARANTINED")
+    expect(cancelFn).toHaveBeenCalledWith("Cost overrun")
+  })
+
+  it("returns 409 when agent is already quarantined", async () => {
+    const { app } = await buildTestApp({ agentStatus: "QUARANTINED" })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/kill`,
+      payload: { reason: "test" },
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(res.json().error).toBe("conflict")
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const { app } = await buildTestApp({ agentExists: false })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/kill`,
+      payload: { reason: "test" },
+    })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.json().error).toBe("not_found")
+  })
+
+  it("returns 400 when reason is missing", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/kill`,
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+
+  it("emits kill_requested event to agent_event", async () => {
+    const eventEmitter = makeMockEventEmitter()
+    const { app } = await buildTestApp({ eventEmitter })
+
+    await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/kill`,
+      payload: { reason: "Operator intervention" },
+    })
+
+    expect(eventEmitter.emit).toHaveBeenCalledWith({
+      agentId: AGENT_ID,
+      jobId: null,
+      eventType: "kill_requested",
+      payload: { reason: "Operator intervention", cancelledJobId: null },
+    })
+  })
+
+  it("emits kill_requested event with cancelledJobId when job was running", async () => {
+    const eventEmitter = makeMockEventEmitter()
+    const { app } = await buildTestApp({
+      runningJobId: JOB_ID,
+      eventEmitter,
+    })
+
+    await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/kill`,
+      payload: { reason: "Cost overrun" },
+    })
+
+    expect(eventEmitter.emit).toHaveBeenCalledWith({
+      agentId: AGENT_ID,
+      jobId: JOB_ID,
+      eventType: "kill_requested",
+      payload: { reason: "Cost overrun", cancelledJobId: JOB_ID },
+    })
+  })
+
+  it("broadcasts agent:killed SSE event to connected clients", async () => {
+    const sseManager = makeMockSseManager()
+    const { app } = await buildTestApp({ sseManager })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/kill`,
+      payload: { reason: "Manual kill" },
+    })
+
+    const body = res.json()
+    expect(sseManager.broadcast).toHaveBeenCalledWith(AGENT_ID, "agent:killed", {
+      agentId: AGENT_ID,
+      previousState: "ACTIVE",
+      cancelledJobId: null,
+      state: "QUARANTINED",
+      reason: "Manual kill",
+      killedAt: body.killedAt,
+    })
+  })
+
+  it("cancels in-flight execution via ExecutionRegistry", async () => {
+    const registry = new ExecutionRegistry()
+    const cancelFn = vi.fn().mockResolvedValue(undefined)
+    registry.register(JOB_ID, {
+      taskId: JOB_ID,
+      cancel: cancelFn,
+      events: () => (async function* () {})(),
+      result: () => Promise.resolve({} as never),
+    })
+
+    const { app } = await buildTestApp({
+      runningJobId: JOB_ID,
+      executionRegistry: registry,
+    })
+
+    await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/kill`,
+      payload: { reason: "Abort" },
+    })
+
+    expect(cancelFn).toHaveBeenCalledWith("Abort")
+    expect(registry.size).toBe(1) // registry.cancel doesn't unregister
+  })
+})

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -207,13 +207,16 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
     }),
   )
 
-  // Register agent control routes (dry run, etc.)
+  // Register agent control routes (dry run, kill switch, etc.)
   await app.register(
     agentControlRoutes({
       db,
       authConfig,
       sessionService,
       mcpToolRouter,
+      executionRegistry,
+      eventEmitter,
+      sseManager,
     }),
   )
 

--- a/packages/control-plane/src/routes/agent-control.ts
+++ b/packages/control-plane/src/routes/agent-control.ts
@@ -2,6 +2,7 @@
  * Agent Control Routes
  *
  * POST /agents/:agentId/dry-run — simulate an agent turn without tool execution
+ * POST /agents/:agentId/kill    — immediate execution cancellation (kill switch)
  */
 
 import Anthropic from "@anthropic-ai/sdk"
@@ -25,6 +26,9 @@ import {
   loadConversationContext,
   type PlannedAction,
 } from "../observability/dry-run.js"
+import type { AgentEventEmitter } from "../observability/event-emitter.js"
+import type { ExecutionRegistry } from "../observability/execution-registry.js"
+import type { SSEConnectionManager } from "../streaming/manager.js"
 
 // ---------------------------------------------------------------------------
 // Route types
@@ -40,6 +44,14 @@ interface DryRunBody {
   maxTurns?: number
 }
 
+interface KillParams {
+  agentId: string
+}
+
+interface KillBody {
+  reason: string
+}
+
 // ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
@@ -49,10 +61,21 @@ export interface AgentControlRouteDeps {
   authConfig: AuthConfig
   sessionService?: SessionService
   mcpToolRouter?: McpToolRouter
+  executionRegistry?: ExecutionRegistry
+  eventEmitter?: AgentEventEmitter
+  sseManager?: SSEConnectionManager
 }
 
 export function agentControlRoutes(deps: AgentControlRouteDeps) {
-  const { db, authConfig, sessionService, mcpToolRouter } = deps
+  const {
+    db,
+    authConfig,
+    sessionService,
+    mcpToolRouter,
+    executionRegistry,
+    eventEmitter,
+    sseManager,
+  } = deps
 
   const authOpts: AuthMiddlewareOptions = { config: authConfig, sessionService }
   const requireAuth: PreHandler = createRequireAuth(authOpts)
@@ -216,6 +239,128 @@ export function agentControlRoutes(deps: AgentControlRouteDeps) {
             message: `Dry run LLM call failed: ${errorMsg}`,
           })
         }
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // POST /agents/:agentId/kill — immediate execution cancellation
+    // Requires: auth + operator role
+    // -----------------------------------------------------------------
+    app.post<{ Params: KillParams; Body: KillBody }>(
+      "/agents/:agentId/kill",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              reason: { type: "string", minLength: 1, maxLength: 1000 },
+            },
+            required: ["reason"],
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: KillParams; Body: KillBody }>,
+        reply: FastifyReply,
+      ) => {
+        const { agentId } = request.params
+        const { reason } = request.body
+
+        // Check agent exists in DB
+        const agent = await db
+          .selectFrom("agent")
+          .select(["id", "status"])
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          return reply.status(404).send({ error: "not_found", message: "Agent not found" })
+        }
+
+        if (agent.status === "QUARANTINED") {
+          return reply.status(409).send({
+            error: "conflict",
+            message: "Agent is already quarantined",
+          })
+        }
+
+        const previousState = agent.status
+
+        // Look up the agent's current running job
+        const runningJob = await db
+          .selectFrom("job")
+          .select(["id"])
+          .where("agent_id", "=", agentId)
+          .where("status", "=", "RUNNING")
+          .executeTakeFirst()
+
+        let cancelledJobId: string | null = null
+
+        if (runningJob) {
+          cancelledJobId = runningJob.id
+
+          // Cancel in-flight execution via AbortController
+          if (executionRegistry) {
+            await executionRegistry.cancel(runningJob.id, reason)
+          }
+
+          // Transition job to FAILED with operator_kill category
+          await db
+            .updateTable("job")
+            .set({
+              status: "FAILED",
+              error: { category: "operator_kill", message: reason },
+              completed_at: new Date(),
+            })
+            .where("id", "=", runningJob.id)
+            .where("status", "=", "RUNNING")
+            .execute()
+        }
+
+        // Transition agent to QUARANTINED
+        await db
+          .updateTable("agent")
+          .set({ status: "QUARANTINED" })
+          .where("id", "=", agentId)
+          .execute()
+
+        const killedAt = new Date().toISOString()
+
+        // Emit kill_requested event to agent_event
+        if (eventEmitter) {
+          await eventEmitter.emit({
+            agentId,
+            jobId: cancelledJobId,
+            eventType: "kill_requested",
+            payload: { reason, cancelledJobId },
+          })
+        }
+
+        // Broadcast agent:killed SSE event to connected clients
+        if (sseManager) {
+          sseManager.broadcast(agentId, "agent:killed", {
+            agentId,
+            previousState,
+            cancelledJobId,
+            state: "QUARANTINED",
+            reason,
+            killedAt,
+          })
+        }
+
+        return reply.status(200).send({
+          agentId,
+          previousState,
+          cancelledJobId,
+          state: "QUARANTINED",
+          killedAt,
+        })
       },
     )
   }

--- a/packages/control-plane/src/streaming/types.ts
+++ b/packages/control-plane/src/streaming/types.ts
@@ -17,6 +17,7 @@ export type SSEEventType =
   | "agent:state"
   | "agent:error"
   | "agent:complete"
+  | "agent:killed"
   | "steer:ack"
   | "steer:injected"
   | "steer:acknowledged"


### PR DESCRIPTION
## Summary
- Add `POST /agents/:agentId/kill` endpoint to `agent-control.ts` for immediate agent execution cancellation
- On kill: cancels running job via `ExecutionRegistry.cancel()` (triggers `AbortController.abort()`), transitions job to `FAILED` with `operator_kill` category, transitions agent to `QUARANTINED`
- Persists `kill_requested` event to `agent_event` table and broadcasts `agent:killed` SSE event to connected clients
- Add `agent:killed` to `SSEEventType` union

## Test plan
- [x] Kill on executing agent: running job cancelled, agent quarantined (200)
- [x] Kill on idle agent (no running job): agent quarantined, no job cancelled (200)
- [x] Kill on already-quarantined agent: 409 Conflict
- [x] 404 when agent not found
- [x] 400 when reason missing
- [x] `kill_requested` event emitted (with and without running job)
- [x] `agent:killed` SSE broadcast sent
- [x] `ExecutionRegistry.cancel()` called with correct reason
- [x] Full test suite passes (82 files, 1375 tests)
- [x] Lint clean, typecheck clean

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added POST /agents/:agentId/kill endpoint to quarantine agents, with proper validation and error handling.
  * Implemented cancellation of running jobs when killing executing agents.
  * Added real-time SSE broadcasts for agent kill events with detailed payload information.
  * New kill_requested event emissions for agent state tracking.

* **Tests**
  * Added comprehensive test suite for agent kill endpoint covering idle agents, executing agents, error cases, and event emissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->