### PR TITLE
feat(lifecycle): agent circuit breaker defaults and config resolver

### DIFF
--- a/packages/control-plane/src/lifecycle/__tests__/defaults.test.ts
+++ b/packages/control-plane/src/lifecycle/__tests__/defaults.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+
+import { DEFAULT_AGENT_CIRCUIT_BREAKER_CONFIG, resolveCircuitBreakerConfig } from "../defaults.js"
+
+describe("DEFAULT_AGENT_CIRCUIT_BREAKER_CONFIG", () => {
+  it("has expected default values", () => {
+    expect(DEFAULT_AGENT_CIRCUIT_BREAKER_CONFIG).toEqual({
+      maxConsecutiveFailures: 3,
+      maxToolErrorsPerJob: 10,
+      maxLlmRetriesPerJob: 5,
+      tokenBudgetPerJob: 500_000,
+      tokenBudgetPerSession: 2_000_000,
+      toolCallRateLimit: { maxCalls: 50, windowSeconds: 300 },
+      llmCallRateLimit: { maxCalls: 20, windowSeconds: 300 },
+    })
+  })
+})
+
+describe("resolveCircuitBreakerConfig", () => {
+  it("returns undefined when resource_limits has no circuitBreaker key", () => {
+    expect(resolveCircuitBreakerConfig({})).toBeUndefined()
+  })
+
+  it("returns undefined when circuitBreaker is null", () => {
+    expect(resolveCircuitBreakerConfig({ circuitBreaker: null })).toBeUndefined()
+  })
+
+  it("returns undefined when circuitBreaker is a primitive", () => {
+    expect(resolveCircuitBreakerConfig({ circuitBreaker: 42 })).toBeUndefined()
+    expect(resolveCircuitBreakerConfig({ circuitBreaker: "yes" })).toBeUndefined()
+    expect(resolveCircuitBreakerConfig({ circuitBreaker: true })).toBeUndefined()
+  })
+
+  it("returns the object when circuitBreaker is a valid partial config", () => {
+    const partial = { maxConsecutiveFailures: 5 }
+    const result = resolveCircuitBreakerConfig({ circuitBreaker: partial })
+    expect(result).toEqual({ maxConsecutiveFailures: 5 })
+  })
+
+  it("returns the full object for a complete config", () => {
+    const full = {
+      maxConsecutiveFailures: 10,
+      maxToolErrorsPerJob: 20,
+      maxLlmRetriesPerJob: 8,
+      tokenBudgetPerJob: 1_000_000,
+      tokenBudgetPerSession: 5_000_000,
+      toolCallRateLimit: { maxCalls: 100, windowSeconds: 600 },
+      llmCallRateLimit: { maxCalls: 40, windowSeconds: 600 },
+    }
+    const result = resolveCircuitBreakerConfig({ circuitBreaker: full })
+    expect(result).toEqual(full)
+  })
+
+  it("ignores unrelated keys in resource_limits", () => {
+    const result = resolveCircuitBreakerConfig({
+      contextBudget: { maxTokens: 100_000 },
+      circuitBreaker: { tokenBudgetPerJob: 200_000 },
+    })
+    expect(result).toEqual({ tokenBudgetPerJob: 200_000 })
+  })
+})

--- a/packages/control-plane/src/lifecycle/agent-circuit-breaker.ts
+++ b/packages/control-plane/src/lifecycle/agent-circuit-breaker.ts
@@ -44,18 +44,11 @@ export interface AbortDecision {
 }
 
 // ---------------------------------------------------------------------------
-// Defaults
+// Defaults (canonical source: defaults.ts)
 // ---------------------------------------------------------------------------
 
-export const DEFAULT_AGENT_CIRCUIT_BREAKER_CONFIG: AgentCircuitBreakerConfig = {
-  maxConsecutiveFailures: 3,
-  maxToolErrorsPerJob: 10,
-  maxLlmRetriesPerJob: 5,
-  tokenBudgetPerJob: 500_000,
-  tokenBudgetPerSession: 2_000_000,
-  toolCallRateLimit: { maxCalls: 50, windowSeconds: 300 },
-  llmCallRateLimit: { maxCalls: 20, windowSeconds: 300 },
-}
+export { DEFAULT_AGENT_CIRCUIT_BREAKER_CONFIG } from "./defaults.js"
+import { DEFAULT_AGENT_CIRCUIT_BREAKER_CONFIG } from "./defaults.js"
 
 // ---------------------------------------------------------------------------
 // Implementation

--- a/packages/control-plane/src/lifecycle/defaults.ts
+++ b/packages/control-plane/src/lifecycle/defaults.ts
@@ -1,0 +1,41 @@
+/**
+ * Centralized lifecycle defaults and config resolvers.
+ *
+ * Keeps default values and JSONB-to-config resolution logic in one place
+ * so that both the `AgentCircuitBreaker` class and the `agent-execute`
+ * task can share a single source of truth.
+ */
+
+import type { AgentCircuitBreakerConfig } from "./agent-circuit-breaker.js"
+
+// ---------------------------------------------------------------------------
+// Circuit breaker defaults
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_AGENT_CIRCUIT_BREAKER_CONFIG: AgentCircuitBreakerConfig = {
+  maxConsecutiveFailures: 3,
+  maxToolErrorsPerJob: 10,
+  maxLlmRetriesPerJob: 5,
+  tokenBudgetPerJob: 500_000,
+  tokenBudgetPerSession: 2_000_000,
+  toolCallRateLimit: { maxCalls: 50, windowSeconds: 300 },
+  llmCallRateLimit: { maxCalls: 20, windowSeconds: 300 },
+}
+
+// ---------------------------------------------------------------------------
+// Config resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a partial `AgentCircuitBreakerConfig` from an agent's
+ * `resource_limits` JSONB column. Returns `undefined` when no
+ * circuit-breaker override is present (→ fall back to defaults).
+ */
+export function resolveCircuitBreakerConfig(
+  resourceLimits: Record<string, unknown>,
+): Partial<AgentCircuitBreakerConfig> | undefined {
+  const raw = resourceLimits.circuitBreaker
+  return typeof raw === "object" && raw !== null
+    ? (raw as Partial<AgentCircuitBreakerConfig>)
+    : undefined
+}

--- a/packages/control-plane/src/lifecycle/index.ts
+++ b/packages/control-plane/src/lifecycle/index.ts
@@ -17,6 +17,7 @@ export {
   truncateComponent,
   validateContextBudget,
 } from "./context-budget.js"
+export { resolveCircuitBreakerConfig } from "./defaults.js"
 export {
   type AgentHealthRecord,
   type AgentHealthStatus,

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -29,7 +29,6 @@ import type { UserRateLimiter } from "../../auth/user-rate-limiter.js"
 import type { TokenRefresher } from "../../backends/http-llm.js"
 import type { CredentialResolver } from "../../backends/tools/webhook.js"
 import type { Database, Job } from "../../db/types.js"
-import type { AgentCircuitBreakerConfig } from "../../lifecycle/agent-circuit-breaker.js"
 import { AgentCircuitBreaker } from "../../lifecycle/agent-circuit-breaker.js"
 import {
   type ContextBudgetConfig,
@@ -37,6 +36,7 @@ import {
   enforceContextBudget,
   type ExecutionContext,
 } from "../../lifecycle/context-budget.js"
+import { resolveCircuitBreakerConfig } from "../../lifecycle/defaults.js"
 import type { AgentLifecycleManager, SteerMessage } from "../../lifecycle/manager.js"
 import { recordCircuitBreakerTrip, recordContextBudgetExceeded } from "../../lifecycle/metrics.js"
 import type { McpClientPool } from "../../mcp/client-pool.js"
@@ -169,11 +169,7 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
         loadedAgentId = agent.id
 
         // ── Step 1b: Instantiate agent-level circuit breaker ──
-        const rawCb = agent.resource_limits.circuitBreaker
-        const cbConfig =
-          typeof rawCb === "object" && rawCb !== null
-            ? (rawCb as Partial<AgentCircuitBreakerConfig>)
-            : undefined
+        const cbConfig = resolveCircuitBreakerConfig(agent.resource_limits)
         agentCB = new AgentCircuitBreaker(agent.id, cbConfig)
 
         // Hydrate consecutive failure count from recent jobs


### PR DESCRIPTION
## Summary
- Extracts `DEFAULT_AGENT_CIRCUIT_BREAKER_CONFIG` to `src/lifecycle/defaults.ts` per issue scope
- Adds `resolveCircuitBreakerConfig()` utility that safely extracts partial circuit breaker config from agent `resource_limits` JSONB (null/primitive guard → `undefined`)
- Updates `agent-execute.ts` to use the shared resolver instead of inline type-casting
- Adds 7 unit tests for the defaults module (value verification + resolver edge cases)

Closes #313

## Test plan
- [x] `npx vitest run` — 1459 tests pass (87 files)
- [x] `npm run typecheck` — clean
- [x] `npx eslint` — clean on changed files
- [x] Existing circuit breaker tests (23) and integration tests (9) pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for circuit breaker configuration defaults and resolution logic.

* **Chores**
  * Refactored circuit breaker configuration management into a centralized module for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->