### PR TITLE
feat(routes): CRUD routes for user grants, pairing codes, and access requests (#340)

### DIFF
--- a/packages/control-plane/src/__tests__/agent-user-routes.test.ts
+++ b/packages/control-plane/src/__tests__/agent-user-routes.test.ts
@@ -1,0 +1,667 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+import Fastify from "fastify"
+import { describe, expect, it, vi } from "vitest"
+
+import { AccessRequestConflictError } from "../auth/access-request-service.js"
+import type { AuthConfig } from "../middleware/types.js"
+import { agentUserRoutes } from "../routes/agent-user-routes.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEV_AUTH_CONFIG: AuthConfig = {
+  requireAuth: false,
+  apiKeys: [],
+}
+
+const AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+const GRANT_ID = "gggggggg-1111-2222-3333-444444444444"
+const USER_ID = "uuuuuuuu-1111-2222-3333-444444444444"
+const CODE_ID = "pppppppp-1111-2222-3333-444444444444"
+const REQUEST_ID = "rrrrrrrr-1111-2222-3333-444444444444"
+
+function makeGrant(overrides: Record<string, unknown> = {}) {
+  return {
+    id: GRANT_ID,
+    agent_id: AGENT_ID,
+    user_account_id: USER_ID,
+    access_level: "write",
+    origin: "dashboard_invite",
+    granted_by: "dev-user",
+    rate_limit: null,
+    token_budget: null,
+    expires_at: null,
+    revoked_at: null,
+    created_at: new Date(),
+    ...overrides,
+  }
+}
+
+function makeUser(overrides: Record<string, unknown> = {}) {
+  return {
+    id: USER_ID,
+    display_name: "Test User",
+    email: "test@example.com",
+    avatar_url: null,
+    role: "operator",
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  }
+}
+
+function makeChannelMapping(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "cmcmcmcm-1111-2222-3333-444444444444",
+    user_account_id: USER_ID,
+    channel_type: "telegram",
+    channel_user_id: "12345",
+    metadata: null,
+    created_at: new Date(),
+    ...overrides,
+  }
+}
+
+function makeAccessRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    id: REQUEST_ID,
+    agent_id: AGENT_ID,
+    channel_mapping_id: "cmcmcmcm-1111-2222-3333-444444444444",
+    user_account_id: USER_ID,
+    status: "pending",
+    message_preview: null,
+    reviewed_by: null,
+    reviewed_at: null,
+    deny_reason: null,
+    created_at: new Date(),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock DB builder
+// ---------------------------------------------------------------------------
+
+interface MockDbOptions {
+  grants?: Record<string, unknown>[]
+  grantTotal?: number
+  existingGrant?: Record<string, unknown> | null
+  insertedGrant?: Record<string, unknown>
+  updatedGrant?: Record<string, unknown> | null
+  user?: Record<string, unknown> | null
+  channelMappings?: Record<string, unknown>[]
+  joinedAgent?: { name: string } | null
+}
+
+function mockDb(opts: MockDbOptions = {}) {
+  const {
+    grants = [makeGrant()],
+    grantTotal = grants.length,
+    existingGrant = null,
+    insertedGrant = makeGrant(),
+    updatedGrant = makeGrant(),
+    user = makeUser(),
+    channelMappings = [makeChannelMapping()],
+    joinedAgent = { name: "Test Agent" },
+  } = opts
+
+  const db = {
+    selectFrom: vi.fn().mockImplementation((table: string) => {
+      if (table === "agent_user_grant") {
+        // Chain: selectAll → where → where → where → executeTakeFirst (dup check)
+        // OR:   selectAll → where → where → orderBy → limit → offset → execute (list)
+        // OR:   select(countAll) → executeTakeFirstOrThrow (count)
+        // Use a versatile mock that supports multiple chains
+        const chain = {
+          selectAll: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation((_col: string, _op: string, _val: unknown) => {
+              // Return a chain that handles both list (execute) and single (executeTakeFirst)
+              const innerChain: Record<string, ReturnType<typeof vi.fn>> = {}
+              innerChain.where = vi.fn().mockReturnValue(innerChain)
+              innerChain.orderBy = vi.fn().mockReturnValue(innerChain)
+              innerChain.limit = vi.fn().mockReturnValue(innerChain)
+              innerChain.offset = vi.fn().mockReturnValue(innerChain)
+              innerChain.execute = vi.fn().mockResolvedValue(grants)
+              innerChain.executeTakeFirst = vi.fn().mockResolvedValue(existingGrant)
+              return innerChain
+            }),
+          }),
+          select: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation(() => {
+              const innerChain: Record<string, ReturnType<typeof vi.fn>> = {}
+              innerChain.where = vi.fn().mockReturnValue(innerChain)
+              innerChain.executeTakeFirstOrThrow = vi
+                .fn()
+                .mockResolvedValue({ total: String(grantTotal) })
+              return innerChain
+            }),
+          }),
+          where: vi.fn().mockImplementation(() => {
+            // For base query builder pattern (used in GET /agents/:agentId/users)
+            const baseChain: Record<string, ReturnType<typeof vi.fn>> = {}
+            baseChain.where = vi.fn().mockReturnValue(baseChain)
+            baseChain.selectAll = vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockReturnValue({
+                    execute: vi.fn().mockResolvedValue(grants),
+                  }),
+                }),
+              }),
+            })
+            baseChain.select = vi.fn().mockReturnValue({
+              executeTakeFirstOrThrow: vi.fn().mockResolvedValue({ total: String(grantTotal) }),
+            })
+            return baseChain
+          }),
+          innerJoin: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                executeTakeFirst: vi.fn().mockResolvedValue(joinedAgent),
+              }),
+            }),
+          }),
+        }
+        return chain
+      }
+
+      if (table === "user_account") {
+        return {
+          selectAll: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              executeTakeFirst: vi.fn().mockResolvedValue(user),
+            }),
+          }),
+        }
+      }
+
+      if (table === "channel_mapping") {
+        return {
+          selectAll: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              execute: vi.fn().mockResolvedValue(channelMappings),
+            }),
+          }),
+        }
+      }
+
+      if (table === "access_request") {
+        const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+        chain.where = vi.fn().mockReturnValue(chain)
+        chain.selectAll = vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              offset: vi.fn().mockReturnValue({
+                execute: vi.fn().mockResolvedValue([makeAccessRequest()]),
+              }),
+            }),
+          }),
+        })
+        chain.select = vi.fn().mockReturnValue({
+          executeTakeFirstOrThrow: vi.fn().mockResolvedValue({ total: "1" }),
+        })
+        return chain
+      }
+
+      // Fallback
+      return {
+        selectAll: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            executeTakeFirst: vi.fn().mockResolvedValue(null),
+          }),
+        }),
+      }
+    }),
+
+    insertInto: vi.fn().mockImplementation(() => {
+      return {
+        values: vi.fn().mockReturnValue({
+          returningAll: vi.fn().mockReturnValue({
+            executeTakeFirstOrThrow: vi.fn().mockResolvedValue(insertedGrant),
+          }),
+        }),
+      }
+    }),
+
+    updateTable: vi.fn().mockImplementation(() => {
+      const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+      chain.set = vi.fn().mockReturnValue(chain)
+      chain.where = vi.fn().mockReturnValue(chain)
+      chain.returningAll = vi.fn().mockReturnValue(chain)
+      chain.executeTakeFirst = vi.fn().mockResolvedValue(updatedGrant)
+      return chain
+    }),
+  }
+
+  return db
+}
+
+// ---------------------------------------------------------------------------
+// Mock services
+// ---------------------------------------------------------------------------
+
+function mockPairingService() {
+  return {
+    generate: vi.fn().mockResolvedValue({ code: "ABC123", expiresAt: new Date("2099-01-01") }),
+    redeem: vi
+      .fn()
+      .mockResolvedValue({ success: true, message: "Pairing code redeemed", grantId: GRANT_ID }),
+    listActive: vi.fn().mockResolvedValue([
+      {
+        id: CODE_ID,
+        code: "ABC123",
+        agent_id: AGENT_ID,
+        created_by: "dev-user",
+        expires_at: new Date("2099-01-01"),
+        created_at: new Date(),
+      },
+    ]),
+    revoke: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function mockAccessRequestService() {
+  return {
+    create: vi.fn().mockResolvedValue(makeAccessRequest()),
+    approve: vi.fn().mockResolvedValue(makeGrant({ origin: "approval" })),
+    deny: vi.fn().mockResolvedValue(undefined),
+    listPending: vi.fn().mockResolvedValue({ requests: [makeAccessRequest()], total: 1 }),
+    pendingCounts: vi.fn().mockResolvedValue(new Map([[AGENT_ID, 3]])),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// App builder
+// ---------------------------------------------------------------------------
+
+async function buildTestApp(dbOpts: MockDbOptions = {}) {
+  const app = Fastify({ logger: false })
+  const db = mockDb(dbOpts)
+  const pairing = mockPairingService()
+  const accessReq = mockAccessRequestService()
+
+  await app.register(
+    agentUserRoutes({
+      db: db as never,
+      pairingService: pairing as never,
+      accessRequestService: accessReq as never,
+      authConfig: DEV_AUTH_CONFIG,
+    }),
+  )
+
+  return { app, db, pairingService: pairing, accessRequestService: accessReq }
+}
+
+// ===========================================================================
+// GRANTS
+// ===========================================================================
+
+describe("GET /agents/:agentId/users", () => {
+  it("returns grants with total count", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/users`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.grants).toBeDefined()
+    expect(Array.isArray(body.grants)).toBe(true)
+    expect(typeof body.total).toBe("number")
+  })
+})
+
+describe("POST /agents/:agentId/users", () => {
+  it("creates a grant and returns 201", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/users`,
+      payload: { user_account_id: USER_ID },
+    })
+
+    expect(res.statusCode).toBe(201)
+    const body = res.json()
+    expect(body.grant).toBeDefined()
+    expect(body.grant.id).toBe(GRANT_ID)
+  })
+
+  it("returns 409 when user already has a grant", async () => {
+    const { app } = await buildTestApp({ existingGrant: makeGrant() })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/users`,
+      payload: { user_account_id: USER_ID },
+    })
+
+    expect(res.statusCode).toBe(409)
+    const body = res.json()
+    expect(body.error).toBe("conflict")
+  })
+
+  it("validates required user_account_id", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/users`,
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+})
+
+describe("PATCH /agents/:agentId/users/:grantId", () => {
+  it("updates a grant and returns 200", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/agents/${AGENT_ID}/users/${GRANT_ID}`,
+      payload: { access_level: "read" },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.grant).toBeDefined()
+  })
+
+  it("returns 404 when grant not found", async () => {
+    const { app } = await buildTestApp({ updatedGrant: null })
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/agents/${AGENT_ID}/users/${GRANT_ID}`,
+      payload: { access_level: "read" },
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+
+  it("returns 400 when no fields to update", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/agents/${AGENT_ID}/users/${GRANT_ID}`,
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+})
+
+describe("DELETE /agents/:agentId/users/:grantId", () => {
+  it("revokes a grant and returns 204", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/agents/${AGENT_ID}/users/${GRANT_ID}`,
+    })
+
+    expect(res.statusCode).toBe(204)
+  })
+
+  it("returns 404 when grant not found", async () => {
+    const { app } = await buildTestApp({ updatedGrant: null })
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/agents/${AGENT_ID}/users/${GRANT_ID}`,
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+// ===========================================================================
+// PAIRING CODES
+// ===========================================================================
+
+describe("POST /agents/:agentId/pairing-codes", () => {
+  it("generates a pairing code and returns 201", async () => {
+    const { app, pairingService: pairing } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/pairing-codes`,
+    })
+
+    expect(res.statusCode).toBe(201)
+    const body = res.json()
+    expect(body.code).toBe("ABC123")
+    expect(body.expiresAt).toBeDefined()
+    expect(pairing.generate).toHaveBeenCalledWith(AGENT_ID, "dev-user")
+  })
+})
+
+describe("GET /agents/:agentId/pairing-codes", () => {
+  it("returns active pairing codes", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/pairing-codes`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.codes).toBeDefined()
+    expect(Array.isArray(body.codes)).toBe(true)
+  })
+})
+
+describe("DELETE /agents/:agentId/pairing-codes/:codeId", () => {
+  it("revokes a pairing code and returns 204", async () => {
+    const { app, pairingService: pairing } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/agents/${AGENT_ID}/pairing-codes/${CODE_ID}`,
+    })
+
+    expect(res.statusCode).toBe(204)
+    expect(pairing.revoke).toHaveBeenCalledWith(CODE_ID)
+  })
+})
+
+// ===========================================================================
+// ACCESS REQUESTS
+// ===========================================================================
+
+describe("GET /agents/:agentId/access-requests", () => {
+  it("returns access requests with total", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_ID}/access-requests?status=pending`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.requests).toBeDefined()
+    expect(typeof body.total).toBe("number")
+  })
+})
+
+describe("PATCH /agents/:agentId/access-requests/:requestId", () => {
+  it("approves a request and creates a grant", async () => {
+    const { app, accessRequestService: arService } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/agents/${AGENT_ID}/access-requests/${REQUEST_ID}`,
+      payload: { status: "approved" },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.request.status).toBe("approved")
+    expect(body.request.grant_id).toBe(GRANT_ID)
+    expect(arService.approve).toHaveBeenCalledWith(REQUEST_ID, "dev-user")
+  })
+
+  it("denies a request", async () => {
+    const { app, accessRequestService: arService } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/agents/${AGENT_ID}/access-requests/${REQUEST_ID}`,
+      payload: { status: "denied", deny_reason: "Not authorized" },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.request.status).toBe("denied")
+    expect(arService.deny).toHaveBeenCalledWith(REQUEST_ID, "dev-user", "Not authorized")
+  })
+
+  it("returns 409 on conflict", async () => {
+    const { app, accessRequestService: arService } = await buildTestApp()
+    arService.approve.mockRejectedValueOnce(new AccessRequestConflictError("Already approved"))
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/agents/${AGENT_ID}/access-requests/${REQUEST_ID}`,
+      payload: { status: "approved" },
+    })
+
+    expect(res.statusCode).toBe(409)
+    const body = res.json()
+    expect(body.error).toBe("conflict")
+  })
+
+  it("validates required status field", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/agents/${AGENT_ID}/access-requests/${REQUEST_ID}`,
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+})
+
+describe("GET /access-requests/pending-count", () => {
+  it("returns per-agent pending counts", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/access-requests/pending-count",
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.counts).toBeDefined()
+    expect(body.counts[AGENT_ID]).toBe(3)
+  })
+})
+
+// ===========================================================================
+// USER PROFILE
+// ===========================================================================
+
+describe("GET /users/:userId", () => {
+  it("returns user with channel mappings and grants", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/users/${USER_ID}`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.user).toBeDefined()
+    expect(body.user.id).toBe(USER_ID)
+    expect(Array.isArray(body.channelMappings)).toBe(true)
+    expect(Array.isArray(body.grants)).toBe(true)
+  })
+
+  it("returns 404 when user not found", async () => {
+    const { app } = await buildTestApp({ user: null })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/users/${USER_ID}`,
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+// ===========================================================================
+// PAIRING
+// ===========================================================================
+
+describe("POST /pair", () => {
+  it("redeems a pairing code and returns linked=true", async () => {
+    const { app, pairingService: pairing } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/pair",
+      payload: {
+        code: "ABC123",
+        channel_mapping_id: "cmcmcmcm-1111-2222-3333-444444444444",
+        user_account_id: USER_ID,
+      },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.linked).toBe(true)
+    expect(body.agentName).toBe("Test Agent")
+    expect(pairing.redeem).toHaveBeenCalledWith(
+      "ABC123",
+      "cmcmcmcm-1111-2222-3333-444444444444",
+      USER_ID,
+    )
+  })
+
+  it("returns 400 when pairing code is invalid", async () => {
+    const { app, pairingService: pairing } = await buildTestApp()
+    pairing.redeem.mockResolvedValueOnce({
+      success: false,
+      message: "Invalid pairing code",
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/pair",
+      payload: {
+        code: "BADCODE",
+        channel_mapping_id: "cmcmcmcm-1111-2222-3333-444444444444",
+        user_account_id: USER_ID,
+      },
+    })
+
+    expect(res.statusCode).toBe(400)
+    const body = res.json()
+    expect(body.error).toBe("bad_request")
+    expect(body.message).toContain("Invalid")
+  })
+
+  it("validates required fields", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/pair",
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+})

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -8,7 +8,9 @@ import type { Kysely } from "kysely"
 import type pg from "pg"
 
 import { ApprovalService } from "./approval/service.js"
+import { AccessRequestService } from "./auth/access-request-service.js"
 import { CredentialService } from "./auth/credential-service.js"
+import { PairingService } from "./auth/pairing-service.js"
 import { SessionService } from "./auth/session-service.js"
 import { ClaudeCodeBackend } from "./backends/claude-code.js"
 import { HttpLlmBackend } from "./backends/http-llm.js"
@@ -34,6 +36,7 @@ import { agentControlRoutes } from "./routes/agent-control.js"
 import { agentCredentialRoutes } from "./routes/agent-credentials.js"
 import { agentLifecycleRoutes } from "./routes/agent-lifecycle.js"
 import { agentToolBindingRoutes } from "./routes/agent-tool-bindings.js"
+import { agentUserRoutes } from "./routes/agent-user-routes.js"
 import { agentRoutes } from "./routes/agents.js"
 import { approvalRoutes } from "./routes/approval.js"
 import { authRoutes } from "./routes/auth.js"
@@ -228,6 +231,19 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
   await app.register(
     agentChannelRoutes({
       service: agentChannelService,
+      authConfig,
+      sessionService,
+    }),
+  )
+
+  // Register agent user grant, pairing code, and access request routes
+  const pairingService = new PairingService(db)
+  const accessRequestService = new AccessRequestService(db)
+  await app.register(
+    agentUserRoutes({
+      db,
+      pairingService,
+      accessRequestService,
       authConfig,
       sessionService,
     }),

--- a/packages/control-plane/src/routes/agent-user-routes.ts
+++ b/packages/control-plane/src/routes/agent-user-routes.ts
@@ -1,0 +1,627 @@
+/**
+ * Agent User Routes — CRUD for user grants, pairing codes, and access requests.
+ *
+ * GET    /agents/:agentId/users                       — List grants (paginated)
+ * POST   /agents/:agentId/users                       — Create grant (201)
+ * PATCH  /agents/:agentId/users/:grantId              — Update grant
+ * DELETE /agents/:agentId/users/:grantId              — Revoke grant (soft-delete, 204)
+ *
+ * POST   /agents/:agentId/pairing-codes               — Generate pairing code (201)
+ * GET    /agents/:agentId/pairing-codes               — List active pairing codes
+ * DELETE /agents/:agentId/pairing-codes/:codeId       — Revoke pairing code (204)
+ *
+ * GET    /agents/:agentId/access-requests              — List access requests (paginated)
+ * PATCH  /agents/:agentId/access-requests/:requestId  — Approve or deny
+ * GET    /access-requests/pending-count                — Per-agent pending counts
+ *
+ * GET    /users/:userId                                — User profile + grants
+ * POST   /pair                                         — Redeem pairing code
+ */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
+import type { Kysely } from "kysely"
+
+import {
+  AccessRequestConflictError,
+  type AccessRequestService,
+} from "../auth/access-request-service.js"
+import type { PairingService } from "../auth/pairing-service.js"
+import type { SessionService } from "../auth/session-service.js"
+import type { AccessRequestStatus, Database, GrantAccessLevel } from "../db/types.js"
+import {
+  type AuthMiddlewareOptions,
+  createRequireAuth,
+  createRequireRole,
+  type PreHandler,
+} from "../middleware/auth.js"
+import type { AuthConfig, AuthenticatedRequest } from "../middleware/types.js"
+
+// ---------------------------------------------------------------------------
+// Route types
+// ---------------------------------------------------------------------------
+
+interface AgentParams {
+  agentId: string
+}
+
+interface GrantParams {
+  agentId: string
+  grantId: string
+}
+
+interface PairingCodeParams {
+  agentId: string
+  codeId: string
+}
+
+interface AccessRequestParams {
+  agentId: string
+  requestId: string
+}
+
+interface UserParams {
+  userId: string
+}
+
+interface PaginationQuery {
+  limit?: number
+  offset?: number
+}
+
+interface AccessRequestQuery extends PaginationQuery {
+  status?: AccessRequestStatus
+}
+
+interface CreateGrantBody {
+  user_account_id: string
+  access_level?: GrantAccessLevel
+  rate_limit?: { max_messages: number; window_seconds: number } | null
+  token_budget?: { max_tokens: number; window_seconds: number } | null
+  expires_at?: string | null
+}
+
+interface UpdateGrantBody {
+  access_level?: GrantAccessLevel
+  rate_limit?: { max_messages: number; window_seconds: number } | null
+  token_budget?: { max_tokens: number; window_seconds: number } | null
+}
+
+interface PatchAccessRequestBody {
+  status: "approved" | "denied"
+  deny_reason?: string
+}
+
+interface PairBody {
+  code: string
+  channel_mapping_id: string
+  user_account_id: string
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+export interface AgentUserRouteDeps {
+  db: Kysely<Database>
+  pairingService: PairingService
+  accessRequestService: AccessRequestService
+  authConfig: AuthConfig
+  sessionService?: SessionService
+}
+
+export function agentUserRoutes(deps: AgentUserRouteDeps) {
+  const { db, pairingService, accessRequestService, authConfig, sessionService } = deps
+
+  const authOpts: AuthMiddlewareOptions = { config: authConfig, sessionService }
+  const requireAuth: PreHandler = createRequireAuth(authOpts)
+  const requireOperator: PreHandler = createRequireRole("operator")
+
+  return function register(app: FastifyInstance): void {
+    // =================================================================
+    // GRANTS
+    // =================================================================
+
+    // GET /agents/:agentId/users — List active grants (paginated)
+    app.get<{ Params: AgentParams; Querystring: PaginationQuery }>(
+      "/agents/:agentId/users",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+          querystring: {
+            type: "object",
+            properties: {
+              limit: { type: "integer", minimum: 1, maximum: 100, default: 50 },
+              offset: { type: "integer", minimum: 0, default: 0 },
+            },
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: AgentParams; Querystring: PaginationQuery }>,
+        reply: FastifyReply,
+      ) => {
+        const { agentId } = request.params
+        const { limit = 50, offset = 0 } = request.query
+
+        const baseQuery = db
+          .selectFrom("agent_user_grant")
+          .where("agent_id", "=", agentId)
+          .where("revoked_at", "is", null)
+
+        const [grants, countResult] = await Promise.all([
+          baseQuery.selectAll().orderBy("created_at", "desc").limit(limit).offset(offset).execute(),
+          baseQuery.select((eb) => eb.fn.countAll<string>().as("total")).executeTakeFirstOrThrow(),
+        ])
+
+        const total = Number(countResult.total)
+        return reply.status(200).send({ grants, total })
+      },
+    )
+
+    // POST /agents/:agentId/users — Create a dashboard-invite grant
+    app.post<{ Params: AgentParams; Body: CreateGrantBody }>(
+      "/agents/:agentId/users",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              user_account_id: { type: "string", minLength: 1 },
+              access_level: { type: "string", enum: ["read", "write"] },
+              rate_limit: {
+                type: ["object", "null"],
+                properties: {
+                  max_messages: { type: "integer" },
+                  window_seconds: { type: "integer" },
+                },
+              },
+              token_budget: {
+                type: ["object", "null"],
+                properties: {
+                  max_tokens: { type: "integer" },
+                  window_seconds: { type: "integer" },
+                },
+              },
+              expires_at: { type: ["string", "null"] },
+            },
+            required: ["user_account_id"],
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: AgentParams; Body: CreateGrantBody }>,
+        reply: FastifyReply,
+      ) => {
+        const { agentId } = request.params
+        const body = request.body
+        const principal = (request as AuthenticatedRequest).principal
+
+        // Check for duplicate active grant
+        const existing = await db
+          .selectFrom("agent_user_grant")
+          .selectAll()
+          .where("agent_id", "=", agentId)
+          .where("user_account_id", "=", body.user_account_id)
+          .where("revoked_at", "is", null)
+          .executeTakeFirst()
+
+        if (existing) {
+          return reply.status(409).send({
+            error: "conflict",
+            message: "User already has an active grant for this agent",
+          })
+        }
+
+        const grant = await db
+          .insertInto("agent_user_grant")
+          .values({
+            agent_id: agentId,
+            user_account_id: body.user_account_id,
+            access_level: body.access_level ?? "write",
+            origin: "dashboard_invite",
+            granted_by: principal.userId,
+            rate_limit: body.rate_limit ?? null,
+            token_budget: body.token_budget ?? null,
+            expires_at: body.expires_at ? new Date(body.expires_at) : null,
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow()
+
+        return reply.status(201).send({ grant })
+      },
+    )
+
+    // PATCH /agents/:agentId/users/:grantId — Update grant
+    app.patch<{ Params: GrantParams; Body: UpdateGrantBody }>(
+      "/agents/:agentId/users/:grantId",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string" },
+              grantId: { type: "string" },
+            },
+            required: ["agentId", "grantId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              access_level: { type: "string", enum: ["read", "write"] },
+              rate_limit: {
+                type: ["object", "null"],
+                properties: {
+                  max_messages: { type: "integer" },
+                  window_seconds: { type: "integer" },
+                },
+              },
+              token_budget: {
+                type: ["object", "null"],
+                properties: {
+                  max_tokens: { type: "integer" },
+                  window_seconds: { type: "integer" },
+                },
+              },
+            },
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: GrantParams; Body: UpdateGrantBody }>,
+        reply: FastifyReply,
+      ) => {
+        const { agentId, grantId } = request.params
+        const body = request.body
+
+        const updates: Record<string, unknown> = {}
+        if (body.access_level !== undefined) updates.access_level = body.access_level
+        if (body.rate_limit !== undefined) updates.rate_limit = body.rate_limit
+        if (body.token_budget !== undefined) updates.token_budget = body.token_budget
+
+        if (Object.keys(updates).length === 0) {
+          return reply.status(400).send({ error: "bad_request", message: "No fields to update" })
+        }
+
+        const grant = await db
+          .updateTable("agent_user_grant")
+          .set(updates)
+          .where("id", "=", grantId)
+          .where("agent_id", "=", agentId)
+          .where("revoked_at", "is", null)
+          .returningAll()
+          .executeTakeFirst()
+
+        if (!grant) {
+          return reply.status(404).send({ error: "not_found", message: "Grant not found" })
+        }
+
+        return reply.status(200).send({ grant })
+      },
+    )
+
+    // DELETE /agents/:agentId/users/:grantId — Revoke grant (soft delete)
+    app.delete<{ Params: GrantParams }>(
+      "/agents/:agentId/users/:grantId",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string" },
+              grantId: { type: "string" },
+            },
+            required: ["agentId", "grantId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: GrantParams }>, reply: FastifyReply) => {
+        const { agentId, grantId } = request.params
+
+        const updated = await db
+          .updateTable("agent_user_grant")
+          .set({ revoked_at: new Date() })
+          .where("id", "=", grantId)
+          .where("agent_id", "=", agentId)
+          .where("revoked_at", "is", null)
+          .returningAll()
+          .executeTakeFirst()
+
+        if (!updated) {
+          return reply.status(404).send({ error: "not_found", message: "Grant not found" })
+        }
+
+        return reply.status(204).send()
+      },
+    )
+
+    // =================================================================
+    // PAIRING CODES
+    // =================================================================
+
+    // POST /agents/:agentId/pairing-codes — Generate a pairing code
+    app.post<{ Params: AgentParams }>(
+      "/agents/:agentId/pairing-codes",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: AgentParams }>, reply: FastifyReply) => {
+        const { agentId } = request.params
+        const principal = (request as AuthenticatedRequest).principal
+
+        const result = await pairingService.generate(agentId, principal.userId)
+
+        return reply.status(201).send({ code: result.code, expiresAt: result.expiresAt })
+      },
+    )
+
+    // GET /agents/:agentId/pairing-codes — List active pairing codes
+    app.get<{ Params: AgentParams }>(
+      "/agents/:agentId/pairing-codes",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: AgentParams }>, reply: FastifyReply) => {
+        const codes = await pairingService.listActive(request.params.agentId)
+        return reply.status(200).send({ codes })
+      },
+    )
+
+    // DELETE /agents/:agentId/pairing-codes/:codeId — Revoke a pairing code
+    app.delete<{ Params: PairingCodeParams }>(
+      "/agents/:agentId/pairing-codes/:codeId",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string" },
+              codeId: { type: "string" },
+            },
+            required: ["agentId", "codeId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: PairingCodeParams }>, reply: FastifyReply) => {
+        const { codeId } = request.params
+
+        await pairingService.revoke(codeId)
+        return reply.status(204).send()
+      },
+    )
+
+    // =================================================================
+    // ACCESS REQUESTS
+    // =================================================================
+
+    // GET /agents/:agentId/access-requests — List access requests (paginated)
+    app.get<{ Params: AgentParams; Querystring: AccessRequestQuery }>(
+      "/agents/:agentId/access-requests",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+          querystring: {
+            type: "object",
+            properties: {
+              status: { type: "string", enum: ["pending", "approved", "denied"] },
+              limit: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+              offset: { type: "integer", minimum: 0, default: 0 },
+            },
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: AgentParams; Querystring: AccessRequestQuery }>,
+        reply: FastifyReply,
+      ) => {
+        const { agentId } = request.params
+        const { status, limit = 20, offset = 0 } = request.query
+
+        let baseQuery = db.selectFrom("access_request").where("agent_id", "=", agentId)
+
+        if (status) {
+          baseQuery = baseQuery.where("status", "=", status)
+        }
+
+        const [requests, countResult] = await Promise.all([
+          baseQuery.selectAll().orderBy("created_at", "desc").limit(limit).offset(offset).execute(),
+          baseQuery.select((eb) => eb.fn.countAll<string>().as("total")).executeTakeFirstOrThrow(),
+        ])
+
+        const total = Number(countResult.total)
+        return reply.status(200).send({ requests, total })
+      },
+    )
+
+    // PATCH /agents/:agentId/access-requests/:requestId — Approve or deny
+    app.patch<{ Params: AccessRequestParams; Body: PatchAccessRequestBody }>(
+      "/agents/:agentId/access-requests/:requestId",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              agentId: { type: "string" },
+              requestId: { type: "string" },
+            },
+            required: ["agentId", "requestId"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              status: { type: "string", enum: ["approved", "denied"] },
+              deny_reason: { type: "string" },
+            },
+            required: ["status"],
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: AccessRequestParams; Body: PatchAccessRequestBody }>,
+        reply: FastifyReply,
+      ) => {
+        const { requestId } = request.params
+        const { status, deny_reason } = request.body
+        const principal = (request as AuthenticatedRequest).principal
+
+        try {
+          if (status === "approved") {
+            const grant = await accessRequestService.approve(requestId, principal.userId)
+            return reply.status(200).send({ request: { status: "approved", grant_id: grant.id } })
+          }
+
+          await accessRequestService.deny(requestId, principal.userId, deny_reason)
+          return reply.status(200).send({ request: { status: "denied" } })
+        } catch (err: unknown) {
+          if (err instanceof AccessRequestConflictError) {
+            return reply.status(409).send({ error: "conflict", message: (err as Error).message })
+          }
+          throw err
+        }
+      },
+    )
+
+    // GET /access-requests/pending-count — Per-agent pending counts
+    app.get(
+      "/access-requests/pending-count",
+      {
+        preHandler: [requireAuth, requireOperator],
+      },
+      async (_request: FastifyRequest, reply: FastifyReply) => {
+        const counts = await accessRequestService.pendingCounts()
+        // Convert Map to plain object for JSON serialization
+        const countsObj: Record<string, number> = {}
+        for (const [agentId, count] of counts) {
+          countsObj[agentId] = count
+        }
+        return reply.status(200).send({ counts: countsObj })
+      },
+    )
+
+    // =================================================================
+    // USER PROFILE
+    // =================================================================
+
+    // GET /users/:userId — User profile with channel mappings and grants
+    app.get<{ Params: UserParams }>(
+      "/users/:userId",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: { userId: { type: "string" } },
+            required: ["userId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: UserParams }>, reply: FastifyReply) => {
+        const { userId } = request.params
+
+        const user = await db
+          .selectFrom("user_account")
+          .selectAll()
+          .where("id", "=", userId)
+          .executeTakeFirst()
+
+        if (!user) {
+          return reply.status(404).send({ error: "not_found", message: "User not found" })
+        }
+
+        const [channelMappings, grants] = await Promise.all([
+          db
+            .selectFrom("channel_mapping")
+            .selectAll()
+            .where("user_account_id", "=", userId)
+            .execute(),
+          db
+            .selectFrom("agent_user_grant")
+            .selectAll()
+            .where("user_account_id", "=", userId)
+            .where("revoked_at", "is", null)
+            .execute(),
+        ])
+
+        return reply.status(200).send({ user, channelMappings, grants })
+      },
+    )
+
+    // =================================================================
+    // PAIRING (public endpoint for end-users)
+    // =================================================================
+
+    // POST /pair — Redeem a pairing code
+    app.post<{ Body: PairBody }>(
+      "/pair",
+      {
+        schema: {
+          body: {
+            type: "object",
+            properties: {
+              code: { type: "string", minLength: 1 },
+              channel_mapping_id: { type: "string", minLength: 1 },
+              user_account_id: { type: "string", minLength: 1 },
+            },
+            required: ["code", "channel_mapping_id", "user_account_id"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Body: PairBody }>, reply: FastifyReply) => {
+        const { code, channel_mapping_id, user_account_id } = request.body
+
+        const result = await pairingService.redeem(code, channel_mapping_id, user_account_id)
+
+        if (!result.success) {
+          return reply.status(400).send({ error: "bad_request", message: result.message })
+        }
+
+        // Look up agent name if a grant was created
+        let agentName: string | undefined
+        if (result.grantId) {
+          const grant = await db
+            .selectFrom("agent_user_grant")
+            .innerJoin("agent", "agent.id", "agent_user_grant.agent_id")
+            .select("agent.name")
+            .where("agent_user_grant.id", "=", result.grantId)
+            .executeTakeFirst()
+          agentName = grant?.name ?? undefined
+        }
+
+        return reply.status(200).send({ linked: true, agentName })
+      },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Add `agent-user-routes.ts` with 12 REST endpoints for user grant CRUD, pairing code lifecycle, access request review, user profile lookup, and pending-count dashboard query
- Register routes in `app.ts` with `PairingService` and `AccessRequestService` dependency injection
- Add 23 tests covering all routes (happy path + error cases: 409 conflict, 404 not found, 400 validation)

## Routes implemented
| Method | Path | Description |
|--------|------|-------------|
| GET | `/agents/:agentId/users` | List active grants (paginated) |
| POST | `/agents/:agentId/users` | Create dashboard-invite grant |
| PATCH | `/agents/:agentId/users/:grantId` | Update grant (access_level, rate_limit, token_budget) |
| DELETE | `/agents/:agentId/users/:grantId` | Revoke grant (soft delete) |
| POST | `/agents/:agentId/pairing-codes` | Generate pairing code |
| GET | `/agents/:agentId/pairing-codes` | List active pairing codes |
| DELETE | `/agents/:agentId/pairing-codes/:codeId` | Revoke pairing code |
| GET | `/agents/:agentId/access-requests` | List access requests (filterable by status) |
| PATCH | `/agents/:agentId/access-requests/:reqId` | Approve or deny request |
| GET | `/access-requests/pending-count` | Per-agent pending counts |
| GET | `/users/:userId` | User profile + channel mappings + grants |
| POST | `/pair` | Redeem pairing code |

## Test plan
- [x] All 23 new route tests pass
- [x] Full test suite (1444 tests) passes
- [x] TypeScript typecheck passes
- [x] ESLint passes (0 errors, only pre-existing turbo warnings)

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent user grant management: create, update, and revoke access grants
  * Pairing code workflow: generate codes, retrieve active codes, and redeem for account linking
  * Access request system: list and approve/deny requests with per-agent pending count tracking
  * User profile endpoint: retrieve user information with associated channel mappings and grants

* **Tests**
  * Comprehensive test coverage for all agent-user routes including success and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->