### PR TITLE
feat(observability): CostTracker service — estimation, accumulation, budget enforcement (#323)

### DIFF
--- a/packages/control-plane/src/observability/__tests__/cost-tracker.test.ts
+++ b/packages/control-plane/src/observability/__tests__/cost-tracker.test.ts
@@ -1,0 +1,586 @@
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import type { Database } from "../../db/types.js"
+import { type CostBudget, CostTracker, type RecordLlmCostParams } from "../cost-tracker.js"
+import type { AgentEventEmitter } from "../event-emitter.js"
+import { DEFAULT_PRICING, estimateCost, MODEL_PRICING } from "../model-pricing.js"
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function buildMockDb(
+  opts: {
+    jobCostUsd?: string
+    sessionCostUsd?: string
+    dailyCost?: string
+    sessionRow?: {
+      total_tokens_in: number
+      total_tokens_out: number
+      total_cost_usd: string
+    } | null
+    summaryRow?: Record<string, unknown>
+    modelRows?: Array<Record<string, unknown>>
+    countRow?: Record<string, unknown>
+  } = {},
+) {
+  const {
+    jobCostUsd = "0.010500",
+    sessionCostUsd = "0.050000",
+    dailyCost: _dailyCost = "0.100000",
+    sessionRow = null,
+    summaryRow = {
+      total_cost: "0.500000",
+      total_tokens_in: 10000,
+      total_tokens_out: 5000,
+      llm_calls: 5,
+      tool_calls: 3,
+    },
+    modelRows = [],
+    countRow = { llm_calls: 5, tool_calls: 3 },
+  } = opts
+
+  const updateExecuteTakeFirst = vi.fn()
+  const updateReturning = vi.fn()
+  const updateWhere = vi.fn()
+  const updateSet = vi.fn()
+
+  // Track which table is being updated to return correct values
+  let currentUpdateTable = ""
+
+  updateExecuteTakeFirst.mockImplementation(() => {
+    if (currentUpdateTable === "job") {
+      return Promise.resolve({ cost_usd: jobCostUsd })
+    }
+    if (currentUpdateTable === "session") {
+      return Promise.resolve({ total_cost_usd: sessionCostUsd })
+    }
+    return Promise.resolve(null)
+  })
+
+  updateReturning.mockReturnValue({
+    executeTakeFirst: updateExecuteTakeFirst,
+  })
+
+  updateWhere.mockReturnValue({
+    returning: updateReturning,
+    where: updateWhere,
+    executeTakeFirst: updateExecuteTakeFirst,
+  })
+
+  updateSet.mockReturnValue({
+    where: updateWhere,
+    returning: updateReturning,
+  })
+
+  const selectExecute = vi.fn().mockResolvedValue(modelRows)
+  const selectExecuteTakeFirst = vi.fn().mockImplementation(() => {
+    return Promise.resolve(sessionRow)
+  })
+  const selectExecuteTakeFirstOrThrow = vi.fn().mockImplementation(() => {
+    return Promise.resolve(summaryRow)
+  })
+
+  // Track select-from context for different queries
+  let selectCallIndex = 0
+
+  function makeSelectChain() {
+    const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+    const where = vi.fn().mockReturnValue(chain)
+    const select = vi.fn().mockReturnValue(chain)
+    const selectAll = vi.fn().mockReturnValue(chain)
+    const groupBy = vi.fn().mockReturnValue(chain)
+    const orderBy = vi.fn().mockReturnValue(chain)
+    const limit = vi.fn().mockReturnValue(chain)
+
+    Object.assign(chain, {
+      where,
+      select,
+      selectAll,
+      groupBy,
+      orderBy,
+      limit,
+      execute: selectExecute,
+      executeTakeFirst: selectExecuteTakeFirst,
+      executeTakeFirstOrThrow: selectExecuteTakeFirstOrThrow,
+    })
+    return chain
+  }
+
+  const selectFrom = vi.fn().mockImplementation((table: string) => {
+    selectCallIndex++
+    if (table === "session") {
+      // Return session row
+      const chain = makeSelectChain()
+      chain.executeTakeFirst = vi.fn().mockResolvedValue(sessionRow)
+      return chain
+    }
+    if (table === "agent_event") {
+      const chain = makeSelectChain()
+      // First agent_event query returns summary, subsequent return modelRows or countRow
+      if (selectCallIndex <= 1) {
+        chain.executeTakeFirstOrThrow = vi.fn().mockResolvedValue(summaryRow)
+      } else {
+        chain.executeTakeFirstOrThrow = vi.fn().mockResolvedValue(countRow)
+      }
+      chain.execute = vi.fn().mockResolvedValue(modelRows)
+      return chain
+    }
+    return makeSelectChain()
+  })
+
+  const updateTable = vi.fn().mockImplementation((table: string) => {
+    currentUpdateTable = table
+    return { set: updateSet }
+  })
+
+  const db = {
+    updateTable,
+    selectFrom,
+    fn: { countAll: vi.fn() },
+  } as unknown as Kysely<Database>
+
+  return {
+    db,
+    updateTable,
+    updateSet,
+    updateWhere,
+    updateReturning,
+    updateExecuteTakeFirst,
+    selectFrom,
+    selectExecute,
+    selectExecuteTakeFirst,
+    selectExecuteTakeFirstOrThrow,
+  }
+}
+
+function buildMockEmitter() {
+  const emit = vi.fn().mockResolvedValue({ eventId: "evt-1" })
+  const emitter = { emit } as unknown as AgentEventEmitter
+  return { emitter, emit }
+}
+
+const DEFAULT_BUDGET: CostBudget = {
+  maxUsdPerJob: 1.0,
+  maxUsdPerSession: 5.0,
+  maxUsdPerDay: 10.0,
+  warningThresholdPct: 0.8,
+}
+
+function baseRecordParams(overrides?: Partial<RecordLlmCostParams>): RecordLlmCostParams {
+  return {
+    agentId: "agent-1",
+    jobId: "job-1",
+    sessionId: "sess-1",
+    model: "claude-sonnet-4-6",
+    tokensIn: 1000,
+    tokensOut: 500,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("model-pricing", () => {
+  describe("estimateCost()", () => {
+    it("returns correct cost for claude-sonnet-4-6", () => {
+      // 1000 in * 3.0/1M + 500 out * 15.0/1M = 0.003 + 0.0075 = 0.0105
+      const cost = estimateCost("claude-sonnet-4-6", 1000, 500)
+      expect(cost).toBeCloseTo(0.0105, 6)
+    })
+
+    it("returns correct cost for claude-opus-4-6", () => {
+      // 1000 * 15/1M + 500 * 75/1M = 0.015 + 0.0375 = 0.0525
+      const cost = estimateCost("claude-opus-4-6", 1000, 500)
+      expect(cost).toBeCloseTo(0.0525, 6)
+    })
+
+    it("returns correct cost for gpt-4o", () => {
+      // 1000 * 2.5/1M + 500 * 10.0/1M = 0.0025 + 0.005 = 0.0075
+      const cost = estimateCost("gpt-4o", 1000, 500)
+      expect(cost).toBeCloseTo(0.0075, 6)
+    })
+
+    it("uses default pricing for unknown model (not zero)", () => {
+      const cost = estimateCost("unknown-model-xyz", 1000, 500)
+      const expected =
+        (1000 / 1_000_000) * DEFAULT_PRICING.inputPerMToken +
+        (500 / 1_000_000) * DEFAULT_PRICING.outputPerMToken
+      expect(cost).toBeCloseTo(expected, 6)
+      expect(cost).toBeGreaterThan(0)
+    })
+
+    it("includes cache read tokens when pricing supports it", () => {
+      const withoutCache = estimateCost("claude-sonnet-4-6", 1000, 500)
+      const withCache = estimateCost("claude-sonnet-4-6", 1000, 500, 2000)
+      // Cache cost: 2000 * 0.3/1M = 0.0006
+      expect(withCache - withoutCache).toBeCloseTo(0.0006, 6)
+    })
+
+    it("ignores cache read tokens when model has no cache pricing", () => {
+      const withoutCache = estimateCost("gpt-4o", 1000, 500)
+      const withCache = estimateCost("gpt-4o", 1000, 500, 2000)
+      expect(withCache).toBe(withoutCache)
+    })
+
+    it("returns 0 for zero token counts", () => {
+      expect(estimateCost("claude-sonnet-4-6", 0, 0)).toBe(0)
+    })
+  })
+
+  describe("MODEL_PRICING", () => {
+    it("contains entries for common models", () => {
+      expect(MODEL_PRICING["claude-sonnet-4-6"]).toBeDefined()
+      expect(MODEL_PRICING["claude-opus-4-6"]).toBeDefined()
+      expect(MODEL_PRICING["claude-haiku-4-5"]).toBeDefined()
+      expect(MODEL_PRICING["gpt-4o"]).toBeDefined()
+      expect(MODEL_PRICING["gpt-4o-mini"]).toBeDefined()
+    })
+
+    it("all prices are positive", () => {
+      for (const [, pricing] of Object.entries(MODEL_PRICING)) {
+        expect(pricing.inputPerMToken).toBeGreaterThan(0)
+        expect(pricing.outputPerMToken).toBeGreaterThan(0)
+      }
+    })
+  })
+})
+
+describe("CostTracker", () => {
+  describe("estimateCost()", () => {
+    it("delegates to model pricing table", () => {
+      const { db } = buildMockDb()
+      const tracker = new CostTracker(db)
+      const cost = tracker.estimateCost("claude-sonnet-4-6", 1000, 500)
+      expect(cost).toBeCloseTo(0.0105, 6)
+    })
+  })
+
+  // ── recordLlmCost() ──────────────────────────────────────────────────
+
+  describe("recordLlmCost()", () => {
+    it("atomically increments job.tokens_in, tokens_out, cost_usd, llm_call_count", async () => {
+      const { db, updateTable, updateSet } = buildMockDb()
+      const tracker = new CostTracker(db)
+
+      await tracker.recordLlmCost(baseRecordParams())
+
+      // First updateTable call should be for "job"
+      expect(updateTable).toHaveBeenCalledWith("job")
+      expect(updateSet).toHaveBeenCalled()
+    })
+
+    it("atomically increments session.total_tokens_in, total_tokens_out, total_cost_usd", async () => {
+      const { db, updateTable } = buildMockDb()
+      const tracker = new CostTracker(db)
+
+      await tracker.recordLlmCost(baseRecordParams({ sessionId: "sess-1" }))
+
+      // Should call updateTable for both "job" and "session"
+      expect(updateTable).toHaveBeenCalledWith("job")
+      expect(updateTable).toHaveBeenCalledWith("session")
+    })
+
+    it("skips session update when sessionId is null", async () => {
+      const { db, updateTable } = buildMockDb()
+      const tracker = new CostTracker(db)
+
+      await tracker.recordLlmCost(baseRecordParams({ sessionId: null }))
+
+      // Only job should be updated
+      expect(updateTable).toHaveBeenCalledTimes(1)
+      expect(updateTable).toHaveBeenCalledWith("job")
+    })
+
+    it("returns estimated cost in USD", async () => {
+      const { db } = buildMockDb()
+      const tracker = new CostTracker(db)
+
+      const result = await tracker.recordLlmCost(baseRecordParams())
+
+      expect(result.costUsd).toBeCloseTo(0.0105, 6)
+    })
+
+    it("returns empty budgetStatuses when no budget provided", async () => {
+      const { db } = buildMockDb()
+      const tracker = new CostTracker(db)
+
+      const result = await tracker.recordLlmCost(baseRecordParams({ budget: undefined }))
+
+      expect(result.budgetStatuses).toEqual([])
+    })
+
+    // ── Budget enforcement ────────────────────────────────────────────
+
+    it("returns job exceeded when job cost exceeds maxUsdPerJob", async () => {
+      const { db } = buildMockDb({ jobCostUsd: "1.500000" })
+      const tracker = new CostTracker(db)
+
+      const result = await tracker.recordLlmCost(
+        baseRecordParams({ budget: { ...DEFAULT_BUDGET, maxUsdPerJob: 1.0 } }),
+      )
+
+      const jobStatus = result.budgetStatuses.find((s) => s.level === "job")
+      expect(jobStatus).toBeDefined()
+      expect(jobStatus!.exceeded).toBe(true)
+      expect(jobStatus!.currentUsd).toBe(1.5)
+      expect(jobStatus!.limitUsd).toBe(1.0)
+    })
+
+    it("returns session exceeded when session cost exceeds maxUsdPerSession", async () => {
+      const { db } = buildMockDb({ sessionCostUsd: "6.000000" })
+      const tracker = new CostTracker(db)
+
+      const result = await tracker.recordLlmCost(
+        baseRecordParams({ budget: { ...DEFAULT_BUDGET, maxUsdPerSession: 5.0 } }),
+      )
+
+      const sessionStatus = result.budgetStatuses.find((s) => s.level === "session")
+      expect(sessionStatus).toBeDefined()
+      expect(sessionStatus!.exceeded).toBe(true)
+    })
+
+    it("returns daily exceeded when daily cost exceeds maxUsdPerDay", async () => {
+      // getDailyCost reads from agent_event
+      const summaryRow = { daily_cost: "15.000000" }
+      const { db } = buildMockDb()
+      // Override selectFrom for the daily cost query
+      const selectChain: Record<string, ReturnType<typeof vi.fn>> = {}
+      const where = vi.fn().mockReturnValue(selectChain)
+      const select = vi.fn().mockReturnValue(selectChain)
+      Object.assign(selectChain, {
+        where,
+        select,
+        executeTakeFirstOrThrow: vi.fn().mockResolvedValue(summaryRow),
+        execute: vi.fn().mockResolvedValue([]),
+        executeTakeFirst: vi.fn().mockResolvedValue(null),
+      })
+      ;(db.selectFrom as ReturnType<typeof vi.fn>).mockReturnValue(selectChain)
+
+      const tracker = new CostTracker(db)
+
+      const result = await tracker.recordLlmCost(
+        baseRecordParams({ budget: { ...DEFAULT_BUDGET, maxUsdPerDay: 10.0 } }),
+      )
+
+      const dailyStatus = result.budgetStatuses.find((s) => s.level === "daily")
+      expect(dailyStatus).toBeDefined()
+      expect(dailyStatus!.exceeded).toBe(true)
+      expect(dailyStatus!.currentUsd).toBe(15)
+      expect(dailyStatus!.limitUsd).toBe(10)
+    })
+
+    it("returns warning at 80% threshold", async () => {
+      // Job cost at 85% of budget (0.85 of 1.0)
+      const { db } = buildMockDb({ jobCostUsd: "0.850000" })
+      const tracker = new CostTracker(db)
+
+      const result = await tracker.recordLlmCost(
+        baseRecordParams({
+          budget: { ...DEFAULT_BUDGET, maxUsdPerJob: 1.0, warningThresholdPct: 0.8 },
+        }),
+      )
+
+      const jobStatus = result.budgetStatuses.find((s) => s.level === "job")
+      expect(jobStatus).toBeDefined()
+      expect(jobStatus!.warning).toBe(true)
+      expect(jobStatus!.exceeded).toBe(false)
+    })
+
+    it("emits cost_alert event via eventEmitter on budget warning", async () => {
+      const { db } = buildMockDb({ jobCostUsd: "0.850000" })
+      const { emitter, emit } = buildMockEmitter()
+      const tracker = new CostTracker(db, emitter)
+
+      await tracker.recordLlmCost(
+        baseRecordParams({
+          budget: { ...DEFAULT_BUDGET, maxUsdPerJob: 1.0, warningThresholdPct: 0.8 },
+        }),
+      )
+
+      expect(emit).toHaveBeenCalled()
+      const call = emit.mock.calls[0]![0] as Record<string, unknown>
+      expect(call.eventType).toBe("cost_alert")
+      expect(call.actor).toBe("system")
+      expect(call.agentId).toBe("agent-1")
+      const payload = call.payload as Record<string, unknown>
+      expect(payload.warning).toBe(true)
+      expect(payload.level).toBe("job")
+    })
+
+    it("emits cost_alert event on budget exceeded", async () => {
+      const { db } = buildMockDb({ jobCostUsd: "1.500000" })
+      const { emitter, emit } = buildMockEmitter()
+      const tracker = new CostTracker(db, emitter)
+
+      await tracker.recordLlmCost(
+        baseRecordParams({
+          budget: { ...DEFAULT_BUDGET, maxUsdPerJob: 1.0 },
+        }),
+      )
+
+      expect(emit).toHaveBeenCalled()
+      const call = emit.mock.calls[0]![0] as Record<string, unknown>
+      expect(call.eventType).toBe("cost_alert")
+      const payload = call.payload as Record<string, unknown>
+      expect(payload.exceeded).toBe(true)
+    })
+
+    it("does not emit events when no eventEmitter provided", async () => {
+      const { db } = buildMockDb({ jobCostUsd: "1.500000" })
+      const tracker = new CostTracker(db) // no emitter
+
+      // Should not throw
+      const result = await tracker.recordLlmCost(baseRecordParams({ budget: DEFAULT_BUDGET }))
+
+      expect(result.budgetStatuses.some((s) => s.exceeded)).toBe(true)
+    })
+
+    it("skips budget levels with zero limits", async () => {
+      const { db } = buildMockDb()
+      const tracker = new CostTracker(db)
+
+      const result = await tracker.recordLlmCost(
+        baseRecordParams({
+          budget: {
+            maxUsdPerJob: 0,
+            maxUsdPerSession: 0,
+            maxUsdPerDay: 0,
+            warningThresholdPct: 0.8,
+          },
+        }),
+      )
+
+      expect(result.budgetStatuses).toHaveLength(0)
+    })
+  })
+
+  // ── getAgentCostSummary() ─────────────────────────────────────────
+
+  describe("getAgentCostSummary()", () => {
+    it("aggregates cost correctly from agent_event", async () => {
+      const { db } = buildMockDb({
+        summaryRow: {
+          total_cost: "1.250000",
+          total_tokens_in: 25000,
+          total_tokens_out: 12000,
+          llm_calls: 10,
+          tool_calls: 7,
+        },
+        modelRows: [
+          { model: "claude-sonnet-4-6", cost: "0.800000", tokens_in: 15000, tokens_out: 8000 },
+          { model: "gpt-4o", cost: "0.450000", tokens_in: 10000, tokens_out: 4000 },
+        ],
+      })
+      const tracker = new CostTracker(db)
+
+      const summary = await tracker.getAgentCostSummary("agent-1")
+
+      expect(summary.totalCostUsd).toBe(1.25)
+      expect(summary.totalTokensIn).toBe(25000)
+      expect(summary.totalTokensOut).toBe(12000)
+      expect(summary.totalLlmCalls).toBe(10)
+      expect(summary.totalToolCalls).toBe(7)
+      expect(summary.byModel["claude-sonnet-4-6"]).toEqual({
+        costUsd: 0.8,
+        tokensIn: 15000,
+        tokensOut: 8000,
+      })
+      expect(summary.byModel["gpt-4o"]).toEqual({
+        costUsd: 0.45,
+        tokensIn: 10000,
+        tokensOut: 4000,
+      })
+    })
+
+    it("applies since date filter", async () => {
+      const { db, selectFrom } = buildMockDb()
+      const tracker = new CostTracker(db)
+
+      const since = new Date("2025-01-01")
+      await tracker.getAgentCostSummary("agent-1", since)
+
+      // Verify selectFrom was called with agent_event
+      expect(selectFrom).toHaveBeenCalledWith("agent_event")
+    })
+
+    it("returns zeros when no events exist", async () => {
+      const { db } = buildMockDb({
+        summaryRow: {
+          total_cost: "0",
+          total_tokens_in: 0,
+          total_tokens_out: 0,
+          llm_calls: 0,
+          tool_calls: 0,
+        },
+        modelRows: [],
+      })
+      const tracker = new CostTracker(db)
+
+      const summary = await tracker.getAgentCostSummary("agent-1")
+
+      expect(summary.totalCostUsd).toBe(0)
+      expect(summary.totalTokensIn).toBe(0)
+      expect(summary.totalTokensOut).toBe(0)
+      expect(summary.totalLlmCalls).toBe(0)
+      expect(summary.totalToolCalls).toBe(0)
+      expect(summary.byModel).toEqual({})
+    })
+
+    it("labels null model as 'unknown' in byModel", async () => {
+      const { db } = buildMockDb({
+        modelRows: [{ model: null, cost: "0.100000", tokens_in: 1000, tokens_out: 500 }],
+      })
+      const tracker = new CostTracker(db)
+
+      const summary = await tracker.getAgentCostSummary("agent-1")
+
+      expect(summary.byModel["unknown"]).toBeDefined()
+      expect(summary.byModel["unknown"]!.costUsd).toBe(0.1)
+    })
+  })
+
+  // ── getSessionCostSummary() ───────────────────────────────────────
+
+  describe("getSessionCostSummary()", () => {
+    it("reads cost from session columns", async () => {
+      const { db } = buildMockDb({
+        sessionRow: {
+          total_tokens_in: 8000,
+          total_tokens_out: 4000,
+          total_cost_usd: "0.750000",
+        },
+        countRow: { llm_calls: 4, tool_calls: 2 },
+        modelRows: [
+          { model: "claude-sonnet-4-6", cost: "0.750000", tokens_in: 8000, tokens_out: 4000 },
+        ],
+      })
+      const tracker = new CostTracker(db)
+
+      const summary = await tracker.getSessionCostSummary("sess-1")
+
+      expect(summary.totalCostUsd).toBe(0.75)
+      expect(summary.totalTokensIn).toBe(8000)
+      expect(summary.totalTokensOut).toBe(4000)
+      expect(summary.totalLlmCalls).toBe(4)
+      expect(summary.totalToolCalls).toBe(2)
+    })
+
+    it("returns zeros when session not found", async () => {
+      const { db } = buildMockDb({ sessionRow: null })
+      const tracker = new CostTracker(db)
+
+      const summary = await tracker.getSessionCostSummary("nonexistent")
+
+      expect(summary.totalCostUsd).toBe(0)
+      expect(summary.totalTokensIn).toBe(0)
+      expect(summary.totalTokensOut).toBe(0)
+      expect(summary.totalLlmCalls).toBe(0)
+      expect(summary.totalToolCalls).toBe(0)
+      expect(summary.byModel).toEqual({})
+    })
+  })
+})

--- a/packages/control-plane/src/observability/cost-tracker.ts
+++ b/packages/control-plane/src/observability/cost-tracker.ts
@@ -1,19 +1,60 @@
 /**
- * CostTracker — accumulates LLM cost and token usage within a single job
- * execution. Provides budget enforcement: when cumulative cost exceeds the
- * configured budget, `checkBudget()` returns `false`.
+ * CostTracker — cost estimation, accumulation, and budget enforcement.
+ *
+ * Wraps atomic SQL increments on `job` and `session` tables, checks cost
+ * budgets at job / session / daily levels, and emits `cost_alert` events
+ * when thresholds are breached.
  */
+
+import { type Kysely, sql } from "kysely"
+
+import type { Database } from "../db/types.js"
+import type { AgentEventEmitter } from "./event-emitter.js"
+import { estimateCost } from "./model-pricing.js"
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export interface CostSnapshot {
+export interface CostBudget {
+  maxUsdPerJob: number
+  maxUsdPerSession: number
+  maxUsdPerDay: number
+  /** Fraction 0–1 (e.g. 0.8 = 80%). */
+  warningThresholdPct: number
+}
+
+export interface BudgetStatus {
+  exceeded: boolean
+  warning: boolean
+  currentUsd: number
+  limitUsd: number
+  level: "job" | "session" | "daily"
+}
+
+export interface CostSummary {
+  totalCostUsd: number
+  totalTokensIn: number
+  totalTokensOut: number
+  totalLlmCalls: number
+  totalToolCalls: number
+  byModel: Record<string, { costUsd: number; tokensIn: number; tokensOut: number }>
+}
+
+export interface RecordLlmCostParams {
+  agentId: string
+  jobId: string
+  sessionId?: string | null
+  model: string
   tokensIn: number
   tokensOut: number
+  cacheReadTokens?: number
+  budget?: CostBudget
+}
+
+export interface RecordLlmCostResult {
   costUsd: number
-  llmCalls: number
-  toolCalls: number
+  budgetStatuses: BudgetStatus[]
 }
 
 // ---------------------------------------------------------------------------
@@ -21,54 +62,282 @@ export interface CostSnapshot {
 // ---------------------------------------------------------------------------
 
 export class CostTracker {
-  private tokensIn = 0
-  private tokensOut = 0
-  private costUsd = 0
-  private llmCalls = 0
-  private toolCalls = 0
+  constructor(
+    private readonly db: Kysely<Database>,
+    private readonly eventEmitter?: AgentEventEmitter,
+  ) {}
 
   /**
-   * Record an LLM call's cost and token usage.
+   * Estimate the cost of an LLM call in USD.
+   * Delegates to the model pricing table.
    */
-  recordLlmCost(tokensIn: number, tokensOut: number, costUsd: number): void {
-    this.tokensIn += tokensIn
-    this.tokensOut += tokensOut
-    this.costUsd += costUsd
-    this.llmCalls++
+  estimateCost(
+    model: string,
+    tokensIn: number,
+    tokensOut: number,
+    cacheReadTokens?: number,
+  ): number {
+    return estimateCost(model, tokensIn, tokensOut, cacheReadTokens)
   }
 
   /**
-   * Record a tool call (count only — tool calls don't have direct cost).
+   * Record an LLM call's token usage and cost.
+   *
+   * 1. Atomically increments `job.tokens_in`, `tokens_out`, `cost_usd`,
+   *    `llm_call_count`.
+   * 2. Atomically increments `session.total_tokens_in`, `total_tokens_out`,
+   *    `total_cost_usd` (when `sessionId` is provided).
+   * 3. Checks cost budgets and emits `cost_alert` events on breach.
    */
-  recordToolCall(): void {
-    this.toolCalls++
+  async recordLlmCost(params: RecordLlmCostParams): Promise<RecordLlmCostResult> {
+    const costUsd = estimateCost(
+      params.model,
+      params.tokensIn,
+      params.tokensOut,
+      params.cacheReadTokens,
+    )
+
+    // ── Atomic increment on job ──────────────────────────────────────────
+    const jobRow = await this.db
+      .updateTable("job")
+      .set({
+        tokens_in: sql`"tokens_in" + ${params.tokensIn}`,
+        tokens_out: sql`"tokens_out" + ${params.tokensOut}`,
+        cost_usd: sql`"cost_usd" + ${costUsd}`,
+        llm_call_count: sql`"llm_call_count" + 1`,
+      })
+      .where("id", "=", params.jobId)
+      .returning(["cost_usd"])
+      .executeTakeFirst()
+
+    // ── Atomic increment on session ──────────────────────────────────────
+    let sessionCostUsd: number | null = null
+    if (params.sessionId) {
+      const sessionRow = await this.db
+        .updateTable("session")
+        .set({
+          total_tokens_in: sql`"total_tokens_in" + ${params.tokensIn}`,
+          total_tokens_out: sql`"total_tokens_out" + ${params.tokensOut}`,
+          total_cost_usd: sql`"total_cost_usd" + ${costUsd}`,
+        })
+        .where("id", "=", params.sessionId)
+        .returning(["total_cost_usd"])
+        .executeTakeFirst()
+
+      if (sessionRow) {
+        sessionCostUsd = Number(sessionRow.total_cost_usd)
+      }
+    }
+
+    // ── Budget enforcement ───────────────────────────────────────────────
+    const budgetStatuses: BudgetStatus[] = []
+
+    if (params.budget) {
+      const { budget, agentId, jobId, sessionId } = params
+      const warnPct = budget.warningThresholdPct
+
+      // Job-level
+      if (budget.maxUsdPerJob > 0 && jobRow) {
+        const current = Number(jobRow.cost_usd)
+        const status = checkThreshold(current, budget.maxUsdPerJob, warnPct, "job")
+        budgetStatuses.push(status)
+        if (status.warning || status.exceeded) {
+          await this.emitCostAlert(agentId, jobId, sessionId ?? null, status)
+        }
+      }
+
+      // Session-level
+      if (budget.maxUsdPerSession > 0 && sessionCostUsd != null) {
+        const status = checkThreshold(sessionCostUsd, budget.maxUsdPerSession, warnPct, "session")
+        budgetStatuses.push(status)
+        if (status.warning || status.exceeded) {
+          await this.emitCostAlert(agentId, jobId, sessionId ?? null, status)
+        }
+      }
+
+      // Daily-level
+      if (budget.maxUsdPerDay > 0) {
+        const dailyCost = await this.getDailyCost(agentId)
+        const status = checkThreshold(dailyCost, budget.maxUsdPerDay, warnPct, "daily")
+        budgetStatuses.push(status)
+        if (status.warning || status.exceeded) {
+          await this.emitCostAlert(agentId, jobId, sessionId ?? null, status)
+        }
+      }
+    }
+
+    return { costUsd, budgetStatuses }
   }
 
   /**
-   * Check whether the accumulated cost is within the given budget.
-   * Returns `true` if within budget, `false` if exceeded.
+   * Aggregate cost summary for an agent from the `agent_event` table.
    */
-  checkBudget(budgetUsd: number): boolean {
-    return this.costUsd <= budgetUsd
-  }
+  async getAgentCostSummary(agentId: string, since?: Date): Promise<CostSummary> {
+    let baseQuery = this.db.selectFrom("agent_event").where("agent_id", "=", agentId)
 
-  /**
-   * Return a snapshot of the current accumulated usage.
-   */
-  getSnapshot(): CostSnapshot {
+    if (since) {
+      baseQuery = baseQuery.where("created_at", ">=", since)
+    }
+
+    const summary = await baseQuery
+      .select([
+        sql<string>`coalesce(sum(cast(cost_usd as double precision)), 0)`.as("total_cost"),
+        sql<number>`coalesce(sum(tokens_in), 0)`.as("total_tokens_in"),
+        sql<number>`coalesce(sum(tokens_out), 0)`.as("total_tokens_out"),
+        sql<number>`count(*) filter (where event_type = 'llm_call_end')`.as("llm_calls"),
+        sql<number>`count(*) filter (where event_type = 'tool_call_end')`.as("tool_calls"),
+      ])
+      .executeTakeFirstOrThrow()
+
+    const byModel = await this.queryByModelBreakdown({ agentId, since })
+
     return {
-      tokensIn: this.tokensIn,
-      tokensOut: this.tokensOut,
-      costUsd: this.costUsd,
-      llmCalls: this.llmCalls,
-      toolCalls: this.toolCalls,
+      totalCostUsd: Number(summary.total_cost),
+      totalTokensIn: Number(summary.total_tokens_in),
+      totalTokensOut: Number(summary.total_tokens_out),
+      totalLlmCalls: Number(summary.llm_calls),
+      totalToolCalls: Number(summary.tool_calls),
+      byModel,
     }
   }
 
   /**
-   * Total accumulated cost in USD.
+   * Read cost summary from session columns + event aggregation.
    */
-  getTotalCost(): number {
-    return this.costUsd
+  async getSessionCostSummary(sessionId: string): Promise<CostSummary> {
+    const session = await this.db
+      .selectFrom("session")
+      .select(["total_tokens_in", "total_tokens_out", "total_cost_usd"])
+      .where("id", "=", sessionId)
+      .executeTakeFirst()
+
+    if (!session) {
+      return {
+        totalCostUsd: 0,
+        totalTokensIn: 0,
+        totalTokensOut: 0,
+        totalLlmCalls: 0,
+        totalToolCalls: 0,
+        byModel: {},
+      }
+    }
+
+    const counts = await this.db
+      .selectFrom("agent_event")
+      .where("session_id", "=", sessionId)
+      .select([
+        sql<number>`count(*) filter (where event_type = 'llm_call_end')`.as("llm_calls"),
+        sql<number>`count(*) filter (where event_type = 'tool_call_end')`.as("tool_calls"),
+      ])
+      .executeTakeFirstOrThrow()
+
+    const byModel = await this.queryByModelBreakdown({ sessionId })
+
+    return {
+      totalCostUsd: Number(session.total_cost_usd),
+      totalTokensIn: Number(session.total_tokens_in),
+      totalTokensOut: Number(session.total_tokens_out),
+      totalLlmCalls: Number(counts.llm_calls),
+      totalToolCalls: Number(counts.tool_calls),
+      byModel,
+    }
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────
+
+  private async getDailyCost(agentId: string): Promise<number> {
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+
+    const result = await this.db
+      .selectFrom("agent_event")
+      .where("agent_id", "=", agentId)
+      .where("cost_usd", "is not", null)
+      .where("created_at", ">=", today)
+      .select(sql<string>`coalesce(sum(cast(cost_usd as double precision)), 0)`.as("daily_cost"))
+      .executeTakeFirstOrThrow()
+
+    return Number(result.daily_cost)
+  }
+
+  private async queryByModelBreakdown(filters: {
+    agentId?: string
+    sessionId?: string
+    since?: Date
+  }): Promise<CostSummary["byModel"]> {
+    let q = this.db.selectFrom("agent_event").where("cost_usd", "is not", null)
+
+    if (filters.agentId) {
+      q = q.where("agent_id", "=", filters.agentId)
+    }
+    if (filters.sessionId) {
+      q = q.where("session_id", "=", filters.sessionId)
+    }
+    if (filters.since) {
+      q = q.where("created_at", ">=", filters.since)
+    }
+
+    const modelRows = await q
+      .select([
+        "model",
+        sql<string>`coalesce(sum(cast(cost_usd as double precision)), 0)`.as("cost"),
+        sql<number>`coalesce(sum(tokens_in), 0)`.as("tokens_in"),
+        sql<number>`coalesce(sum(tokens_out), 0)`.as("tokens_out"),
+      ])
+      .groupBy("model")
+      .execute()
+
+    const byModel: CostSummary["byModel"] = {}
+    for (const row of modelRows) {
+      byModel[row.model ?? "unknown"] = {
+        costUsd: Number(row.cost),
+        tokensIn: Number(row.tokens_in),
+        tokensOut: Number(row.tokens_out),
+      }
+    }
+    return byModel
+  }
+
+  private async emitCostAlert(
+    agentId: string,
+    jobId: string,
+    sessionId: string | null,
+    status: BudgetStatus,
+  ): Promise<void> {
+    if (!this.eventEmitter) return
+
+    await this.eventEmitter.emit({
+      agentId,
+      jobId,
+      sessionId,
+      eventType: "cost_alert",
+      actor: "system",
+      payload: {
+        level: status.level,
+        exceeded: status.exceeded,
+        warning: status.warning,
+        currentUsd: status.currentUsd,
+        limitUsd: status.limitUsd,
+      },
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function checkThreshold(
+  current: number,
+  limit: number,
+  warningPct: number,
+  level: "job" | "session" | "daily",
+): BudgetStatus {
+  return {
+    exceeded: current > limit,
+    warning: !!(current >= limit * warningPct && current <= limit),
+    currentUsd: current,
+    limitUsd: limit,
+    level,
   }
 }

--- a/packages/control-plane/src/observability/index.ts
+++ b/packages/control-plane/src/observability/index.ts
@@ -1,8 +1,16 @@
-export type { CostSnapshot } from "./cost-tracker.js"
+export type {
+  BudgetStatus,
+  CostBudget,
+  CostSummary,
+  RecordLlmCostParams,
+  RecordLlmCostResult,
+} from "./cost-tracker.js"
 export { CostTracker } from "./cost-tracker.js"
 export type { EventEndParams, EventHandle, EventStartParams } from "./event-emitter.js"
 export { AgentEventEmitter } from "./event-emitter.js"
 export { ExecutionRegistry } from "./execution-registry.js"
+export type { ModelPricing } from "./model-pricing.js"
+export { DEFAULT_PRICING, estimateCost, MODEL_PRICING } from "./model-pricing.js"
 export type {
   AgentEventInput,
   AgentEventRow,

--- a/packages/control-plane/src/observability/model-pricing.ts
+++ b/packages/control-plane/src/observability/model-pricing.ts
@@ -1,0 +1,88 @@
+/**
+ * Model pricing table and cost estimation.
+ *
+ * Prices are in USD per million tokens. When a model is not found in the
+ * table, {@link DEFAULT_PRICING} is used so that cost is never zero for
+ * non-zero token counts.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ModelPricing {
+  /** USD per million input tokens. */
+  inputPerMToken: number
+  /** USD per million output tokens. */
+  outputPerMToken: number
+  /** USD per million cache-read tokens (optional). */
+  cacheReadPerMToken?: number
+}
+
+// ---------------------------------------------------------------------------
+// Pricing table
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_PRICING: ModelPricing = {
+  inputPerMToken: 3.0,
+  outputPerMToken: 15.0,
+}
+
+export const MODEL_PRICING: Record<string, ModelPricing> = {
+  // Claude 4.x
+  "claude-opus-4-6": {
+    inputPerMToken: 15.0,
+    outputPerMToken: 75.0,
+    cacheReadPerMToken: 1.5,
+  },
+  "claude-sonnet-4-6": {
+    inputPerMToken: 3.0,
+    outputPerMToken: 15.0,
+    cacheReadPerMToken: 0.3,
+  },
+  "claude-haiku-4-5": {
+    inputPerMToken: 0.8,
+    outputPerMToken: 4.0,
+    cacheReadPerMToken: 0.08,
+  },
+
+  // GPT-4o family
+  "gpt-4o": {
+    inputPerMToken: 2.5,
+    outputPerMToken: 10.0,
+  },
+  "gpt-4o-mini": {
+    inputPerMToken: 0.15,
+    outputPerMToken: 0.6,
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Estimation
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate the cost of an LLM call in USD.
+ *
+ * Uses model-specific pricing when available, otherwise falls back to
+ * {@link DEFAULT_PRICING}. Returns a positive number for non-zero token
+ * counts; never returns zero for unknown models.
+ */
+export function estimateCost(
+  model: string,
+  tokensIn: number,
+  tokensOut: number,
+  cacheReadTokens?: number,
+): number {
+  const pricing = MODEL_PRICING[model] ?? DEFAULT_PRICING
+
+  let cost =
+    (tokensIn / 1_000_000) * pricing.inputPerMToken +
+    (tokensOut / 1_000_000) * pricing.outputPerMToken
+
+  if (cacheReadTokens && pricing.cacheReadPerMToken) {
+    cost += (cacheReadTokens / 1_000_000) * pricing.cacheReadPerMToken
+  }
+
+  return cost
+}

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -499,13 +499,35 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
             executionRegistry.register(jobId, handle)
           }
 
-          // Per-job cost tracker (always created; wired to event emitter + budget below)
-          const costTracker = new CostTracker()
+          // Per-job cost tracker — atomic DB increments + budget enforcement
+          const costTracker = new CostTracker(db, eventEmitter)
 
           // Resolve cost budget from resource_limits (optional)
-          const rawCostBudget = agent.resource_limits.costBudgetUsd
-          const costBudgetUsd =
-            typeof rawCostBudget === "number" && rawCostBudget > 0 ? rawCostBudget : undefined
+          const rl = agent.resource_limits
+          const rawJobBudget =
+            typeof rl.maxUsdPerJob === "number"
+              ? rl.maxUsdPerJob
+              : typeof rl.costBudgetUsd === "number"
+                ? rl.costBudgetUsd
+                : 0
+          const costBudget =
+            rawJobBudget > 0 ||
+            (typeof rl.maxUsdPerSession === "number" && rl.maxUsdPerSession > 0) ||
+            (typeof rl.maxUsdPerDay === "number" && rl.maxUsdPerDay > 0)
+              ? {
+                  maxUsdPerJob: rawJobBudget,
+                  maxUsdPerSession:
+                    typeof rl.maxUsdPerSession === "number" ? rl.maxUsdPerSession : 0,
+                  maxUsdPerDay: typeof rl.maxUsdPerDay === "number" ? rl.maxUsdPerDay : 0,
+                  warningThresholdPct:
+                    typeof rl.warningThresholdPct === "number" ? rl.warningThresholdPct : 0.8,
+                }
+              : undefined
+          let toolCallCount = 0
+          let accTokensIn = 0
+          let accTokensOut = 0
+          let accCostUsd = 0
+          let llmCallCount = 0
 
           // Store the user prompt as a session message for memory extraction batching.
           if (job.session_id && task.instruction.prompt.trim().length > 0) {
@@ -609,7 +631,25 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
               // ── Event emission + cost tracking ──
               if (event.type === "usage") {
                 const { inputTokens, outputTokens, costUsd } = event.tokenUsage
-                costTracker.recordLlmCost(inputTokens, outputTokens, costUsd)
+
+                accTokensIn += inputTokens
+                accTokensOut += outputTokens
+                accCostUsd += costUsd
+                llmCallCount++
+
+                // Atomic DB increments + budget enforcement
+                const { budgetStatuses } = await costTracker
+                  .recordLlmCost({
+                    agentId: agent.id,
+                    jobId,
+                    sessionId: job.session_id,
+                    model: task.constraints.model,
+                    tokensIn: inputTokens,
+                    tokensOut: outputTokens,
+                    cacheReadTokens: event.tokenUsage.cacheReadTokens,
+                    budget: costBudget,
+                  })
+                  .catch(() => ({ budgetStatuses: [] }))
 
                 if (eventEmitter) {
                   await eventEmitter
@@ -633,12 +673,12 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                 }
 
                 // Cost budget enforcement
-                if (costBudgetUsd != null && !costTracker.checkBudget(costBudgetUsd)) {
+                if (budgetStatuses.some((s) => s.exceeded)) {
                   void handle.cancel("cost_budget_exceeded")
                 }
               }
               if (event.type === "tool_use") {
-                costTracker.recordToolCall()
+                toolCallCount++
 
                 if (eventEmitter) {
                   // Fire-and-forget start event; duration tracked by tool_result
@@ -735,8 +775,9 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
           rootSpan.setAttribute(CortexAttributes.EXECUTION_DURATION_MS, result.durationMs)
 
           // ── Step 12: Map status and persist result ──
+          // Token/cost fields are already atomically incremented by CostTracker
+          // during execution; only status, result, and tool_call_count written here.
           const jobStatus = mapExecutionStatus(result.status)
-          const costSnapshot = costTracker.getSnapshot()
 
           await db
             .updateTable("job")
@@ -744,31 +785,11 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
               status: jobStatus,
               completed_at: new Date(),
               result: executionResultToJson(result),
-              tokens_in: costSnapshot.tokensIn,
-              tokens_out: costSnapshot.tokensOut,
-              cost_usd: String(costSnapshot.costUsd),
-              llm_call_count: costSnapshot.llmCalls,
-              tool_call_count: costSnapshot.toolCalls,
+              tool_call_count: toolCallCount,
             })
             .where("id", "=", jobId)
             .where("status", "=", "RUNNING")
             .execute()
-
-          // Update session-level cost accumulators
-          if (job.session_id) {
-            await db
-              .updateTable("session")
-              .set({
-                total_tokens_in: costSnapshot.tokensIn,
-                total_tokens_out: costSnapshot.tokensOut,
-                total_cost_usd: String(costSnapshot.costUsd),
-              })
-              .where("id", "=", job.session_id)
-              .execute()
-              .catch(() => {
-                // Non-fatal: session cost update is best-effort
-              })
-          }
 
           // Record per-user usage in the usage ledger
           if (userRateLimiter && job.session_id) {
@@ -784,9 +805,9 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                   session.user_account_id,
                   agent.id,
                   1,
-                  costSnapshot.tokensIn,
-                  costSnapshot.tokensOut,
-                  costSnapshot.costUsd,
+                  accTokensIn,
+                  accTokensOut,
+                  accCostUsd,
                 )
                 .catch(() => {
                   // Non-fatal: usage recording is best-effort
@@ -798,8 +819,8 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
           if (eventEmitter) {
             const sessionEndPayload: Record<string, unknown> = {
               status: jobStatus,
-              llmCalls: costSnapshot.llmCalls,
-              toolCalls: costSnapshot.toolCalls,
+              llmCalls: llmCallCount,
+              toolCalls: toolCallCount,
               durationMs: result.durationMs,
             }
 
@@ -815,9 +836,9 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                 agentId: agent.id,
                 sessionId: job.session_id,
                 jobId,
-                tokensIn: costSnapshot.tokensIn,
-                tokensOut: costSnapshot.tokensOut,
-                costUsd: costSnapshot.costUsd,
+                tokensIn: accTokensIn,
+                tokensOut: accTokensOut,
+                costUsd: accCostUsd,
                 payload: sessionEndPayload,
               })
               .catch(() => {


### PR DESCRIPTION
## Summary

- **New `model-pricing.ts`**: `MODEL_PRICING` table with per-model pricing (Claude 4.x, GPT-4o family) and `estimateCost()` function with fallback to `DEFAULT_PRICING` for unknown models.
- **Rewritten `cost-tracker.ts`**: DB-backed `CostTracker` class with `recordLlmCost()` (atomic SQL increments on `job` + `session`), `getAgentCostSummary()`, `getSessionCostSummary()`, and multi-level budget enforcement (job/session/daily) with `cost_alert` event emission.
- **Updated `agent-execute.ts`**: Wired new CostTracker with `CostBudget` from `resource_limits`; atomic increments replace end-of-job batch writes.
- **29 unit tests** covering estimation, atomic DB operations, budget thresholds, warning/exceeded alerts, and summary aggregation.

Closes #323

## Test plan

- [x] `estimateCost("claude-sonnet-4-6", 1000, 500)` returns correct cost (0.0105)
- [x] `recordLlmCost()` atomically increments job and session columns
- [x] Job cost exceeding `maxUsdPerJob` returns `{ exceeded: true, level: 'job' }`
- [x] Session cost exceeding `maxUsdPerSession` returns `{ exceeded: true, level: 'session' }`
- [x] Warning at 80% threshold emits `cost_alert` event
- [x] Unknown model uses default pricing, not zero
- [x] `getAgentCostSummary()` aggregates correctly with per-model breakdown
- [x] All 1508 tests pass; lint, typecheck, and build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Model-specific pricing for accurate cost estimation with fallback to default rates
* Multi-level budget enforcement supporting job, session, and daily spending limits
* Automatic cost alerts triggered on budget warnings and exceedances
* Per-agent and per-session cost summaries with per-model breakdowns
* Budget warning threshold configuration for proactive monitoring

## Tests
* Comprehensive test suite validating cost estimation, budget enforcement, and alert emission

<!-- end of auto-generated comment: release notes by coderabbit.ai -->