### PR TITLE
feat(auth): per-user rate limiting and token budget enforcement (#339)

### DIFF
--- a/packages/control-plane/src/auth/__tests__/user-rate-limiter.test.ts
+++ b/packages/control-plane/src/auth/__tests__/user-rate-limiter.test.ts
@@ -1,0 +1,307 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import type { Database, RateLimit, TokenBudget } from "../../db/types.js"
+import { UserRateLimiter } from "../user-rate-limiter.js"
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const AGENT_ID = "aaaaaaaa-1111-2222-3333-444444444444"
+const USER_ID = "bbbbbbbb-1111-2222-3333-444444444444"
+
+// ---------------------------------------------------------------------------
+// Chainable Kysely mock helpers
+// ---------------------------------------------------------------------------
+
+function mockSelectChain(result: unknown) {
+  const executeTakeFirst = vi.fn().mockResolvedValue(result)
+  const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(result)
+  const execute = vi
+    .fn()
+    .mockResolvedValue(Array.isArray(result) ? result : result == null ? [] : [result])
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  const selectFn = vi.fn()
+  const innerJoinFn: ReturnType<typeof vi.fn> = vi.fn()
+  const chain = {
+    where: whereFn,
+    select: selectFn,
+    innerJoin: innerJoinFn,
+    executeTakeFirst,
+    executeTakeFirstOrThrow,
+    execute,
+  }
+  whereFn.mockReturnValue(chain)
+  selectFn.mockReturnValue(chain)
+  innerJoinFn.mockReturnValue(chain)
+  return chain
+}
+
+function mockInsertChain() {
+  const executeFn = vi.fn().mockResolvedValue(undefined)
+  const onConflictFn = vi.fn()
+  const doUpdateSetFn = vi.fn()
+  const columnsFn = vi.fn()
+  const valuesFn = vi.fn()
+
+  const conflictChain = {
+    columns: columnsFn,
+    doUpdateSet: doUpdateSetFn,
+  }
+  columnsFn.mockReturnValue(conflictChain)
+  doUpdateSetFn.mockReturnValue({ execute: executeFn })
+
+  // onConflict receives a builder callback — invoke it with our chain
+  onConflictFn.mockImplementation((cb: (oc: typeof conflictChain) => unknown) => {
+    cb(conflictChain)
+    return { execute: executeFn }
+  })
+
+  const chain = {
+    values: valuesFn,
+    onConflict: onConflictFn,
+    execute: executeFn,
+  }
+  valuesFn.mockReturnValue(chain)
+
+  return chain
+}
+
+// ---------------------------------------------------------------------------
+// DB mock builder
+// ---------------------------------------------------------------------------
+
+interface MockDbOpts {
+  agentResourceLimits?: Record<string, unknown>
+  messageCount?: number
+  totalTokens?: number
+}
+
+function buildMockDb(opts: MockDbOpts = {}) {
+  const { agentResourceLimits = {}, messageCount = 0, totalTokens = 0 } = opts
+
+  const selectFromCalls: string[] = []
+
+  const insertChain = mockInsertChain()
+
+  const db = {
+    selectFrom: vi.fn().mockImplementation((table: string) => {
+      selectFromCalls.push(table)
+
+      if (table === "agent") {
+        return mockSelectChain({ resource_limits: agentResourceLimits })
+      }
+
+      // session_message as sm — rate limit query
+      if (table === "session_message as sm") {
+        return mockSelectChain({ count: messageCount })
+      }
+
+      // user_usage_ledger — token budget query / usage summary
+      if (table === "user_usage_ledger") {
+        return mockSelectChain({
+          total_tokens: totalTokens,
+          messages_sent: messageCount,
+          tokens_in: Math.floor(totalTokens * 0.6),
+          tokens_out: Math.floor(totalTokens * 0.4),
+          cost_usd: 0.5,
+        })
+      }
+
+      return mockSelectChain(null)
+    }),
+    insertInto: vi.fn().mockReturnValue(insertChain),
+  } as unknown as Kysely<Database>
+
+  return { db, selectFromCalls, insertChain }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("UserRateLimiter", () => {
+  // ── check() ──
+
+  describe("check()", () => {
+    it("allows user within rate limit", async () => {
+      const { db } = buildMockDb({ messageCount: 5 })
+      const limiter = new UserRateLimiter(db)
+
+      const grantRateLimit: RateLimit = { max_messages: 60, window_seconds: 3600 }
+      const result = await limiter.check(USER_ID, AGENT_ID, grantRateLimit)
+
+      expect(result).toEqual({ allowed: true, reason: "allowed" })
+    })
+
+    it("denies user exceeding message rate limit", async () => {
+      const { db } = buildMockDb({ messageCount: 60 })
+      const limiter = new UserRateLimiter(db)
+
+      const grantRateLimit: RateLimit = { max_messages: 60, window_seconds: 3600 }
+      const result = await limiter.check(USER_ID, AGENT_ID, grantRateLimit)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toBe("rate_limited")
+      expect(result.replyToUser).toContain("message limit")
+      expect(result.retryAfterSeconds).toBe(3600)
+    })
+
+    it("denies user exceeding token budget", async () => {
+      const { db } = buildMockDb({ messageCount: 5, totalTokens: 100_000 })
+      const limiter = new UserRateLimiter(db)
+
+      const grantTokenBudget: TokenBudget = { max_tokens: 100_000, window_seconds: 86400 }
+      const result = await limiter.check(USER_ID, AGENT_ID, null, grantTokenBudget)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toBe("budget_exceeded")
+      expect(result.replyToUser).toContain("token budget")
+      expect(result.retryAfterSeconds).toBe(86400)
+    })
+
+    it("per-grant override takes precedence over agent default", async () => {
+      // Agent default: 100 messages/hr — would allow
+      // Grant override: 10 messages/hr — should deny at count=15
+      const { db } = buildMockDb({
+        agentResourceLimits: {
+          userRateLimit: { max_messages: 100, window_seconds: 3600 },
+        },
+        messageCount: 15,
+      })
+      const limiter = new UserRateLimiter(db)
+
+      const grantRateLimit: RateLimit = { max_messages: 10, window_seconds: 3600 }
+      const result = await limiter.check(USER_ID, AGENT_ID, grantRateLimit)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toBe("rate_limited")
+    })
+
+    it("falls back to agent default when grant has no rate limit", async () => {
+      const { db } = buildMockDb({
+        agentResourceLimits: {
+          userRateLimit: { max_messages: 10, window_seconds: 3600 },
+        },
+        messageCount: 15,
+      })
+      const limiter = new UserRateLimiter(db)
+
+      // No grant-level override
+      const result = await limiter.check(USER_ID, AGENT_ID)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toBe("rate_limited")
+    })
+
+    it("allows when no limits configured at any level", async () => {
+      const { db } = buildMockDb({
+        agentResourceLimits: {},
+        messageCount: 1000,
+        totalTokens: 1_000_000,
+      })
+      const limiter = new UserRateLimiter(db)
+
+      const result = await limiter.check(USER_ID, AGENT_ID)
+
+      expect(result).toEqual({ allowed: true, reason: "allowed" })
+    })
+
+    it("checks rate limit before token budget", async () => {
+      // Both limits exceeded — should return rate_limited (checked first)
+      const { db } = buildMockDb({ messageCount: 60, totalTokens: 100_000 })
+      const limiter = new UserRateLimiter(db)
+
+      const grantRateLimit: RateLimit = { max_messages: 60, window_seconds: 3600 }
+      const grantTokenBudget: TokenBudget = { max_tokens: 100_000, window_seconds: 86400 }
+      const result = await limiter.check(USER_ID, AGENT_ID, grantRateLimit, grantTokenBudget)
+
+      expect(result.reason).toBe("rate_limited")
+    })
+
+    it("agent default takes precedence over platform default (no limit)", async () => {
+      const { db } = buildMockDb({
+        agentResourceLimits: {
+          userTokenBudget: { max_tokens: 50_000, window_seconds: 86400 },
+        },
+        totalTokens: 60_000,
+      })
+      const limiter = new UserRateLimiter(db)
+
+      const result = await limiter.check(USER_ID, AGENT_ID)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toBe("budget_exceeded")
+    })
+  })
+
+  // ── recordUsage() ──
+
+  describe("recordUsage()", () => {
+    it("upserts into correct hourly bucket", async () => {
+      const { db, insertChain } = buildMockDb()
+      const limiter = new UserRateLimiter(db)
+
+      await limiter.recordUsage(USER_ID, AGENT_ID, 1, 500, 200, 0.01)
+
+      expect(db.insertInto).toHaveBeenCalledWith("user_usage_ledger")
+      expect(insertChain.values).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_account_id: USER_ID,
+          agent_id: AGENT_ID,
+          messages_sent: 1,
+          tokens_in: 500,
+          tokens_out: 200,
+          cost_usd: 0.01,
+        }) as Record<string, unknown>,
+      )
+      expect(insertChain.onConflict).toHaveBeenCalled()
+    })
+
+    it("sets period_start to floor of current hour", async () => {
+      const { db, insertChain } = buildMockDb()
+      const limiter = new UserRateLimiter(db)
+
+      await limiter.recordUsage(USER_ID, AGENT_ID, 1, 100, 50, 0.005)
+
+      const callArgs = insertChain.values.mock.calls[0]?.[0] as Record<string, unknown>
+      const periodStart = callArgs.period_start as Date
+      const periodEnd = callArgs.period_end as Date
+
+      expect(periodStart.getUTCMinutes()).toBe(0)
+      expect(periodStart.getUTCSeconds()).toBe(0)
+      expect(periodStart.getUTCMilliseconds()).toBe(0)
+
+      // period_end should be exactly 1 hour after period_start
+      expect(periodEnd.getTime() - periodStart.getTime()).toBe(3_600_000)
+    })
+  })
+
+  // ── getUsageSummary() ──
+
+  describe("getUsageSummary()", () => {
+    it("returns correct aggregates for requested window", async () => {
+      const { db } = buildMockDb({ messageCount: 10, totalTokens: 5000 })
+      const limiter = new UserRateLimiter(db)
+
+      const summary = await limiter.getUsageSummary(USER_ID, AGENT_ID, 3600)
+
+      expect(summary.windowSeconds).toBe(3600)
+      expect(summary.messagesSent).toBe(10)
+      expect(typeof summary.tokensIn).toBe("number")
+      expect(typeof summary.tokensOut).toBe("number")
+      expect(typeof summary.costUsd).toBe("number")
+    })
+
+    it("queries user_usage_ledger table", async () => {
+      const { db } = buildMockDb()
+      const limiter = new UserRateLimiter(db)
+
+      await limiter.getUsageSummary(USER_ID, AGENT_ID, 86400)
+
+      expect(db.selectFrom).toHaveBeenCalledWith("user_usage_ledger")
+    })
+  })
+})

--- a/packages/control-plane/src/auth/user-rate-limiter.ts
+++ b/packages/control-plane/src/auth/user-rate-limiter.ts
@@ -1,0 +1,226 @@
+import type { Kysely } from "kysely"
+import { sql } from "kysely"
+
+import type { Database, RateLimit, TokenBudget } from "../db/types.js"
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface RateLimitDecision {
+  allowed: boolean
+  reason: "allowed" | "rate_limited" | "budget_exceeded"
+  replyToUser?: string
+  retryAfterSeconds?: number
+}
+
+export interface UsageSummary {
+  messagesSent: number
+  tokensIn: number
+  tokensOut: number
+  costUsd: number
+  windowSeconds: number
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isRateLimit(v: unknown): v is RateLimit {
+  if (typeof v !== "object" || v === null) return false
+  const r = v as Record<string, unknown>
+  return typeof r.max_messages === "number" && typeof r.window_seconds === "number"
+}
+
+function isTokenBudget(v: unknown): v is TokenBudget {
+  if (typeof v !== "object" || v === null) return false
+  const r = v as Record<string, unknown>
+  return typeof r.max_tokens === "number" && typeof r.window_seconds === "number"
+}
+
+/** Floor a date to the start of its UTC hour. */
+function floorToHour(d: Date): Date {
+  const floored = new Date(d)
+  floored.setUTCMinutes(0, 0, 0)
+  return floored
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class UserRateLimiter {
+  constructor(private readonly db: Kysely<Database>) {}
+
+  /**
+   * Pre-message check — should the user be allowed to send a new message?
+   *
+   * Resolution order:
+   *   1. grantRateLimit / grantTokenBudget (per-grant override)
+   *   2. agent.resource_limits.userRateLimit / userTokenBudget (agent default)
+   *   3. No limit (allow)
+   */
+  async check(
+    userAccountId: string,
+    agentId: string,
+    grantRateLimit?: RateLimit | null,
+    grantTokenBudget?: TokenBudget | null,
+  ): Promise<RateLimitDecision> {
+    // ── Resolve effective limits ──
+    const agent = await this.db
+      .selectFrom("agent")
+      .select(["resource_limits"])
+      .where("id", "=", agentId)
+      .executeTakeFirst()
+
+    const agentLimits = agent?.resource_limits ?? {}
+
+    const rateLimit =
+      grantRateLimit ?? (isRateLimit(agentLimits.userRateLimit) ? agentLimits.userRateLimit : null)
+
+    const tokenBudget =
+      grantTokenBudget ??
+      (isTokenBudget(agentLimits.userTokenBudget) ? agentLimits.userTokenBudget : null)
+
+    // ── Rate limit check (message count in sliding window) ──
+    if (rateLimit) {
+      const { count } = await this.db
+        .selectFrom("session_message as sm")
+        .innerJoin("session as s", "s.id", "sm.session_id")
+        .select(sql<number>`count(*)::int`.as("count"))
+        .where("s.agent_id", "=", agentId)
+        .where("s.user_account_id", "=", userAccountId)
+        .where("sm.role", "=", "user")
+        .where(
+          "sm.created_at",
+          ">",
+          sql<Date>`now() - make_interval(secs => ${sql.lit(rateLimit.window_seconds)})`,
+        )
+        .executeTakeFirstOrThrow()
+
+      if (count >= rateLimit.max_messages) {
+        return {
+          allowed: false,
+          reason: "rate_limited",
+          replyToUser: `You've reached the message limit (${rateLimit.max_messages} per ${formatWindow(rateLimit.window_seconds)}). Please try again later.`,
+          retryAfterSeconds: rateLimit.window_seconds,
+        }
+      }
+    }
+
+    // ── Token budget check (token sum in sliding window from ledger) ──
+    if (tokenBudget) {
+      const row = await this.db
+        .selectFrom("user_usage_ledger")
+        .select(sql<number>`coalesce(sum(tokens_in + tokens_out), 0)::int`.as("total_tokens"))
+        .where("user_account_id", "=", userAccountId)
+        .where("agent_id", "=", agentId)
+        .where(
+          "period_start",
+          ">",
+          sql<Date>`now() - make_interval(secs => ${sql.lit(tokenBudget.window_seconds)})`,
+        )
+        .executeTakeFirstOrThrow()
+
+      if (row.total_tokens >= tokenBudget.max_tokens) {
+        return {
+          allowed: false,
+          reason: "budget_exceeded",
+          replyToUser: `You've reached the token budget (${tokenBudget.max_tokens} tokens per ${formatWindow(tokenBudget.window_seconds)}). Please try again later.`,
+          retryAfterSeconds: tokenBudget.window_seconds,
+        }
+      }
+    }
+
+    return { allowed: true, reason: "allowed" }
+  }
+
+  /**
+   * Post-execution usage recording — upserts into the current hourly bucket.
+   */
+  async recordUsage(
+    userAccountId: string,
+    agentId: string,
+    messageCount: number,
+    tokensIn: number,
+    tokensOut: number,
+    costUsd: number,
+  ): Promise<void> {
+    const now = new Date()
+    const periodStart = floorToHour(now)
+    const periodEnd = new Date(periodStart.getTime() + 3_600_000)
+
+    await this.db
+      .insertInto("user_usage_ledger")
+      .values({
+        user_account_id: userAccountId,
+        agent_id: agentId,
+        period_start: periodStart,
+        period_end: periodEnd,
+        messages_sent: messageCount,
+        tokens_in: tokensIn,
+        tokens_out: tokensOut,
+        cost_usd: costUsd,
+      })
+      .onConflict((oc) =>
+        oc.columns(["user_account_id", "agent_id", "period_start"]).doUpdateSet({
+          messages_sent: sql`user_usage_ledger.messages_sent + excluded.messages_sent`,
+          tokens_in: sql`user_usage_ledger.tokens_in + excluded.tokens_in`,
+          tokens_out: sql`user_usage_ledger.tokens_out + excluded.tokens_out`,
+          cost_usd: sql`user_usage_ledger.cost_usd + excluded.cost_usd`,
+        }),
+      )
+      .execute()
+  }
+
+  /**
+   * Aggregate usage for a user+agent within a time window.
+   */
+  async getUsageSummary(
+    userAccountId: string,
+    agentId: string,
+    windowSeconds: number,
+  ): Promise<UsageSummary> {
+    const row = await this.db
+      .selectFrom("user_usage_ledger")
+      .select([
+        sql<number>`coalesce(sum(messages_sent), 0)::int`.as("messages_sent"),
+        sql<number>`coalesce(sum(tokens_in), 0)::int`.as("tokens_in"),
+        sql<number>`coalesce(sum(tokens_out), 0)::int`.as("tokens_out"),
+        sql<number>`coalesce(sum(cost_usd), 0)::numeric(12,6)`.as("cost_usd"),
+      ])
+      .where("user_account_id", "=", userAccountId)
+      .where("agent_id", "=", agentId)
+      .where(
+        "period_start",
+        ">",
+        sql<Date>`now() - make_interval(secs => ${sql.lit(windowSeconds)})`,
+      )
+      .executeTakeFirstOrThrow()
+
+    return {
+      messagesSent: Number(row.messages_sent),
+      tokensIn: Number(row.tokens_in),
+      tokensOut: Number(row.tokens_out),
+      costUsd: Number(row.cost_usd),
+      windowSeconds,
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helper
+// ---------------------------------------------------------------------------
+
+function formatWindow(seconds: number): string {
+  if (seconds >= 86_400) {
+    const days = Math.floor(seconds / 86_400)
+    return days === 1 ? "day" : `${days} days`
+  }
+  if (seconds >= 3_600) {
+    const hours = Math.floor(seconds / 3_600)
+    return hours === 1 ? "hour" : `${hours} hours`
+  }
+  const minutes = Math.floor(seconds / 60)
+  return minutes === 1 ? "minute" : `${minutes} minutes`
+}

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -710,6 +710,39 @@ export type NewAgentUserGrant = Insertable<AgentUserGrantTable>
 export type AgentUserGrantUpdate = Updateable<AgentUserGrantTable>
 
 // ---------------------------------------------------------------------------
+// Table: user_usage_ledger
+// ---------------------------------------------------------------------------
+export interface UserUsageLedgerTable {
+  id: Generated<string>
+  user_account_id: string
+  agent_id: string
+  period_start: Date
+  period_end: Date
+  messages_sent: ColumnType<number, number | undefined, number>
+  tokens_in: ColumnType<number, number | undefined, number>
+  tokens_out: ColumnType<number, number | undefined, number>
+  cost_usd: ColumnType<string, string | number | undefined, string | number>
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
+export type UserUsageLedger = Selectable<UserUsageLedgerTable>
+export type NewUserUsageLedger = Insertable<UserUsageLedgerTable>
+export type UserUsageLedgerUpdate = Updateable<UserUsageLedgerTable>
+
+// ---------------------------------------------------------------------------
+// Rate limit / token budget shapes (stored as JSONB in agent_user_grant)
+// ---------------------------------------------------------------------------
+export interface RateLimit {
+  max_messages: number
+  window_seconds: number
+}
+
+export interface TokenBudget {
+  max_tokens: number
+  window_seconds: number
+}
+
+// ---------------------------------------------------------------------------
 // Enum: access_request_status
 // ---------------------------------------------------------------------------
 export type AccessRequestStatus = "pending" | "approved" | "denied"
@@ -817,4 +850,5 @@ export interface Database {
   pairing_code: PairingCodeTable
   agent_user_grant: AgentUserGrantTable
   access_request: AccessRequestTable
+  user_usage_ledger: UserUsageLedgerTable
 }

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -25,6 +25,7 @@ import type { JobHelpers, Task } from "graphile-worker"
 import type { Kysely } from "kysely"
 
 import type { CredentialService } from "../../auth/credential-service.js"
+import type { UserRateLimiter } from "../../auth/user-rate-limiter.js"
 import type { CredentialResolver } from "../../backends/tools/webhook.js"
 import type { Database, Job } from "../../db/types.js"
 import type { AgentCircuitBreakerConfig } from "../../lifecycle/agent-circuit-breaker.js"
@@ -73,6 +74,8 @@ export interface AgentExecuteDeps {
   eventEmitter?: AgentEventEmitter
   /** Optional execution registry for tracking in-flight handles. */
   executionRegistry?: ExecutionRegistry
+  /** Optional user rate limiter for recording per-user usage after execution. */
+  userRateLimiter?: UserRateLimiter
 }
 
 /** Polling interval (ms) for checking cancellation. */
@@ -99,6 +102,7 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
     lifecycleManager,
     eventEmitter,
     executionRegistry,
+    userRateLimiter,
   } = deps
   const memoryScheduler = createMemoryScheduler({ db, threshold: memoryExtractThreshold })
 
@@ -753,6 +757,30 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
               .catch(() => {
                 // Non-fatal: session cost update is best-effort
               })
+          }
+
+          // Record per-user usage in the usage ledger
+          if (userRateLimiter && job.session_id) {
+            const session = await db
+              .selectFrom("session")
+              .select("user_account_id")
+              .where("id", "=", job.session_id)
+              .executeTakeFirst()
+
+            if (session) {
+              await userRateLimiter
+                .recordUsage(
+                  session.user_account_id,
+                  agent.id,
+                  1,
+                  costSnapshot.tokensIn,
+                  costSnapshot.tokensOut,
+                  costSnapshot.costUsd,
+                )
+                .catch(() => {
+                  // Non-fatal: usage recording is best-effort
+                })
+            }
           }
 
           // Emit session_end event with accumulated cost


### PR DESCRIPTION
## Summary
- Add `UserRateLimiter` service (`src/auth/user-rate-limiter.ts`) with `check()`, `recordUsage()`, and `getUsageSummary()` methods
- Rate limit resolution cascade: per-grant override → agent `resource_limits.userRateLimit` default → no limit
- Token budget resolution cascade: per-grant override → agent `resource_limits.userTokenBudget` default → no limit
- Wire post-execution usage recording into `agent-execute.ts` (upserts into hourly `user_usage_ledger` buckets)
- Add `UserUsageLedgerTable`, `RateLimit`, and `TokenBudget` types to `db/types.ts`

Closes #339

## Test plan
- [x] 12 unit tests covering all acceptance criteria
- [x] User within rate limit → allowed
- [x] User exceeding message rate limit → denied with cooldown message
- [x] User exceeding token budget → denied with budget message
- [x] Per-grant override takes precedence over agent default
- [x] Agent default takes precedence over platform default (no limit)
- [x] Usage recording upserts into correct hourly bucket
- [x] Usage summary returns correct aggregates
- [x] `pnpm test` passes (85 files, 1421 tests)
- [x] Lint, typecheck, build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rate limiting and token budget enforcement per user and agent, with configurable per-grant overrides.
  * Implemented usage tracking to monitor messages sent, tokens consumed, and costs across customizable time windows.
  * Added decision system that provides clear feedback when rate limits or budgets are exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->