### PR TITLE
feat(routes): replay — re-run from checkpoint with modifications (#328)

### DIFF
--- a/packages/control-plane/src/__tests__/agent-control-replay.test.ts
+++ b/packages/control-plane/src/__tests__/agent-control-replay.test.ts
@@ -1,0 +1,344 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/unbound-method */
+import Fastify from "fastify"
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import type { Database } from "../db/types.js"
+import type { AuthConfig } from "../middleware/types.js"
+import type { AgentEventEmitter } from "../observability/event-emitter.js"
+import { agentControlRoutes } from "../routes/agent-control.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEV_AUTH_CONFIG: AuthConfig = {
+  requireAuth: false,
+  apiKeys: [],
+}
+
+const AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+const CHECKPOINT_ID = "cccccccc-1111-2222-3333-444444444444"
+const VALID_STATE = { hello: "world" }
+const VALID_CRC = 3624485329
+
+function makeMockDb(
+  opts: {
+    agentExists?: boolean
+    agentStatus?: string
+    checkpointExists?: boolean
+    checkpointCrc?: number
+    checkpointState?: Record<string, unknown>
+  } = {},
+) {
+  const {
+    agentExists = true,
+    agentStatus = "ACTIVE",
+    checkpointExists = true,
+    checkpointCrc = VALID_CRC,
+    checkpointState = VALID_STATE,
+  } = opts
+
+  const agentRow = agentExists ? { id: AGENT_ID, status: agentStatus } : null
+  const checkpointRow = checkpointExists
+    ? {
+        id: CHECKPOINT_ID,
+        agent_id: AGENT_ID,
+        job_id: "job-old",
+        label: "v1",
+        state: checkpointState,
+        state_crc: checkpointCrc,
+        context_snapshot: null,
+        created_at: new Date("2026-01-01T00:00:00Z"),
+        created_by: "dev-user",
+      }
+    : null
+
+  const insertedJob = {
+    id: "job-replay-1",
+    agent_id: AGENT_ID,
+    session_id: null,
+    status: "CREATED",
+    payload: {},
+    priority: 0,
+    timeout_seconds: 300,
+    max_attempts: 1,
+    attempt: 0,
+    created_at: new Date(),
+    updated_at: new Date(),
+  }
+
+  const updateExecute = vi.fn().mockResolvedValue([])
+
+  const db = {
+    selectFrom: vi.fn().mockImplementation((table: string) => {
+      if (table === "agent") {
+        return {
+          select: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              executeTakeFirst: vi.fn().mockResolvedValue(agentRow),
+            }),
+          }),
+          selectAll: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              executeTakeFirst: vi.fn().mockResolvedValue(agentRow),
+            }),
+          }),
+        }
+      }
+      if (table === "agent_checkpoint") {
+        return {
+          selectAll: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                executeTakeFirst: vi.fn().mockResolvedValue(checkpointRow),
+              }),
+            }),
+          }),
+        }
+      }
+      if (table === "job") {
+        return {
+          select: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                executeTakeFirst: vi.fn().mockResolvedValue(null),
+              }),
+            }),
+          }),
+        }
+      }
+      return {
+        select: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            executeTakeFirst: vi.fn().mockResolvedValue(null),
+          }),
+        }),
+      }
+    }),
+
+    insertInto: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returningAll: vi.fn().mockReturnValue({
+          executeTakeFirstOrThrow: vi.fn().mockResolvedValue(insertedJob),
+        }),
+      }),
+    }),
+
+    updateTable: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            execute: updateExecute,
+          }),
+          execute: updateExecute,
+        }),
+      }),
+    }),
+  } as unknown as Kysely<Database>
+
+  return { db, updateExecute, insertedJob }
+}
+
+function makeMockEventEmitter() {
+  return {
+    emit: vi.fn().mockResolvedValue("event-1"),
+    emitStart: vi.fn(),
+  } as unknown as AgentEventEmitter
+}
+
+async function buildTestApp(
+  opts: {
+    agentExists?: boolean
+    agentStatus?: string
+    checkpointExists?: boolean
+    checkpointCrc?: number
+    checkpointState?: Record<string, unknown>
+    enqueueJob?: (jobId: string) => Promise<void>
+    eventEmitter?: AgentEventEmitter
+  } = {},
+) {
+  const app = Fastify({ logger: false })
+  const { db, updateExecute, insertedJob } = makeMockDb(opts)
+  const enqueueJob = opts.enqueueJob ?? vi.fn().mockResolvedValue(undefined)
+  const eventEmitter = opts.eventEmitter ?? makeMockEventEmitter()
+
+  await app.register(
+    agentControlRoutes({
+      db,
+      authConfig: DEV_AUTH_CONFIG,
+      enqueueJob,
+      eventEmitter,
+    }),
+  )
+
+  return { app, db, updateExecute, enqueueJob, eventEmitter, insertedJob }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/replay
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/replay", () => {
+  it("creates a replay job from a valid checkpoint — returns 202", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/replay`,
+      payload: { checkpointId: CHECKPOINT_ID },
+    })
+
+    expect(res.statusCode).toBe(202)
+    const body = res.json()
+    expect(body.replayJobId).toBeDefined()
+    expect(body.fromCheckpoint).toBe(CHECKPOINT_ID)
+    expect(body.modifications).toBeNull()
+  })
+
+  it("passes modifications through to the response", async () => {
+    const { app } = await buildTestApp()
+
+    const modifications = {
+      model: "claude-opus-4-20250514",
+      systemPromptAppend: "Be extra verbose.",
+    }
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/replay`,
+      payload: { checkpointId: CHECKPOINT_ID, modifications },
+    })
+
+    expect(res.statusCode).toBe(202)
+    const body = res.json()
+    expect(body.modifications).toEqual(modifications)
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const { app } = await buildTestApp({ agentExists: false })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/replay`,
+      payload: { checkpointId: CHECKPOINT_ID },
+    })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.json().error).toBe("not_found")
+    expect(res.json().message).toBe("Agent not found")
+  })
+
+  it("returns 404 when checkpoint does not exist", async () => {
+    const { app } = await buildTestApp({ checkpointExists: false })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/replay`,
+      payload: { checkpointId: CHECKPOINT_ID },
+    })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.json().error).toBe("not_found")
+    expect(res.json().message).toBe("Checkpoint not found")
+  })
+
+  it("returns 409 when checkpoint CRC is corrupted", async () => {
+    const { app } = await buildTestApp({ checkpointCrc: 12345 })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/replay`,
+      payload: { checkpointId: CHECKPOINT_ID },
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(res.json().error).toBe("conflict")
+    expect(res.json().message).toContain("CRC mismatch")
+  })
+
+  it("returns 400 when checkpointId is missing", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/replay`,
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+
+  it("inserts a job with REPLAY type and checkpoint state", async () => {
+    const { app, db } = await buildTestApp()
+
+    await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/replay`,
+      payload: { checkpointId: CHECKPOINT_ID },
+    })
+
+    expect(db.insertInto).toHaveBeenCalledWith("job")
+    const insertCall = vi.mocked(db.insertInto).mock.results[0]?.value as {
+      values: ReturnType<typeof vi.fn>
+    }
+    const valuesArg = insertCall.values.mock.calls[0][0] as Record<string, unknown>
+    expect(valuesArg.agent_id).toBe(AGENT_ID)
+    expect(valuesArg.checkpoint).toEqual(VALID_STATE)
+    expect(valuesArg.checkpoint_crc).toBe(VALID_CRC)
+    const payload = valuesArg.payload as Record<string, unknown>
+    expect(payload.type).toBe("REPLAY")
+    expect(payload.replay_source_checkpoint_id).toBe(CHECKPOINT_ID)
+  })
+
+  it("enqueues the job via Graphile Worker", async () => {
+    const enqueueJob = vi.fn().mockResolvedValue(undefined)
+    const { app } = await buildTestApp({ enqueueJob })
+
+    await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/replay`,
+      payload: { checkpointId: CHECKPOINT_ID },
+    })
+
+    expect(enqueueJob).toHaveBeenCalledTimes(1)
+  })
+
+  it("emits replay_initiated event", async () => {
+    const eventEmitter = makeMockEventEmitter()
+    const { app } = await buildTestApp({ eventEmitter })
+
+    await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/replay`,
+      payload: {
+        checkpointId: CHECKPOINT_ID,
+        modifications: { model: "claude-opus-4-20250514" },
+      },
+    })
+
+    expect(eventEmitter.emit).toHaveBeenCalledTimes(1)
+    const emitArg = vi.mocked(eventEmitter.emit).mock.calls[0]![0] as Record<string, unknown>
+    expect(emitArg.agentId).toBe(AGENT_ID)
+    expect(emitArg.eventType).toBe("replay_initiated")
+    expect(typeof emitArg.jobId).toBe("string")
+    const emitPayload = emitArg.payload as Record<string, unknown>
+    expect(emitPayload.replay_source_checkpoint_id).toBe(CHECKPOINT_ID)
+    expect(emitPayload.modifications).toEqual({ model: "claude-opus-4-20250514" })
+  })
+
+  it("handles enqueueJob failure gracefully — job still created", async () => {
+    const enqueueJob = vi.fn().mockRejectedValue(new Error("Worker unavailable"))
+    const { app } = await buildTestApp({ enqueueJob })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/replay`,
+      payload: { checkpointId: CHECKPOINT_ID },
+    })
+
+    // Should still succeed — job is in DB as SCHEDULED
+    expect(res.statusCode).toBe(202)
+    expect(enqueueJob).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -212,6 +212,9 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
     agentControlRoutes({
       db,
       authConfig,
+      enqueueJob: async (jobId: string) => {
+        await workerUtils.addJob("agent_execute", { jobId }, { jobKey: `exec:${jobId}` })
+      },
       sessionService,
       mcpToolRouter,
       executionRegistry,

--- a/packages/control-plane/src/routes/agent-control.ts
+++ b/packages/control-plane/src/routes/agent-control.ts
@@ -3,15 +3,20 @@
  *
  * POST /agents/:agentId/dry-run — simulate an agent turn without tool execution
  * POST /agents/:agentId/kill    — immediate execution cancellation (kill switch)
+ * POST /agents/:agentId/replay  — re-run from checkpoint with modifications
  */
 
+import { randomUUID } from "node:crypto"
+
 import Anthropic from "@anthropic-ai/sdk"
+import type { JobStatus } from "@cortex/shared"
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
 import type { Kysely } from "kysely"
 
 import type { SessionService } from "../auth/session-service.js"
 import { createAgentToolRegistry } from "../backends/tool-executor.js"
 import type { Database } from "../db/types.js"
+import { verifyCheckpointIntegrity } from "../lifecycle/output-validator.js"
 import type { McpToolRouter } from "../mcp/tool-router.js"
 import {
   type AuthMiddlewareOptions,
@@ -52,6 +57,19 @@ interface KillBody {
   reason: string
 }
 
+interface ReplayParams {
+  agentId: string
+}
+
+interface ReplayBody {
+  checkpointId: string
+  modifications?: {
+    model?: string
+    systemPromptAppend?: string
+    resourceLimits?: Record<string, unknown>
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
@@ -59,6 +77,7 @@ interface KillBody {
 export interface AgentControlRouteDeps {
   db: Kysely<Database>
   authConfig: AuthConfig
+  enqueueJob?: (jobId: string) => Promise<void>
   sessionService?: SessionService
   mcpToolRouter?: McpToolRouter
   executionRegistry?: ExecutionRegistry
@@ -70,6 +89,7 @@ export function agentControlRoutes(deps: AgentControlRouteDeps) {
   const {
     db,
     authConfig,
+    enqueueJob,
     sessionService,
     mcpToolRouter,
     executionRegistry,
@@ -80,6 +100,7 @@ export function agentControlRoutes(deps: AgentControlRouteDeps) {
   const authOpts: AuthMiddlewareOptions = { config: authConfig, sessionService }
   const requireAuth: PreHandler = createRequireAuth(authOpts)
   const requireOperator: PreHandler = createRequireRole("operator")
+  const requireAdmin: PreHandler = createRequireRole("admin")
 
   return function register(app: FastifyInstance): void {
     // -----------------------------------------------------------------
@@ -360,6 +381,140 @@ export function agentControlRoutes(deps: AgentControlRouteDeps) {
           cancelledJobId,
           state: "QUARANTINED",
           killedAt,
+        })
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // POST /agents/:agentId/replay — re-run from checkpoint
+    // Requires: auth + admin role
+    // -----------------------------------------------------------------
+    app.post<{ Params: ReplayParams; Body: ReplayBody }>(
+      "/agents/:agentId/replay",
+      {
+        preHandler: [requireAuth, requireAdmin],
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              checkpointId: { type: "string", minLength: 1 },
+              modifications: {
+                type: "object",
+                properties: {
+                  model: { type: "string" },
+                  systemPromptAppend: { type: "string" },
+                  resourceLimits: { type: "object" },
+                },
+              },
+            },
+            required: ["checkpointId"],
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: ReplayParams; Body: ReplayBody }>,
+        reply: FastifyReply,
+      ) => {
+        const { agentId } = request.params
+        const { checkpointId, modifications } = request.body
+
+        // Load agent
+        const agent = await db
+          .selectFrom("agent")
+          .select(["id", "status"])
+          .where("id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!agent) {
+          return reply.status(404).send({ error: "not_found", message: "Agent not found" })
+        }
+
+        // Load checkpoint (must belong to this agent)
+        const checkpoint = await db
+          .selectFrom("agent_checkpoint")
+          .selectAll()
+          .where("id", "=", checkpointId)
+          .where("agent_id", "=", agentId)
+          .executeTakeFirst()
+
+        if (!checkpoint) {
+          return reply.status(404).send({
+            error: "not_found",
+            message: "Checkpoint not found",
+          })
+        }
+
+        // Verify CRC32 integrity
+        if (!verifyCheckpointIntegrity(checkpoint.state, checkpoint.state_crc)) {
+          return reply.status(409).send({
+            error: "conflict",
+            message: "Checkpoint integrity check failed — CRC mismatch",
+          })
+        }
+
+        // Create replay job
+        const jobId = randomUUID()
+
+        const payload: Record<string, unknown> = {
+          type: "REPLAY",
+          replay_source_checkpoint_id: checkpointId,
+          ...(modifications ? { replay_modifications: modifications } : {}),
+        }
+
+        const job = await db
+          .insertInto("job")
+          .values({
+            id: jobId,
+            agent_id: agentId,
+            session_id: null,
+            payload,
+            checkpoint: checkpoint.state,
+            checkpoint_crc: checkpoint.state_crc,
+            priority: 0,
+            timeout_seconds: 300,
+            max_attempts: 1,
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow()
+
+        // Transition to SCHEDULED
+        await db
+          .updateTable("job")
+          .set({ status: "SCHEDULED" as JobStatus })
+          .where("id", "=", jobId)
+          .execute()
+
+        // Enqueue via Graphile Worker
+        if (enqueueJob) {
+          try {
+            await enqueueJob(jobId)
+          } catch {
+            // Job is in the DB as SCHEDULED — the worker cron will pick it up
+          }
+        }
+
+        // Emit replay_initiated event
+        if (eventEmitter) {
+          await eventEmitter.emit({
+            agentId,
+            jobId,
+            eventType: "replay_initiated",
+            payload: {
+              replay_source_checkpoint_id: checkpointId,
+              modifications: modifications ?? null,
+            },
+          })
+        }
+
+        return reply.status(202).send({
+          replayJobId: job.id,
+          fromCheckpoint: checkpointId,
+          modifications: modifications ?? null,
         })
       },
     )

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -757,6 +757,19 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
 
           // Emit session_end event with accumulated cost
           if (eventEmitter) {
+            const sessionEndPayload: Record<string, unknown> = {
+              status: jobStatus,
+              llmCalls: costSnapshot.llmCalls,
+              toolCalls: costSnapshot.toolCalls,
+              durationMs: result.durationMs,
+            }
+
+            // Tag replay events for tracing
+            if (typeof job.payload.replay_source_checkpoint_id === "string") {
+              sessionEndPayload.replay_source_checkpoint_id =
+                job.payload.replay_source_checkpoint_id
+            }
+
             await eventEmitter
               .emit({
                 eventType: "session_end",
@@ -766,12 +779,7 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                 tokensIn: costSnapshot.tokensIn,
                 tokensOut: costSnapshot.tokensOut,
                 costUsd: costSnapshot.costUsd,
-                payload: {
-                  status: jobStatus,
-                  llmCalls: costSnapshot.llmCalls,
-                  toolCalls: costSnapshot.toolCalls,
-                  durationMs: result.durationMs,
-                },
+                payload: sessionEndPayload,
               })
               .catch(() => {
                 // Non-fatal
@@ -979,7 +987,7 @@ function buildExecutionTask(
     }
   }
 
-  return {
+  const task: ExecutionTask = {
     id: job.id,
     jobId: job.id,
     agentId: agent.id,
@@ -1026,6 +1034,32 @@ function buildExecutionTask(
       shellAccess,
     },
   }
+
+  // Apply REPLAY modifications when present
+  if (
+    payload.type === "REPLAY" &&
+    typeof payload.replay_modifications === "object" &&
+    payload.replay_modifications !== null
+  ) {
+    const mods = payload.replay_modifications as Record<string, unknown>
+
+    if (typeof mods.model === "string") {
+      task.constraints.model = mods.model
+    }
+
+    if (typeof mods.systemPromptAppend === "string") {
+      task.context.systemPrompt += "\n" + mods.systemPromptAppend
+    }
+
+    if (typeof mods.resourceLimits === "object" && mods.resourceLimits !== null) {
+      const rl = mods.resourceLimits as Record<string, unknown>
+      if (typeof rl.maxTokens === "number") task.constraints.maxTokens = rl.maxTokens
+      if (typeof rl.maxTurns === "number") task.constraints.maxTurns = rl.maxTurns
+      if (typeof rl.timeoutMs === "number") task.constraints.timeoutMs = rl.timeoutMs
+    }
+  }
+
+  return task
 }
 
 // ── Helper: check approval gate ──


### PR DESCRIPTION
## Summary
- Add `POST /agents/:agentId/replay` route to `agent-control.ts` — loads checkpoint, validates CRC32, creates REPLAY job with checkpoint state, enqueues via Graphile Worker
- Handle REPLAY job type in `agent-execute.ts` — applies model override, system prompt append, and resource limit modifications from replay payload
- Tag replay execution events with `replay_source_checkpoint_id` for audit tracing
- Wire `enqueueJob` into agent-control route deps in `app.ts`
- 10 tests covering: happy path, modifications passthrough, 404/409 error cases, CRC corruption, job insertion, enqueue, event emission, graceful enqueue failure

Closes #328

## Test plan
- [x] `npx vitest run` — 1385 tests pass (83 files)
- [x] `npx eslint` — no new errors (only pre-existing turbo warnings)
- [x] `npm run typecheck` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced agent replay from checkpoints: re-run agent execution from a saved checkpoint with optional modifications to model, system prompt configuration, and resource limits
  * Replay operations create jobs that are tracked and enqueued for background processing with event notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->