### PR TITLE
feat(auth): ChannelAuthGuard service (#335)

### DIFF
--- a/packages/control-plane/src/auth/__tests__/channel-auth-guard.test.ts
+++ b/packages/control-plane/src/auth/__tests__/channel-auth-guard.test.ts
@@ -1,0 +1,623 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import type {
+  Agent,
+  AgentUserGrant,
+  ChannelMapping,
+  Database,
+  UserAccount,
+} from "../../db/types.js"
+import type { AccessRequestService } from "../access-request-service.js"
+import { ChannelAuthGuard } from "../channel-auth-guard.js"
+import type { PairingService, RedeemResult } from "../pairing-service.js"
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const AGENT_ID = "aaaaaaaa-1111-2222-3333-444444444444"
+const USER_ID = "bbbbbbbb-1111-2222-3333-444444444444"
+const GRANT_ID = "cccccccc-1111-2222-3333-444444444444"
+const CHANNEL_MAPPING_ID = "dddddddd-1111-2222-3333-444444444444"
+const BINDING_ID = "eeeeeeee-1111-2222-3333-444444444444"
+const ACCESS_REQUEST_ID = "ffffffff-1111-2222-3333-444444444444"
+
+const now = new Date()
+const pastDate = new Date(Date.now() - 3_600_000)
+
+// ---------------------------------------------------------------------------
+// Row factories
+// ---------------------------------------------------------------------------
+
+function makeAgent(
+  overrides: Partial<Agent> = {},
+): Pick<Agent, "id" | "auth_model" | "channel_permissions"> {
+  return {
+    id: AGENT_ID,
+    auth_model: "allowlist",
+    channel_permissions: {},
+    ...overrides,
+  }
+}
+
+function makeGrant(overrides: Partial<AgentUserGrant> = {}): AgentUserGrant {
+  return {
+    id: GRANT_ID,
+    agent_id: AGENT_ID,
+    user_account_id: USER_ID,
+    access_level: "write",
+    origin: "pairing_code",
+    granted_by: null,
+    rate_limit: null,
+    token_budget: null,
+    expires_at: null,
+    revoked_at: null,
+    created_at: now,
+    ...overrides,
+  }
+}
+
+function makeChannelMapping(
+  overrides: Partial<ChannelMapping> = {},
+): Pick<ChannelMapping, "id" | "user_account_id"> {
+  return {
+    id: CHANNEL_MAPPING_ID,
+    user_account_id: USER_ID,
+    ...overrides,
+  }
+}
+
+function makeUserAccount(overrides: Partial<UserAccount> = {}): UserAccount {
+  return {
+    id: USER_ID,
+    display_name: null,
+    email: null,
+    avatar_url: null,
+    role: "operator",
+    oauth_provider: null,
+    oauth_provider_id: null,
+    encryption_key_enc: null,
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Chainable Kysely mock helpers
+// ---------------------------------------------------------------------------
+
+function mockSelectChain(result: unknown) {
+  const executeTakeFirst = vi.fn().mockResolvedValue(result)
+  const execute = vi
+    .fn()
+    .mockResolvedValue(Array.isArray(result) ? result : result == null ? [] : [result])
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  const orderByFn: ReturnType<typeof vi.fn> = vi.fn()
+  const selectAllFn = vi.fn()
+  const selectFn = vi.fn()
+  const chain = {
+    where: whereFn,
+    orderBy: orderByFn,
+    selectAll: selectAllFn,
+    select: selectFn,
+    executeTakeFirst,
+    execute,
+  }
+  whereFn.mockReturnValue(chain)
+  orderByFn.mockReturnValue(chain)
+  selectAllFn.mockReturnValue(chain)
+  selectFn.mockReturnValue(chain)
+  return chain
+}
+
+function mockInsertChain(result: unknown) {
+  const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(result)
+  const valuesFn = vi.fn()
+  const returningAllFn = vi.fn()
+  const chain = { values: valuesFn, returningAll: returningAllFn, executeTakeFirstOrThrow }
+  valuesFn.mockReturnValue(chain)
+  returningAllFn.mockReturnValue(chain)
+  return chain
+}
+
+// ---------------------------------------------------------------------------
+// Service mock factories
+// ---------------------------------------------------------------------------
+
+function makePairingService(overrides: Partial<PairingService> = {}): PairingService {
+  return {
+    generate: vi.fn(),
+    redeem: vi
+      .fn()
+      .mockResolvedValue({ success: true, message: "Pairing code redeemed", grantId: GRANT_ID }),
+    listActive: vi.fn(),
+    revoke: vi.fn(),
+    ...overrides,
+  } as unknown as PairingService
+}
+
+function makeAccessRequestService(
+  overrides: Partial<AccessRequestService> = {},
+): AccessRequestService {
+  return {
+    create: vi.fn().mockResolvedValue({
+      id: ACCESS_REQUEST_ID,
+      agent_id: AGENT_ID,
+      user_account_id: USER_ID,
+      channel_mapping_id: CHANNEL_MAPPING_ID,
+      status: "pending",
+      message_preview: null,
+      reviewed_by: null,
+      reviewed_at: null,
+      deny_reason: null,
+      created_at: now,
+    }),
+    approve: vi.fn(),
+    deny: vi.fn(),
+    listPending: vi.fn(),
+    pendingCounts: vi.fn(),
+    ...overrides,
+  } as unknown as AccessRequestService
+}
+
+// ---------------------------------------------------------------------------
+// DB mock builder
+// ---------------------------------------------------------------------------
+
+interface MockDbOpts {
+  channelMapping?: Pick<ChannelMapping, "id" | "user_account_id"> | null
+  agent?: Pick<Agent, "id" | "auth_model" | "channel_permissions"> | null
+  grant?: AgentUserGrant | null
+  binding?: { id: string } | null
+  newUser?: UserAccount
+  newMapping?: ChannelMapping
+  newGrant?: AgentUserGrant
+}
+
+function buildMockDb(opts: MockDbOpts = {}) {
+  const {
+    channelMapping = makeChannelMapping(),
+    agent = makeAgent(),
+    grant = null,
+    binding = null,
+    newUser = makeUserAccount(),
+    newMapping,
+    newGrant = makeGrant(),
+  } = opts
+
+  const selectFromCalls: string[] = []
+
+  const db = {
+    selectFrom: vi.fn().mockImplementation((table: string) => {
+      selectFromCalls.push(table)
+
+      if (table === "channel_mapping") {
+        return mockSelectChain(channelMapping)
+      }
+      if (table === "agent") {
+        return mockSelectChain(agent)
+      }
+      if (table === "agent_user_grant") {
+        return mockSelectChain(grant)
+      }
+      if (table === "agent_channel_binding") {
+        return mockSelectChain(binding)
+      }
+      return mockSelectChain(null)
+    }),
+
+    insertInto: vi.fn().mockImplementation((table: string) => {
+      if (table === "user_account") {
+        return mockInsertChain(newUser)
+      }
+      if (table === "channel_mapping") {
+        return mockInsertChain(
+          newMapping ?? {
+            id: CHANNEL_MAPPING_ID,
+            user_account_id: newUser.id,
+            channel_type: "telegram",
+            channel_user_id: "tg-12345",
+            metadata: null,
+            created_at: now,
+          },
+        )
+      }
+      if (table === "agent_user_grant") {
+        return mockInsertChain(newGrant)
+      }
+      return mockInsertChain(null)
+    }),
+  } as unknown as Kysely<Database>
+
+  return { db, selectFromCalls }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ChannelAuthGuard", () => {
+  const baseParams = {
+    agentId: AGENT_ID,
+    channelType: "telegram",
+    channelUserId: "tg-12345",
+    chatId: "chat-001",
+  }
+
+  // -----------------------------------------------------------------------
+  // resolveOrCreateIdentity
+  // -----------------------------------------------------------------------
+  describe("resolveOrCreateIdentity", () => {
+    it("returns existing identity when channel_mapping exists", async () => {
+      const { db } = buildMockDb()
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const result = await guard.resolveOrCreateIdentity("telegram", "tg-12345")
+
+      expect(result).toEqual({
+        userAccountId: USER_ID,
+        channelMappingId: CHANNEL_MAPPING_ID,
+      })
+      expect(db.selectFrom).toHaveBeenCalledWith("channel_mapping")
+      expect(db.insertInto).not.toHaveBeenCalled()
+    })
+
+    it("creates new user_account + channel_mapping for unknown user", async () => {
+      const { db } = buildMockDb({ channelMapping: null })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const result = await guard.resolveOrCreateIdentity("telegram", "tg-new-user", "Alice")
+
+      expect(result.userAccountId).toBe(USER_ID)
+      expect(result.channelMappingId).toBe(CHANNEL_MAPPING_ID)
+      expect(db.insertInto).toHaveBeenCalledWith("user_account")
+      expect(db.insertInto).toHaveBeenCalledWith("channel_mapping")
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // authorize — allowlist
+  // -----------------------------------------------------------------------
+  describe("authorize — allowlist", () => {
+    it("allows when a valid grant exists", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "allowlist" }),
+        grant: makeGrant(),
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.allowed).toBe(true)
+      expect(decision.reason).toBe("granted")
+      expect(decision.grantId).toBe(GRANT_ID)
+      expect(decision.userId).toBe(USER_ID)
+    })
+
+    it("denies with message when no grant exists", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "allowlist" }),
+        grant: null,
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.allowed).toBe(false)
+      expect(decision.reason).toBe("denied")
+      expect(decision.replyToUser).toBeDefined()
+    })
+
+    it("uses custom rejection_message from channel_permissions", async () => {
+      const customMsg = "Contact admin@example.com for access."
+      const { db } = buildMockDb({
+        agent: makeAgent({
+          auth_model: "allowlist",
+          channel_permissions: { rejection_message: customMsg },
+        }),
+        grant: null,
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.replyToUser).toBe(customMsg)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // authorize — approval_queue
+  // -----------------------------------------------------------------------
+  describe("authorize — approval_queue", () => {
+    it("creates access_request when no grant, returns pending", async () => {
+      const accessRequestService = makeAccessRequestService()
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "approval_queue" }),
+        grant: null,
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService,
+      })
+
+      const decision = await guard.authorize({
+        ...baseParams,
+        messageText: "Hello, can I use this?",
+      })
+
+      expect(decision.allowed).toBe(false)
+      expect(decision.reason).toBe("pending_approval")
+      expect(decision.replyToUser).toBeDefined()
+      expect(accessRequestService.create).toHaveBeenCalledWith(
+        AGENT_ID,
+        USER_ID,
+        CHANNEL_MAPPING_ID,
+        "Hello, can I use this?",
+      )
+    })
+
+    it("returns pending without duplicate when request already exists", async () => {
+      // AccessRequestService.create() is idempotent — returns existing
+      const accessRequestService = makeAccessRequestService()
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "approval_queue" }),
+        grant: null,
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService,
+      })
+
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.allowed).toBe(false)
+      expect(decision.reason).toBe("pending_approval")
+      // create() was still called (idempotent), but no error
+      expect(accessRequestService.create).toHaveBeenCalledTimes(1)
+    })
+
+    it("allows with existing valid grant", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "approval_queue" }),
+        grant: makeGrant({ origin: "approval" }),
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.allowed).toBe(true)
+      expect(decision.reason).toBe("granted")
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // authorize — team
+  // -----------------------------------------------------------------------
+  describe("authorize — team", () => {
+    it("auto-grants when agent is bound to the same chat", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "team" }),
+        grant: null,
+        binding: { id: BINDING_ID },
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.allowed).toBe(true)
+      expect(decision.reason).toBe("auto_team")
+      expect(decision.grantId).toBe(GRANT_ID)
+      expect(db.insertInto).toHaveBeenCalledWith("agent_user_grant")
+    })
+
+    it("denies when no matching channel binding", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "team" }),
+        grant: null,
+        binding: null,
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.allowed).toBe(false)
+      expect(decision.reason).toBe("denied")
+    })
+
+    it("allows with existing valid grant (no re-check)", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "team" }),
+        grant: makeGrant({ origin: "auto_team" }),
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.allowed).toBe(true)
+      expect(decision.reason).toBe("granted")
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // authorize — open
+  // -----------------------------------------------------------------------
+  describe("authorize — open", () => {
+    it("auto-grants on first message", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "open" }),
+        grant: null,
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.allowed).toBe(true)
+      expect(decision.reason).toBe("auto_open")
+      expect(decision.grantId).toBe(GRANT_ID)
+      expect(db.insertInto).toHaveBeenCalledWith("agent_user_grant")
+    })
+
+    it("allows with existing grant", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "open" }),
+        grant: makeGrant({ origin: "auto_open" }),
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.allowed).toBe(true)
+      expect(decision.reason).toBe("granted")
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // authorize — revoked / expired grants
+  // -----------------------------------------------------------------------
+  describe("authorize — revoked grant", () => {
+    it("denies with reason revoked", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "allowlist" }),
+        grant: makeGrant({ revoked_at: now }),
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.allowed).toBe(false)
+      expect(decision.reason).toBe("revoked")
+      expect(decision.replyToUser).toContain("revoked")
+    })
+  })
+
+  describe("authorize — expired grant", () => {
+    it("denies with reason expired", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "open" }),
+        grant: makeGrant({ expires_at: pastDate }),
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.allowed).toBe(false)
+      expect(decision.reason).toBe("expired")
+      expect(decision.replyToUser).toContain("expired")
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // authorize — agent not found
+  // -----------------------------------------------------------------------
+  describe("authorize — agent not found", () => {
+    it("denies when agent does not exist", async () => {
+      const { db } = buildMockDb({ agent: null })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.allowed).toBe(false)
+      expect(decision.reason).toBe("denied")
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // handlePairingCode
+  // -----------------------------------------------------------------------
+  describe("handlePairingCode", () => {
+    it("delegates to PairingService.redeem on valid code", async () => {
+      const pairingService = makePairingService()
+      const { db } = buildMockDb()
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService,
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const result = await guard.handlePairingCode("ABC123", CHANNEL_MAPPING_ID, USER_ID)
+
+      expect(result.success).toBe(true)
+      expect(result.grantId).toBe(GRANT_ID)
+      expect(pairingService.redeem).toHaveBeenCalledWith("ABC123", CHANNEL_MAPPING_ID, USER_ID)
+    })
+
+    it("returns failure for expired/redeemed code", async () => {
+      const redeemResult: RedeemResult = { success: false, message: "Code has expired" }
+      const pairingService = makePairingService({
+        redeem: vi.fn().mockResolvedValue(redeemResult),
+      } as unknown as Partial<PairingService>)
+      const { db } = buildMockDb()
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService,
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const result = await guard.handlePairingCode("EXPIRED", CHANNEL_MAPPING_ID, USER_ID)
+
+      expect(result.success).toBe(false)
+      expect(result.message).toBe("Code has expired")
+    })
+  })
+})

--- a/packages/control-plane/src/auth/channel-auth-guard.ts
+++ b/packages/control-plane/src/auth/channel-auth-guard.ts
@@ -1,0 +1,350 @@
+import type { Kysely } from "kysely"
+
+import type { AgentAuthModel, Database } from "../db/types.js"
+import type { AccessRequestService } from "./access-request-service.js"
+import type { PairingService, RedeemResult } from "./pairing-service.js"
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface AuthorizeParams {
+  agentId: string
+  channelType: string
+  channelUserId: string
+  chatId: string
+  messageText?: string
+}
+
+export type AuthDecisionReason =
+  | "granted"
+  | "auto_team"
+  | "auto_open"
+  | "pending_approval"
+  | "denied"
+  | "rate_limited"
+  | "budget_exceeded"
+  | "revoked"
+  | "expired"
+
+export interface AuthDecision {
+  allowed: boolean
+  userId: string
+  grantId?: string
+  reason: AuthDecisionReason
+  replyToUser?: string
+}
+
+export interface PairingResult {
+  success: boolean
+  message: string
+  grantId?: string
+}
+
+export interface ChannelAuthGuardDeps {
+  db: Kysely<Database>
+  pairingService: PairingService
+  accessRequestService: AccessRequestService
+}
+
+// ---------------------------------------------------------------------------
+// Default messages
+// ---------------------------------------------------------------------------
+
+const DEFAULT_REJECTION_MESSAGE = "This agent is private. Ask an operator for a pairing code."
+const DEFAULT_PENDING_MESSAGE = "Your request has been submitted. You'll be notified when approved."
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class ChannelAuthGuard {
+  private db: Kysely<Database>
+  private pairingService: PairingService
+  private accessRequestService: AccessRequestService
+
+  constructor(deps: ChannelAuthGuardDeps) {
+    this.db = deps.db
+    this.pairingService = deps.pairingService
+    this.accessRequestService = deps.accessRequestService
+  }
+
+  /**
+   * Main authorization entry point.
+   *
+   * Resolves the channel identity, looks up the agent's auth model,
+   * checks for an existing grant, and applies the appropriate policy.
+   */
+  async authorize(params: AuthorizeParams): Promise<AuthDecision> {
+    const { agentId, channelType, channelUserId, chatId, messageText } = params
+
+    // 1. Resolve or create identity
+    const { userAccountId, channelMappingId } = await this.resolveOrCreateIdentity(
+      channelType,
+      channelUserId,
+    )
+
+    // 2. Fetch agent to get auth_model + channel_permissions
+    const agent = await this.db
+      .selectFrom("agent")
+      .select(["id", "auth_model", "channel_permissions"])
+      .where("id", "=", agentId)
+      .executeTakeFirst()
+
+    if (!agent) {
+      return {
+        allowed: false,
+        userId: userAccountId,
+        reason: "denied",
+        replyToUser: "Agent not found.",
+      }
+    }
+
+    const authModel: AgentAuthModel = agent.auth_model ?? "allowlist"
+    const permissions = agent.channel_permissions ?? {}
+
+    // 3. Look up existing grant (most recent, including revoked/expired)
+    const grant = await this.db
+      .selectFrom("agent_user_grant")
+      .selectAll()
+      .where("agent_id", "=", agentId)
+      .where("user_account_id", "=", userAccountId)
+      .orderBy("created_at", "desc")
+      .executeTakeFirst()
+
+    // 4. Check revoked/expired before anything else
+    if (grant) {
+      if (grant.revoked_at) {
+        return {
+          allowed: false,
+          userId: userAccountId,
+          reason: "revoked",
+          replyToUser: "Your access to this agent has been revoked.",
+        }
+      }
+
+      if (grant.expires_at && new Date(grant.expires_at) <= new Date()) {
+        return {
+          allowed: false,
+          userId: userAccountId,
+          reason: "expired",
+          replyToUser: "Your access to this agent has expired.",
+        }
+      }
+
+      // Valid grant exists — allowed
+      return {
+        allowed: true,
+        userId: userAccountId,
+        grantId: grant.id,
+        reason: "granted",
+      }
+    }
+
+    // 5. No grant — apply auth model policy
+    switch (authModel) {
+      case "allowlist":
+        return this.handleAllowlist(userAccountId, permissions)
+
+      case "approval_queue":
+        return this.handleApprovalQueue(
+          agentId,
+          userAccountId,
+          channelMappingId,
+          permissions,
+          messageText,
+        )
+
+      case "team":
+        return this.handleTeam(agentId, userAccountId, chatId, permissions)
+
+      case "open":
+        return this.handleOpen(agentId, userAccountId)
+
+      default:
+        return {
+          allowed: false,
+          userId: userAccountId,
+          reason: "denied",
+          replyToUser: DEFAULT_REJECTION_MESSAGE,
+        }
+    }
+  }
+
+  /**
+   * Redeem a pairing code to create a grant for the channel user.
+   */
+  async handlePairingCode(
+    code: string,
+    channelMappingId: string,
+    userAccountId: string,
+  ): Promise<PairingResult> {
+    const result: RedeemResult = await this.pairingService.redeem(
+      code,
+      channelMappingId,
+      userAccountId,
+    )
+
+    return {
+      success: result.success,
+      message: result.message,
+      grantId: result.grantId,
+    }
+  }
+
+  /**
+   * Resolve an existing channel identity or create a new user_account +
+   * channel_mapping for an unknown channel user.
+   */
+  async resolveOrCreateIdentity(
+    channelType: string,
+    channelUserId: string,
+    displayName?: string,
+  ): Promise<{ userAccountId: string; channelMappingId: string }> {
+    // Look up existing channel_mapping
+    const existing = await this.db
+      .selectFrom("channel_mapping")
+      .select(["id", "user_account_id"])
+      .where("channel_type", "=", channelType)
+      .where("channel_user_id", "=", channelUserId)
+      .executeTakeFirst()
+
+    if (existing) {
+      return {
+        userAccountId: existing.user_account_id,
+        channelMappingId: existing.id,
+      }
+    }
+
+    // Create anonymous user_account
+    const userAccount = await this.db
+      .insertInto("user_account")
+      .values({
+        display_name: displayName ?? null,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    // Create channel_mapping
+    const channelMapping = await this.db
+      .insertInto("channel_mapping")
+      .values({
+        user_account_id: userAccount.id,
+        channel_type: channelType,
+        channel_user_id: channelUserId,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    return {
+      userAccountId: userAccount.id,
+      channelMappingId: channelMapping.id,
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Private — auth model handlers
+  // -------------------------------------------------------------------------
+
+  private handleAllowlist(
+    userAccountId: string,
+    permissions: Record<string, unknown>,
+  ): AuthDecision {
+    const message =
+      (permissions.rejection_message as string | undefined) ?? DEFAULT_REJECTION_MESSAGE
+
+    return {
+      allowed: false,
+      userId: userAccountId,
+      reason: "denied",
+      replyToUser: message,
+    }
+  }
+
+  private async handleApprovalQueue(
+    agentId: string,
+    userAccountId: string,
+    channelMappingId: string,
+    permissions: Record<string, unknown>,
+    messageText?: string,
+  ): Promise<AuthDecision> {
+    const message = (permissions.pending_message as string | undefined) ?? DEFAULT_PENDING_MESSAGE
+
+    // AccessRequestService.create() is idempotent — returns existing pending
+    // request if one already exists for (agent_id, user_account_id).
+    await this.accessRequestService.create(agentId, userAccountId, channelMappingId, messageText)
+
+    return {
+      allowed: false,
+      userId: userAccountId,
+      reason: "pending_approval",
+      replyToUser: message,
+    }
+  }
+
+  private async handleTeam(
+    agentId: string,
+    userAccountId: string,
+    chatId: string,
+    permissions: Record<string, unknown>,
+  ): Promise<AuthDecision> {
+    // Team membership: check if the agent is bound to the same chat
+    const binding = await this.db
+      .selectFrom("agent_channel_binding")
+      .select("id")
+      .where("agent_id", "=", agentId)
+      .where("chat_id", "=", chatId)
+      .executeTakeFirst()
+
+    if (!binding) {
+      const message =
+        (permissions.rejection_message as string | undefined) ??
+        "You must be a member of a channel this agent is bound to."
+
+      return {
+        allowed: false,
+        userId: userAccountId,
+        reason: "denied",
+        replyToUser: message,
+      }
+    }
+
+    // Auto-create grant with origin 'auto_team'
+    const grant = await this.db
+      .insertInto("agent_user_grant")
+      .values({
+        agent_id: agentId,
+        user_account_id: userAccountId,
+        origin: "auto_team",
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    return {
+      allowed: true,
+      userId: userAccountId,
+      grantId: grant.id,
+      reason: "auto_team",
+    }
+  }
+
+  private async handleOpen(agentId: string, userAccountId: string): Promise<AuthDecision> {
+    // Auto-create grant with origin 'auto_open'
+    const grant = await this.db
+      .insertInto("agent_user_grant")
+      .values({
+        agent_id: agentId,
+        user_account_id: userAccountId,
+        origin: "auto_open",
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    return {
+      allowed: true,
+      userId: userAccountId,
+      grantId: grant.id,
+      reason: "auto_open",
+    }
+  }
+}

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -49,6 +49,11 @@ export type ToolApprovalPolicy = "auto" | "always_approve" | "conditional"
 export type McpServerStatus = "PENDING" | "ACTIVE" | "DEGRADED" | "ERROR" | "DISABLED"
 
 // ---------------------------------------------------------------------------
+// Enum: agent_auth_model
+// ---------------------------------------------------------------------------
+export type AgentAuthModel = "allowlist" | "approval_queue" | "team" | "open"
+
+// ---------------------------------------------------------------------------
 // Enum: mcp_transport
 // ---------------------------------------------------------------------------
 export type McpTransport = "streamable-http" | "stdio"
@@ -92,6 +97,7 @@ export interface AgentTable {
     Record<string, unknown> | null | undefined,
     Record<string, unknown> | null
   >
+  auth_model: ColumnType<AgentAuthModel, AgentAuthModel | undefined, AgentAuthModel>
   status: ColumnType<AgentStatus, AgentStatus | undefined, AgentStatus>
   created_at: ColumnType<Date, Date | undefined, never>
   updated_at: ColumnType<Date, Date | undefined, never>


### PR DESCRIPTION
## Summary
- Adds `ChannelAuthGuard` class (`src/auth/channel-auth-guard.ts`) with `authorize()`, `handlePairingCode()`, and `resolveOrCreateIdentity()` methods
- Supports all four auth models: `allowlist`, `approval_queue`, `team`, `open` — plus revoked/expired grant handling
- Adds `AgentAuthModel` type and `auth_model` column to `AgentTable` in DB types (matching migration 026)
- 18 unit tests covering all acceptance criteria from the issue

## Test plan
- [x] `allowlist` agent with no grant → denied with message
- [x] `allowlist` agent with valid grant → allowed
- [x] `approval_queue` agent with no grant → access_request created, pending message
- [x] `approval_queue` agent with existing pending request → no duplicate
- [x] `team` agent with matching binding → auto-grant created, allowed
- [x] `team` agent with no binding → denied
- [x] `open` agent with no grant → auto-grant created, allowed
- [x] Revoked grant → denied (revoked)
- [x] Expired grant → denied (expired)
- [x] Pairing code: valid → delegated to PairingService
- [x] Pairing code: expired/redeemed → rejected
- [x] Unknown channel user → new user_account + channel_mapping created
- [x] `pnpm test` passes (1403 tests, 84 files)
- [x] Lint, typecheck, and build clean

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive channel authorization system supporting multiple authentication strategies (allowlist, approval queue, team-based, and open modes).
  * Added support for pairing codes to grant channel access.
  * Automatic grant issuance for team and open authorization modes.
  * Identity resolution and creation for channel users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->