### PR TITLE
feat(dashboard): user detail page — identity, access, and usage (#342)

### DIFF
--- a/packages/dashboard/fixtures/api-responses/user-detail.json
+++ b/packages/dashboard/fixtures/api-responses/user-detail.json
@@ -1,0 +1,59 @@
+{
+  "user": {
+    "id": "u1a2b3c4-d5e6-7890-abcd-ef1234567890",
+    "display_name": "Alice Johnson",
+    "email": "alice@example.com",
+    "avatar_url": "https://example.com/avatars/alice.png",
+    "role": "operator",
+    "oauth_provider": "google",
+    "oauth_provider_id": "112233445566",
+    "created_at": "2025-06-01T09:00:00.000Z",
+    "updated_at": "2025-12-15T14:30:00.000Z"
+  },
+  "channelMappings": [
+    {
+      "id": "cm-001",
+      "user_account_id": "u1a2b3c4-d5e6-7890-abcd-ef1234567890",
+      "channel_type": "telegram",
+      "channel_user_id": "tg_alice_42",
+      "metadata": { "username": "alice_tg" },
+      "created_at": "2025-06-02T10:00:00.000Z"
+    },
+    {
+      "id": "cm-002",
+      "user_account_id": "u1a2b3c4-d5e6-7890-abcd-ef1234567890",
+      "channel_type": "discord",
+      "channel_user_id": "disc_alice_99",
+      "metadata": null,
+      "created_at": "2025-07-10T12:00:00.000Z"
+    }
+  ],
+  "grants": [
+    {
+      "id": "grant-001",
+      "agent_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "user_account_id": "u1a2b3c4-d5e6-7890-abcd-ef1234567890",
+      "access_level": "write",
+      "origin": "dashboard_invite",
+      "granted_by": "admin-user-id",
+      "rate_limit": { "max_messages": 100, "window_seconds": 3600 },
+      "token_budget": { "max_tokens": 50000, "window_seconds": 86400 },
+      "expires_at": null,
+      "revoked_at": null,
+      "created_at": "2025-08-01T08:00:00.000Z"
+    },
+    {
+      "id": "grant-002",
+      "agent_id": "b2c3d4e5-f6a7-8901-bcde-f23456789012",
+      "user_account_id": "u1a2b3c4-d5e6-7890-abcd-ef1234567890",
+      "access_level": "read",
+      "origin": "pairing_code",
+      "granted_by": null,
+      "rate_limit": null,
+      "token_budget": null,
+      "expires_at": "2026-06-01T00:00:00.000Z",
+      "revoked_at": null,
+      "created_at": "2025-09-15T16:00:00.000Z"
+    }
+  ]
+}

--- a/packages/dashboard/src/__tests__/user-detail.test.ts
+++ b/packages/dashboard/src/__tests__/user-detail.test.ts
@@ -1,0 +1,172 @@
+/**
+ * User detail — schema contract tests + fixture validation.
+ *
+ * Validates that the user Zod schemas match the fixture shape and that
+ * API client functions reference the correct schemas.
+ */
+
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import userDetailFixture from "../../fixtures/api-responses/user-detail.json"
+import {
+  ChannelMappingSchema,
+  UserAccountSchema,
+  UserDetailResponseSchema,
+  UserGrantSchema,
+  UserUsageResponseSchema,
+} from "../lib/schemas/users"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function collectKeys(obj: unknown): Set<string> {
+  if (obj === null || obj === undefined || typeof obj !== "object" || Array.isArray(obj)) {
+    return new Set()
+  }
+  return new Set(Object.keys(obj))
+}
+
+function assertContractMatch(schema: z.ZodTypeAny, fixture: unknown, label: string) {
+  const result = schema.safeParse(fixture)
+  if (!result.success) {
+    const formatted = result.error.issues
+      .map((i) => `  ${i.path.join(".")}: ${i.message}`)
+      .join("\n")
+    throw new Error(`${label}: Schema.parse(fixture) failed:\n${formatted}`)
+  }
+
+  const parsed = result.data as Record<string, unknown>
+  const fixtureObj = fixture as Record<string, unknown>
+
+  const parsedKeys = collectKeys(parsed)
+  const fixtureKeys = collectKeys(fixtureObj)
+
+  for (const key of parsedKeys) {
+    expect(fixtureKeys.has(key), `${label}: parsed key "${key}" not found in fixture`).toBe(true)
+  }
+  for (const key of fixtureKeys) {
+    expect(parsedKeys.has(key), `${label}: fixture key "${key}" was silently dropped`).toBe(true)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Contract tests
+// ---------------------------------------------------------------------------
+
+describe("User detail contract tests", () => {
+  describe("GET /users/:id — UserDetailResponseSchema", () => {
+    it("parses the fixture successfully", () => {
+      const result = UserDetailResponseSchema.parse(userDetailFixture)
+      expect(result.user.id).toBe("u1a2b3c4-d5e6-7890-abcd-ef1234567890")
+      expect(result.channelMappings).toHaveLength(2)
+      expect(result.grants).toHaveLength(2)
+    })
+
+    it("does not silently drop user fields", () => {
+      assertContractMatch(UserAccountSchema, userDetailFixture.user, "UserAccount")
+    })
+
+    it("does not silently drop channel mapping fields", () => {
+      for (const mapping of userDetailFixture.channelMappings) {
+        assertContractMatch(ChannelMappingSchema, mapping, `ChannelMapping ${mapping.id}`)
+      }
+    })
+
+    it("does not silently drop grant fields", () => {
+      for (const grant of userDetailFixture.grants) {
+        assertContractMatch(UserGrantSchema, grant, `UserGrant ${grant.id}`)
+      }
+    })
+  })
+
+  describe("strict schema variants", () => {
+    it("UserAccountSchema.strict() accepts fixture exactly", () => {
+      const strict = UserAccountSchema.strict()
+      expect(() => strict.parse(userDetailFixture.user)).not.toThrow()
+    })
+
+    it("ChannelMappingSchema.strict() accepts fixture exactly", () => {
+      const strict = ChannelMappingSchema.strict()
+      for (const mapping of userDetailFixture.channelMappings) {
+        expect(() => strict.parse(mapping)).not.toThrow()
+      }
+    })
+
+    it("UserGrantSchema.strict() accepts fixture exactly", () => {
+      const strict = UserGrantSchema.strict()
+      for (const grant of userDetailFixture.grants) {
+        expect(() => strict.parse(grant)).not.toThrow()
+      }
+    })
+  })
+
+  describe("UserUsageResponseSchema", () => {
+    it("parses empty usage array", () => {
+      const empty = { usage: [] }
+      const result = UserUsageResponseSchema.parse(empty)
+      expect(result.usage).toHaveLength(0)
+    })
+
+    it("parses a usage entry", () => {
+      const response = {
+        usage: [
+          {
+            id: "ul-001",
+            user_account_id: "u1",
+            agent_id: "a1",
+            period_start: "2025-12-01T00:00:00.000Z",
+            period_end: "2025-12-02T00:00:00.000Z",
+            messages_sent: 42,
+            tokens_in: 12000,
+            tokens_out: 8000,
+            cost_usd: "0.15",
+            created_at: "2025-12-02T00:00:01.000Z",
+          },
+        ],
+      }
+      const result = UserUsageResponseSchema.parse(response)
+      expect(result.usage).toHaveLength(1)
+      expect(result.usage[0]!.messages_sent).toBe(42)
+      expect(result.usage[0]!.cost_usd).toBe("0.15")
+    })
+  })
+
+  describe("edge cases", () => {
+    it("handles user with null optional fields", () => {
+      const minimalUser = {
+        id: "u-min",
+        display_name: null,
+        email: null,
+        avatar_url: null,
+        role: "operator",
+        oauth_provider: null,
+        oauth_provider_id: null,
+        created_at: "2025-01-01T00:00:00.000Z",
+        updated_at: "2025-01-01T00:00:00.000Z",
+      }
+      const result = UserAccountSchema.parse(minimalUser)
+      expect(result.display_name).toBeNull()
+      expect(result.email).toBeNull()
+    })
+
+    it("validates grant access_level enum", () => {
+      const badGrant = { ...userDetailFixture.grants[0], access_level: "admin" }
+      const result = UserGrantSchema.safeParse(badGrant)
+      expect(result.success).toBe(false)
+    })
+
+    it("validates grant origin enum", () => {
+      const badGrant = { ...userDetailFixture.grants[0], origin: "unknown" }
+      const result = UserGrantSchema.safeParse(badGrant)
+      expect(result.success).toBe(false)
+    })
+
+    it("validates user role enum", () => {
+      const badUser = { ...userDetailFixture.user, role: "superuser" }
+      const result = UserAccountSchema.safeParse(badUser)
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/packages/dashboard/src/app/users/[id]/page.tsx
+++ b/packages/dashboard/src/app/users/[id]/page.tsx
@@ -1,0 +1,230 @@
+"use client"
+
+import Link from "next/link"
+import { use, useCallback, useState } from "react"
+
+import { EmptyState } from "@/components/layout/empty-state"
+import { Skeleton } from "@/components/layout/skeleton"
+import { Badge } from "@/components/ui/badge"
+import { Panel } from "@/components/ui/panel"
+import { UserIdentityCard } from "@/components/user-identity-card"
+import { UserUsageChart } from "@/components/user-usage-chart"
+import { useApi, useApiQuery } from "@/hooks/use-api"
+import type { UserGrant } from "@/lib/api/users"
+import { getUser, revokeUserGrant } from "@/lib/api/users"
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+interface UserDetailPageProps {
+  params: Promise<{ id: string }>
+}
+
+export default function UserDetailPage({ params }: UserDetailPageProps): React.JSX.Element {
+  const { id: userId } = use(params)
+  const { data, isLoading, error, errorCode, refetch } = useApiQuery(
+    () => getUser(userId),
+    [userId],
+  )
+
+  if (isLoading) {
+    return <UserDetailSkeleton />
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6">
+        <Breadcrumb userId={userId} />
+        <div className="rounded-xl bg-danger/10 px-6 py-4 text-sm text-danger">
+          {errorCode === "NOT_FOUND" ? "User not found." : `Failed to load user: ${error}`}
+        </div>
+      </div>
+    )
+  }
+
+  if (!data) return <UserDetailSkeleton />
+
+  const { user, channelMappings, grants } = data
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6">
+      <Breadcrumb userId={userId} userName={user.display_name} />
+
+      <div className="grid gap-6 lg:grid-cols-[360px_1fr]">
+        {/* Left column: identity + usage */}
+        <div className="flex flex-col gap-6">
+          <UserIdentityCard user={user} channels={channelMappings} />
+          <UserUsageChart userId={userId} />
+        </div>
+
+        {/* Right column: agent access table + actions */}
+        <div className="flex flex-col gap-6">
+          <AgentAccessTable grants={grants} onRevoke={() => void refetch()} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Breadcrumb
+// ---------------------------------------------------------------------------
+
+function Breadcrumb({ userId, userName }: { userId: string; userName?: string | null }) {
+  return (
+    <nav className="flex items-center gap-2 text-sm">
+      <Link href="/agents" className="text-slate-400 transition-colors hover:text-primary">
+        Agents
+      </Link>
+      <span className="material-symbols-outlined text-xs text-slate-600">chevron_right</span>
+      <span className="flex items-center gap-1.5 font-bold text-white">
+        <span className="material-symbols-outlined text-sm text-primary">person</span>
+        {userName ?? userId}
+      </span>
+    </nav>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Agent access table
+// ---------------------------------------------------------------------------
+
+const ORIGIN_LABELS: Record<string, string> = {
+  pairing_code: "Pairing code",
+  dashboard_invite: "Dashboard invite",
+  auto_team: "Auto (team)",
+  auto_open: "Auto (open)",
+  approval: "Approval",
+}
+
+interface AgentAccessTableProps {
+  grants: UserGrant[]
+  onRevoke: () => void
+}
+
+function AgentAccessTable({ grants, onRevoke }: AgentAccessTableProps) {
+  const { execute: executeRevoke, isLoading: revoking } = useApi(
+    (agentId: unknown, grantId: unknown) => revokeUserGrant(agentId as string, grantId as string),
+  )
+  const [confirmId, setConfirmId] = useState<string | null>(null)
+
+  const handleRevoke = useCallback(
+    async (grant: UserGrant) => {
+      await executeRevoke(grant.agent_id, grant.id)
+      setConfirmId(null)
+      onRevoke()
+    },
+    [executeRevoke, onRevoke],
+  )
+
+  if (grants.length === 0) {
+    return (
+      <EmptyState
+        icon="shield_person"
+        title="No agent access"
+        description="This user has no active grants to any agents."
+      />
+    )
+  }
+
+  return (
+    <Panel className="overflow-hidden">
+      <div className="border-b border-surface-border px-5 py-3">
+        <h3 className="font-display text-sm font-bold text-text-main">
+          Agent access ({grants.length})
+        </h3>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr className="border-b border-surface-border text-xs text-text-muted">
+              <th className="px-5 py-2 font-medium">Agent</th>
+              <th className="px-5 py-2 font-medium">Access</th>
+              <th className="px-5 py-2 font-medium">Origin</th>
+              <th className="px-5 py-2 font-medium">Granted</th>
+              <th className="px-5 py-2 font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {grants.map((grant) => (
+              <tr
+                key={grant.id}
+                className="border-b border-surface-border last:border-b-0 hover:bg-secondary/50"
+              >
+                <td className="px-5 py-3">
+                  <Link
+                    href={`/agents/${grant.agent_id}`}
+                    className="font-medium text-primary hover:underline"
+                  >
+                    {grant.agent_id.slice(0, 8)}…
+                  </Link>
+                </td>
+                <td className="px-5 py-3">
+                  <Badge variant={grant.access_level === "write" ? "success" : "info"}>
+                    {grant.access_level}
+                  </Badge>
+                </td>
+                <td className="px-5 py-3 text-text-muted">
+                  {ORIGIN_LABELS[grant.origin] ?? grant.origin}
+                </td>
+                <td className="px-5 py-3 text-text-muted">
+                  {new Date(grant.created_at).toLocaleDateString()}
+                </td>
+                <td className="px-5 py-3">
+                  {confirmId === grant.id ? (
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        disabled={revoking}
+                        onClick={() => void handleRevoke(grant)}
+                        className="rounded bg-danger px-2 py-1 text-xs font-medium text-white hover:bg-danger/80 disabled:opacity-50"
+                      >
+                        {revoking ? "Revoking…" : "Confirm"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setConfirmId(null)}
+                        className="text-xs text-text-muted hover:text-text-main"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setConfirmId(grant.id)}
+                      className="text-xs text-danger hover:underline"
+                    >
+                      Revoke
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Panel>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function UserDetailSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6">
+      <Skeleton className="h-5 w-48" />
+      <div className="grid gap-6 lg:grid-cols-[360px_1fr]">
+        <div className="flex flex-col gap-6">
+          <Skeleton className="h-48 w-full" />
+          <Skeleton className="h-40 w-full" />
+        </div>
+        <Skeleton className="h-64 w-full" />
+      </div>
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/user-identity-card.tsx
+++ b/packages/dashboard/src/components/user-identity-card.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { Panel } from "@/components/ui/panel"
+import type { ChannelMapping, UserAccount } from "@/lib/api/users"
+
+// ---------------------------------------------------------------------------
+// Channel type → icon mapping
+// ---------------------------------------------------------------------------
+
+const CHANNEL_ICONS: Record<string, string> = {
+  telegram: "send",
+  discord: "forum",
+  slack: "tag",
+  rest: "api",
+}
+
+function channelIcon(type: string): string {
+  return CHANNEL_ICONS[type] ?? "link"
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface UserIdentityCardProps {
+  user: UserAccount
+  channels: ChannelMapping[]
+}
+
+export function UserIdentityCard({ user, channels }: UserIdentityCardProps) {
+  const initials = (user.display_name ?? user.email ?? "?")
+    .split(/[\s@]/)
+    .slice(0, 2)
+    .map((s) => s[0]?.toUpperCase() ?? "")
+    .join("")
+
+  return (
+    <Panel className="p-5">
+      <div className="flex items-start gap-4">
+        {/* Avatar */}
+        {user.avatar_url ? (
+          <img
+            src={user.avatar_url}
+            alt={user.display_name ?? "User avatar"}
+            className="size-14 rounded-full object-cover ring-2 ring-surface-border"
+          />
+        ) : (
+          <div className="flex size-14 items-center justify-center rounded-full bg-primary/10 text-lg font-bold text-primary ring-2 ring-surface-border">
+            {initials}
+          </div>
+        )}
+
+        {/* Identity */}
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate font-display text-lg font-bold text-text-main">
+            {user.display_name ?? "Unnamed user"}
+          </h2>
+          {user.email && <p className="truncate text-sm text-text-muted">{user.email}</p>}
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <Badge variant={user.role === "admin" ? "danger" : "info"}>{user.role}</Badge>
+            {user.oauth_provider && <Badge variant="outline">{user.oauth_provider}</Badge>}
+          </div>
+        </div>
+      </div>
+
+      {/* Linked channels */}
+      {channels.length > 0 && (
+        <div className="mt-4 border-t border-surface-border pt-4">
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-text-muted">
+            Linked channels
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {channels.map((ch) => (
+              <span
+                key={ch.id}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-secondary px-2.5 py-1 text-xs text-text-main"
+              >
+                <span className="material-symbols-outlined text-sm text-primary">
+                  {channelIcon(ch.channel_type)}
+                </span>
+                <span className="font-medium">{ch.channel_type}</span>
+                <span className="text-text-muted">{ch.channel_user_id}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Member since */}
+      <p className="mt-3 text-xs text-text-muted">
+        Member since {new Date(user.created_at).toLocaleDateString()}
+      </p>
+    </Panel>
+  )
+}

--- a/packages/dashboard/src/components/user-usage-chart.tsx
+++ b/packages/dashboard/src/components/user-usage-chart.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import { useCallback, useState } from "react"
+
+import { Panel } from "@/components/ui/panel"
+import { useApiQuery } from "@/hooks/use-api"
+import type { UserUsageLedger } from "@/lib/api/users"
+import { getUserUsage } from "@/lib/api/users"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type TimeRange = "24h" | "7d" | "30d"
+
+interface UserUsageChartProps {
+  userId: string
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function aggregateUsage(entries: UserUsageLedger[]) {
+  let totalMessages = 0
+  let totalTokensIn = 0
+  let totalTokensOut = 0
+  let totalCost = 0
+
+  for (const entry of entries) {
+    totalMessages += entry.messages_sent
+    totalTokensIn += entry.tokens_in
+    totalTokensOut += entry.tokens_out
+    totalCost += parseFloat(entry.cost_usd)
+  }
+
+  return { totalMessages, totalTokensIn, totalTokensOut, totalCost }
+}
+
+function formatTokens(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`
+  return String(count)
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const RANGE_LABELS: Record<TimeRange, string> = {
+  "24h": "24 hours",
+  "7d": "7 days",
+  "30d": "30 days",
+}
+
+export function UserUsageChart({ userId }: UserUsageChartProps) {
+  const [range, setRange] = useState<TimeRange>("7d")
+
+  const fetchUsage = useCallback(() => getUserUsage(userId, { range }), [userId, range])
+  const { data, isLoading, error } = useApiQuery(fetchUsage, [userId, range])
+
+  const usage = data?.usage ?? []
+  const stats = aggregateUsage(usage)
+
+  return (
+    <Panel className="p-5">
+      <div className="flex items-center justify-between">
+        <h3 className="font-display text-sm font-bold text-text-main">Usage</h3>
+        <div className="flex gap-1 rounded-lg bg-secondary p-0.5">
+          {(["24h", "7d", "30d"] as const).map((r) => (
+            <button
+              key={r}
+              type="button"
+              onClick={() => setRange(r)}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                range === r
+                  ? "bg-surface-light text-text-main shadow-sm"
+                  : "text-text-muted hover:text-text-main"
+              }`}
+            >
+              {r}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="mt-4 flex items-center justify-center py-8">
+          <span className="text-sm text-text-muted">Loading usage data…</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-4 rounded-lg bg-danger/10 px-4 py-3 text-sm text-danger">
+          Failed to load usage data
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <div className="mt-4 grid grid-cols-2 gap-4 lg:grid-cols-4">
+          <StatCard label="Messages" value={String(stats.totalMessages)} icon="chat" />
+          <StatCard label="Tokens in" value={formatTokens(stats.totalTokensIn)} icon="input" />
+          <StatCard label="Tokens out" value={formatTokens(stats.totalTokensOut)} icon="output" />
+          <StatCard label="Cost" value={`$${stats.totalCost.toFixed(2)}`} icon="payments" />
+        </div>
+      )}
+
+      {!isLoading && !error && usage.length === 0 && (
+        <p className="mt-2 text-center text-xs text-text-muted">
+          No usage in the last {RANGE_LABELS[range]}
+        </p>
+      )}
+    </Panel>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Internal stat card
+// ---------------------------------------------------------------------------
+
+function StatCard({ label, value, icon }: { label: string; value: string; icon: string }) {
+  return (
+    <div className="rounded-lg bg-secondary px-3 py-2.5">
+      <div className="flex items-center gap-1.5 text-xs text-text-muted">
+        <span className="material-symbols-outlined text-sm">{icon}</span>
+        {label}
+      </div>
+      <p className="mt-1 font-display text-lg font-bold text-text-main">{value}</p>
+    </div>
+  )
+}

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -874,3 +874,36 @@ export async function deleteMcpServer(id: string): Promise<unknown> {
 export async function refreshMcpServer(id: string): Promise<unknown> {
   return apiFetch(`/mcp-servers/${id}/refresh`, { method: "POST", schema: McpServerSchema })
 }
+
+// ---------------------------------------------------------------------------
+// User endpoint functions
+// ---------------------------------------------------------------------------
+
+export type { ChannelMapping, UserAccount, UserGrant, UserUsageLedger } from "./schemas/users"
+
+import { UserDetailResponseSchema, UserUsageResponseSchema } from "./schemas/users"
+
+export async function getUser(
+  userId: string,
+): Promise<import("./schemas/users").UserDetailResponse> {
+  return apiFetch(`/users/${userId}`, { schema: UserDetailResponseSchema })
+}
+
+export async function getUserUsage(
+  userId: string,
+  params?: { range?: "24h" | "7d" | "30d" },
+): Promise<import("./schemas/users").UserUsageResponse> {
+  const search = new URLSearchParams()
+  if (params?.range) search.set("range", params.range)
+  const qs = search.toString()
+  return apiFetch(`/users/${userId}/usage${qs ? `?${qs}` : ""}`, {
+    schema: UserUsageResponseSchema,
+  })
+}
+
+export async function revokeUserGrant(agentId: string, grantId: string): Promise<unknown> {
+  return apiFetch(`/agents/${agentId}/users/${grantId}`, {
+    method: "DELETE",
+    schema: z.unknown(),
+  })
+}

--- a/packages/dashboard/src/lib/api/users.ts
+++ b/packages/dashboard/src/lib/api/users.ts
@@ -1,0 +1,6 @@
+/**
+ * User API functions — re-exported from the main api-client for convenience.
+ */
+export { getUser, getUserUsage, revokeUserGrant } from "../api-client"
+export type { ChannelMapping, UserAccount, UserGrant, UserUsageLedger } from "../schemas/users"
+export type { UserDetailResponse, UserUsageResponse } from "../schemas/users"

--- a/packages/dashboard/src/lib/schemas/users.ts
+++ b/packages/dashboard/src/lib/schemas/users.ts
@@ -1,0 +1,95 @@
+import { z } from "zod"
+
+// ---------------------------------------------------------------------------
+// User account
+// ---------------------------------------------------------------------------
+
+export const UserAccountSchema = z.object({
+  id: z.string(),
+  display_name: z.string().nullable(),
+  email: z.string().nullable(),
+  avatar_url: z.string().nullable(),
+  role: z.enum(["operator", "approver", "admin"]),
+  oauth_provider: z.string().nullable(),
+  oauth_provider_id: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export type UserAccount = z.infer<typeof UserAccountSchema>
+
+// ---------------------------------------------------------------------------
+// Channel mapping
+// ---------------------------------------------------------------------------
+
+export const ChannelMappingSchema = z.object({
+  id: z.string(),
+  user_account_id: z.string(),
+  channel_type: z.string(),
+  channel_user_id: z.string(),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  created_at: z.string(),
+})
+
+export type ChannelMapping = z.infer<typeof ChannelMappingSchema>
+
+// ---------------------------------------------------------------------------
+// User grant (from agent_user_grant)
+// ---------------------------------------------------------------------------
+
+export const UserGrantSchema = z.object({
+  id: z.string(),
+  agent_id: z.string(),
+  user_account_id: z.string(),
+  access_level: z.enum(["read", "write"]),
+  origin: z.enum(["pairing_code", "dashboard_invite", "auto_team", "auto_open", "approval"]),
+  granted_by: z.string().nullable(),
+  rate_limit: z.record(z.string(), z.unknown()).nullable(),
+  token_budget: z.record(z.string(), z.unknown()).nullable(),
+  expires_at: z.string().nullable(),
+  revoked_at: z.string().nullable(),
+  created_at: z.string(),
+})
+
+export type UserGrant = z.infer<typeof UserGrantSchema>
+
+// ---------------------------------------------------------------------------
+// User usage ledger
+// ---------------------------------------------------------------------------
+
+export const UserUsageLedgerSchema = z.object({
+  id: z.string(),
+  user_account_id: z.string(),
+  agent_id: z.string(),
+  period_start: z.string(),
+  period_end: z.string(),
+  messages_sent: z.number(),
+  tokens_in: z.number(),
+  tokens_out: z.number(),
+  cost_usd: z.string(),
+  created_at: z.string(),
+})
+
+export type UserUsageLedger = z.infer<typeof UserUsageLedgerSchema>
+
+// ---------------------------------------------------------------------------
+// GET /users/:id response
+// ---------------------------------------------------------------------------
+
+export const UserDetailResponseSchema = z.object({
+  user: UserAccountSchema,
+  channelMappings: z.array(ChannelMappingSchema),
+  grants: z.array(UserGrantSchema),
+})
+
+export type UserDetailResponse = z.infer<typeof UserDetailResponseSchema>
+
+// ---------------------------------------------------------------------------
+// GET /users/:id/usage response
+// ---------------------------------------------------------------------------
+
+export const UserUsageResponseSchema = z.object({
+  usage: z.array(UserUsageLedgerSchema),
+})
+
+export type UserUsageResponse = z.infer<typeof UserUsageResponseSchema>


### PR DESCRIPTION
## Summary
- Add user detail page at `/users/[id]` with identity card, agent access table with revoke, and usage chart with 24h/7d/30d toggle
- Add Zod schemas (`UserAccount`, `ChannelMapping`, `UserGrant`, `UserUsageLedger`) and API client functions (`getUser`, `getUserUsage`, `revokeUserGrant`)
- Add 13 contract tests validating schema-fixture alignment and edge cases

## Files changed
| File | Change |
|------|--------|
| `src/app/users/[id]/page.tsx` | New — user detail page |
| `src/components/user-identity-card.tsx` | New — avatar, name, channels |
| `src/components/user-usage-chart.tsx` | New — usage stats with time range toggle |
| `src/lib/schemas/users.ts` | New — Zod schemas for user API |
| `src/lib/api/users.ts` | New — re-export module |
| `src/lib/api-client.ts` | Added user endpoint functions |
| `fixtures/api-responses/user-detail.json` | New — fixture for contract tests |
| `src/__tests__/user-detail.test.ts` | New — 13 tests |

## Test plan
- [x] 372 tests pass (17 files), including 13 new user-detail tests
- [x] ESLint clean (no new errors)
- [x] TypeScript typecheck clean
- [x] Next.js build succeeds

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user detail page displaying comprehensive user profile with avatar, name, email, role, OAuth provider, and linked channels
  * Added usage analytics dashboard with customizable time ranges (24h, 7d, 30d) showing messages sent, token consumption, and cost estimates
  * Added access management interface to view and revoke user grants with confirmation workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->