### PR TITLE
feat(routes): cross-agent event feed + finalize operator visibility epic (#320)

### DIFF
--- a/docs/design/operator-visibility.md
+++ b/docs/design/operator-visibility.md
@@ -2,7 +2,7 @@
 
 **Issue:** #265
 **Epic:** #320
-**Status:** Proposed
+**Status:** Implemented
 **Authors:** Joe Graham, Hessian
 **Date:** 2026-03-03
 **Depends on:** [Agent Capability Model](./agent-capabilities.md) (#264), [Agent Lifecycle & Resilience](./agent-lifecycle.md) (#266)
@@ -771,24 +771,20 @@ abortController.abort()
 
 ## 12. API Surface Summary
 
-### 12.1 New Endpoints
+### 12.1 Endpoints (All Implemented)
 
 ```
-GET    /agents/:agentId/events/stream    — SSE activity stream
-GET    /agents/:agentId/events           — Historical event query
+GET    /operators/activity-stream         — SSE activity stream (all agents)
 GET    /events                            — Cross-agent event feed (admin)
-POST   /agents/:agentId/kill             — Kill switch
-POST   /agents/:agentId/replay           — Replay from checkpoint
-```
-
-### 12.2 Existing Endpoints (Already Implemented)
-
-```
-POST   /agents/:agentId/dry-run          — Simulate turn (#329)
+GET    /agents/:agentId/events            — Historical event query (operator)
+GET    /agents/:agentId/cost              — Cost aggregation (operator)
+POST   /agents/:agentId/kill             — Kill switch (operator)
+POST   /agents/:agentId/replay           — Replay from checkpoint (admin)
+POST   /agents/:agentId/dry-run          — Simulate turn (operator)
 POST   /agents/:agentId/pause            — Pause execution
 POST   /agents/:agentId/resume           — Resume from checkpoint
-POST   /agents/:agentId/steer            — Steering injection (#327)
-GET    /agents                            — List with cost + health (#332)
+POST   /agents/:agentId/steer            — Steering injection (operator)
+GET    /agents                            — List with cost + health
 ```
 
 ### 12.3 Endpoints from Related Epics
@@ -810,41 +806,39 @@ POST   /agents/:agentId/rollback         — Restore checkpoint (#266)
 
 | # | Ticket | Issue | Size | Status | Dependencies |
 |---|--------|-------|------|--------|-------------|
-| T1 | DB migration — `agent_event` table + job/session cost columns | #321 | M | Done (migration 021) | None |
-| T2 | AgentEventEmitter service — persist + broadcast events | #322 | L | Open | T1 |
-| T3 | CostTracker service — estimation, accumulation, budget enforcement | #323 | L | Open | T1, T2 |
-| T4 | Wire event emitter + cost tracker into agent-execute | #324 | M | Open | T2, T3 |
-| T5 | Activity stream SSE + event query REST endpoints | #325 | M | Open | T2 |
-| T6 | Kill switch — immediate execution cancellation | #326 | M | Open | T4 |
+| T1 | DB migration — `agent_event` table + job/session cost columns | #321 | M | **Done** (migration 021, 025) | None |
+| T2 | AgentEventEmitter service — persist + broadcast events | #322 | L | **Done** | T1 |
+| T3 | CostTracker service — estimation, accumulation, budget enforcement | #323 | L | **Done** | T1, T2 |
+| T4 | Wire event emitter + cost tracker into agent-execute | #324 | M | **Done** | T2, T3 |
+| T5 | Activity stream SSE + event query REST endpoints | #325 | M | **Done** | T2 |
+| T6 | Kill switch — immediate execution cancellation | #326 | M | **Done** | T4 |
 | T7 | Enhanced steer — acknowledgment + operator feedback loop | #327 | S | **Done** | T2, T4 |
-| T8 | Replay — re-run from checkpoint with modifications | #328 | M | Open | #266-T6, #266-T7 |
+| T8 | Replay — re-run from checkpoint with modifications | #328 | M | **Done** | #266-T6, #266-T7 |
 | T9 | Dry run — simulate agent turn without tool execution | #329 | S | **Done** | T2, T3 |
 | T10 | Event retention pruning task | #330 | S | **Done** | T1 |
-| T11 | Dashboard — operations page + agent operations tab | #331 | L | Open | T5, T6, T7, T9 |
+| T11 | Dashboard — operations page + agent operations tab | #331 | L | **Done** | T5, T6, T7, T9 |
 | T12 | Extend GET /agents with cost + health summary fields | #332 | S | **Done** | T1, T3 |
 
 ### Dependency Graph
 
 ```
 T1 (migration) ✓
-├── T2 (event emitter)
-│   ├── T3 (cost tracker)
-│   │   ├── T4 (wire into agent-execute)
-│   │   │   ├── T6 (kill switch)
+├── T2 (event emitter) ✓
+│   ├── T3 (cost tracker) ✓
+│   │   ├── T4 (wire into agent-execute) ✓
+│   │   │   ├── T6 (kill switch) ✓
 │   │   │   └── T7 (enhanced steer) ✓
 │   │   └── T12 (extend /agents API) ✓
-│   ├── T5 (SSE + REST endpoints)
+│   ├── T5 (SSE + REST endpoints) ✓
 │   └── T9 (dry run) ✓
 ├── T10 (event pruning) ✓
 
-T8 (replay)                           ← #266-T6, #266-T7
+T8 (replay) ✓                        ← #266-T6, #266-T7
 
-T11 (dashboard)                       ← T5, T6, T7, T9
+T11 (dashboard) ✓                    ← T5, T6, T7, T9
 ```
 
-**Critical path:** T2 → T3 → T4 → T6 → T11
-
-**Next tickets to implement:** T2 (AgentEventEmitter) and T5 (activity stream endpoints) can proceed in parallel.
+All tickets complete.
 
 ---
 

--- a/packages/control-plane/src/__tests__/operator-events.test.ts
+++ b/packages/control-plane/src/__tests__/operator-events.test.ts
@@ -399,6 +399,108 @@ describe("GET /operators/activity-stream", () => {
 })
 
 // ---------------------------------------------------------------------------
+// Tests: GET /events — cross-agent event feed
+// ---------------------------------------------------------------------------
+
+describe("GET /events", () => {
+  it("returns 200 with events and total", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/events",
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.events).toBeDefined()
+    expect(Array.isArray(body.events)).toBe(true)
+    expect(body.total).toBeDefined()
+  })
+
+  it("accepts agentIds filter", async () => {
+    const { app, db } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/events?agentIds=${AGENT_ID}`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(db.selectFrom).toHaveBeenCalled()
+  })
+
+  it("accepts eventTypes filter", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/events?eventTypes=llm_call_end,tool_call_end",
+    })
+
+    expect(res.statusCode).toBe(200)
+  })
+
+  it("accepts since and until date filters", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/events?since=2026-03-07T00:00:00Z&until=2026-03-08T00:00:00Z",
+    })
+
+    expect(res.statusCode).toBe(200)
+  })
+
+  it("accepts limit and offset pagination", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/events?limit=10&offset=5",
+    })
+
+    expect(res.statusCode).toBe(200)
+  })
+
+  it("rejects limit > 200", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/events?limit=201",
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+
+  it("rejects negative offset", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/events?offset=-1",
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+
+  it("requires auth when requireAuth is true", async () => {
+    const { app } = await buildTestApp({
+      authConfig: { requireAuth: true, apiKeys: [] },
+    })
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/events",
+    })
+
+    expect(res.statusCode).toBe(401)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Tests: Auth role enforcement
 // ---------------------------------------------------------------------------
 

--- a/packages/control-plane/src/routes/operator-events.ts
+++ b/packages/control-plane/src/routes/operator-events.ts
@@ -2,6 +2,7 @@
  * Operator Event Routes
  *
  * GET  /operators/activity-stream       — SSE activity stream (all agents)
+ * GET  /events                          — cross-agent event feed (admin)
  * GET  /agents/:agentId/events          — paginated event query
  * GET  /agents/:agentId/cost            — cost aggregation by model/session/day
  */
@@ -43,6 +44,15 @@ interface EventListQuery {
   offset?: number
 }
 
+interface CrossAgentEventQuery {
+  agentIds?: string
+  eventTypes?: string
+  since?: string
+  until?: string
+  limit?: number
+  offset?: number
+}
+
 interface CostQuery {
   since?: string
   until?: string
@@ -66,6 +76,7 @@ export function operatorEventRoutes(deps: OperatorEventRouteDeps) {
   const authOpts: AuthMiddlewareOptions = { config: authConfig, sessionService }
   const requireAuth: PreHandler = createRequireAuth(authOpts)
   const requireOperator: PreHandler = createRequireRole("operator")
+  const requireAdmin: PreHandler = createRequireRole("admin")
 
   return function register(app: FastifyInstance): void {
     // -----------------------------------------------------------------
@@ -162,6 +173,76 @@ export function operatorEventRoutes(deps: OperatorEventRouteDeps) {
         })
 
         reply.hijack()
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // GET /events — cross-agent event feed (admin)
+    // -----------------------------------------------------------------
+    app.get<{ Querystring: CrossAgentEventQuery }>(
+      "/events",
+      {
+        preHandler: [requireAuth, requireAdmin],
+        schema: {
+          querystring: {
+            type: "object",
+            properties: {
+              agentIds: { type: "string" },
+              eventTypes: { type: "string" },
+              since: { type: "string" },
+              until: { type: "string" },
+              limit: { type: "number", minimum: 1, maximum: 200 },
+              offset: { type: "number", minimum: 0 },
+            },
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Querystring: CrossAgentEventQuery }>,
+        reply: FastifyReply,
+      ) => {
+        const { agentIds, eventTypes, since, until, limit = 50, offset = 0 } = request.query
+
+        let baseQuery = db.selectFrom("agent_event")
+
+        if (agentIds) {
+          const ids = agentIds.split(",").filter(Boolean)
+          if (ids.length > 0) {
+            baseQuery = baseQuery.where("agent_id", "in", ids)
+          }
+        }
+        if (eventTypes) {
+          const types = eventTypes.split(",").filter(Boolean)
+          if (types.length > 0) {
+            baseQuery = baseQuery.where("event_type", "in", types)
+          }
+        }
+        if (since) {
+          baseQuery = baseQuery.where("created_at", ">=", new Date(since))
+        }
+        if (until) {
+          baseQuery = baseQuery.where("created_at", "<=", new Date(until))
+        }
+
+        const [events, countResult] = await Promise.all([
+          baseQuery.selectAll().orderBy("created_at", "desc").limit(limit).offset(offset).execute(),
+          baseQuery.select(db.fn.countAll<number>().as("total")).executeTakeFirstOrThrow(),
+        ])
+
+        return reply.status(200).send({
+          events: events.map((e) => ({
+            id: e.id,
+            agentId: e.agent_id,
+            eventType: e.event_type,
+            payload: e.payload,
+            tokensIn: e.tokens_in,
+            tokensOut: e.tokens_out,
+            costUsd: e.cost_usd ? Number(e.cost_usd) : null,
+            toolRef: e.tool_ref,
+            createdAt: e.created_at,
+          })),
+          total: Number(countResult.total),
+        })
       },
     )
 


### PR DESCRIPTION
## Summary

- Add `GET /events` cross-agent REST endpoint (admin-only) for historical event queries across all agents — specified in design doc §6.3/§12.1 but missing from the implementation
- Supports filtering by `agentIds`, `eventTypes`, `since`/`until` date range, and `limit`/`offset` pagination
- Update design doc status from Proposed → Implemented, mark all 12 sub-tickets (T1–T12) as Done
- Reconcile endpoint documentation in §12.1 with actual route paths

## Test plan

- [x] 8 new tests for `GET /events` endpoint (200 OK, filters, pagination, validation, auth)
- [x] All 1544 tests pass (up from 1536)
- [x] Lint clean on changed files
- [x] Typecheck clean

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Operator visibility design document updated to reflect implementation completion status and finalized API specifications.

* **New Features**
  * New cross-agent event feed endpoint now available for admins to query activity across all agents.
  * Supports filtering by agent IDs, event types, and date ranges with pagination and query validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->