### PR TITLE
feat(dispatch): wire rate limiter into message pipeline + finalize epic #333

### DIFF
--- a/docs/design/channel-authorization.md
+++ b/docs/design/channel-authorization.md
@@ -1,7 +1,7 @@
 # Channel Authorization — Design Document
 
 **Issue:** #268
-**Status:** Proposed
+**Status:** Implemented
 **Authors:** Joe Graham, Hessian
 **Date:** 2026-03-07
 **Depends on:** [Agent Capability Model](./agent-capabilities.md) (#264), [Operator Dashboard](./operator-dashboard.md) (#267)
@@ -442,6 +442,17 @@ Linked from the grant list. Shows:
 ---
 
 ## 10. Implementation Tickets
+
+| Ticket | Title | Issue | Size | Status | Dependencies |
+|--------|-------|-------|------|--------|-------------|
+| T1 | Authorization check in message dispatch | #335, #338 | M | **Done** | None |
+| T2 | Per-user rate limiting enforcement | #339 | S | **Done** | T1 |
+| T3 | Per-user token budget enforcement | #339 | S | **Done** | T1 |
+| T4 | Adapter simplification — remove env var allow lists | #338 | S | **Done** | T1 |
+| T5 | Agent user management API routes | #340 | M | **Done** | T1 |
+| T6 | Auto-create anonymous user accounts in dispatch | #335 | S | **Done** | None |
+| T7 | Account merge on dashboard authentication | — | M | **Deferred** | T6 |
+| T8 | Dashboard — Users tab on agent detail | #341, #342 | L | **Done** | T5 |
 
 ### T1: Authorization check in message dispatch (#333-T1)
 

--- a/packages/control-plane/src/__tests__/message-dispatch.test.ts
+++ b/packages/control-plane/src/__tests__/message-dispatch.test.ts
@@ -3,6 +3,7 @@ import type { Kysely } from "kysely"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { AuthDecision, ChannelAuthGuard } from "../auth/channel-auth-guard.js"
+import type { RateLimitDecision, UserRateLimiter } from "../auth/user-rate-limiter.js"
 import type { AgentChannelService } from "../channels/agent-channel-service.js"
 import { createMessageDispatch, watchJobCompletion } from "../channels/message-dispatch.js"
 import type { Database } from "../db/types.js"
@@ -139,6 +140,14 @@ function mockChannelAuthGuard(decision: AuthDecision) {
     }),
     resolveOrCreateIdentity: vi.fn(),
   } as unknown as ChannelAuthGuard
+}
+
+function mockUserRateLimiter(decision: RateLimitDecision) {
+  return {
+    check: vi.fn().mockResolvedValue(decision),
+    recordUsage: vi.fn().mockResolvedValue(undefined),
+    getUsageSummary: vi.fn(),
+  } as unknown as UserRateLimiter
 }
 
 // ---------------------------------------------------------------------------
@@ -639,6 +648,198 @@ describe("ChannelAuthGuard integration", () => {
     await dispatch(makeRoutedMessage())
 
     // Job created normally without guard
+    expect(enqueueJob).toHaveBeenCalledWith("job-123")
+  })
+})
+
+describe("UserRateLimiter integration", () => {
+  it("blocks message when user exceeds rate limit", async () => {
+    const guard = mockChannelAuthGuard({
+      allowed: true,
+      userId: "user-111",
+      grantId: "grant-999",
+      reason: "granted",
+    })
+    const rateLimiter = mockUserRateLimiter({
+      allowed: false,
+      reason: "rate_limited",
+      replyToUser: "You've reached the message limit (60 per hour). Please try again later.",
+      retryAfterSeconds: 3600,
+    })
+    const agentChannelService = mockAgentChannelService("agent-aaa")
+    const router = mockRouter()
+    const enqueueJob = vi.fn()
+    const logger = { info: vi.fn(), warn: vi.fn() }
+    const db = mockDb({ existingSession: { id: "session-1" } })
+
+    const dispatch = createMessageDispatch({
+      db,
+      agentChannelService,
+      router: router as never,
+      enqueueJob,
+      channelAuthGuard: guard,
+      userRateLimiter: rateLimiter,
+      logger,
+    })
+
+    await dispatch(makeRoutedMessage())
+
+    // Rate limit reply sent
+    expect(router.send).toHaveBeenCalledWith("telegram", "chat-42", {
+      text: "You've reached the message limit (60 per hour). Please try again later.",
+    })
+
+    // No job created
+    expect(enqueueJob).not.toHaveBeenCalled()
+
+    // Blocked log entry
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "rate_limited" }),
+      "Message blocked by rate limiter",
+    )
+  })
+
+  it("blocks message when user exceeds token budget", async () => {
+    const guard = mockChannelAuthGuard({
+      allowed: true,
+      userId: "user-111",
+      grantId: "grant-999",
+      reason: "granted",
+    })
+    const rateLimiter = mockUserRateLimiter({
+      allowed: false,
+      reason: "budget_exceeded",
+      replyToUser:
+        "You've reached the token budget (100000 tokens per day). Please try again later.",
+    })
+    const agentChannelService = mockAgentChannelService("agent-aaa")
+    const router = mockRouter()
+    const enqueueJob = vi.fn()
+    const logger = { info: vi.fn(), warn: vi.fn() }
+    const db = mockDb({ existingSession: { id: "session-1" } })
+
+    const dispatch = createMessageDispatch({
+      db,
+      agentChannelService,
+      router: router as never,
+      enqueueJob,
+      channelAuthGuard: guard,
+      userRateLimiter: rateLimiter,
+      logger,
+    })
+
+    await dispatch(makeRoutedMessage())
+
+    expect(router.send).toHaveBeenCalledWith("telegram", "chat-42", {
+      text: "You've reached the token budget (100000 tokens per day). Please try again later.",
+    })
+    expect(enqueueJob).not.toHaveBeenCalled()
+  })
+
+  it("allows message through when rate limiter approves", async () => {
+    const guard = mockChannelAuthGuard({
+      allowed: true,
+      userId: "user-111",
+      grantId: "grant-999",
+      reason: "granted",
+    })
+    const rateLimiter = mockUserRateLimiter({
+      allowed: true,
+      reason: "allowed",
+    })
+    const agentChannelService = mockAgentChannelService("agent-aaa")
+    const router = mockRouter()
+    const enqueueJob = vi.fn().mockResolvedValue(undefined)
+    const logger = { info: vi.fn(), warn: vi.fn() }
+    const db = mockDb({ existingSession: { id: "session-1" } })
+
+    const dispatch = createMessageDispatch({
+      db,
+      agentChannelService,
+      router: router as never,
+      enqueueJob,
+      channelAuthGuard: guard,
+      userRateLimiter: rateLimiter,
+      logger,
+    })
+
+    await dispatch(makeRoutedMessage())
+
+    // Job created
+    expect(enqueueJob).toHaveBeenCalledWith("job-123")
+
+    // Rate limiter was called
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(rateLimiter.check).toHaveBeenCalledWith("user-111", "agent-aaa", undefined, undefined)
+  })
+
+  it("skips rate limiting when no auth guard is provided", async () => {
+    const rateLimiter = mockUserRateLimiter({
+      allowed: false,
+      reason: "rate_limited",
+      replyToUser: "Rate limited",
+    })
+    const agentChannelService = mockAgentChannelService("agent-aaa")
+    const router = mockRouter()
+    const enqueueJob = vi.fn().mockResolvedValue(undefined)
+    const logger = { info: vi.fn(), warn: vi.fn() }
+    const db = mockDb({ existingSession: { id: "session-1" } })
+
+    const dispatch = createMessageDispatch({
+      db,
+      agentChannelService,
+      router: router as never,
+      enqueueJob,
+      // No channelAuthGuard — rate limiter should be skipped
+      userRateLimiter: rateLimiter,
+      logger,
+    })
+
+    await dispatch(makeRoutedMessage())
+
+    // Rate limiter never called (no auth decision)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(rateLimiter.check).not.toHaveBeenCalled()
+
+    // Job still created
+    expect(enqueueJob).toHaveBeenCalledWith("job-123")
+  })
+
+  it("skips rate limiting when auth grants without grantId", async () => {
+    const guard = mockChannelAuthGuard({
+      allowed: true,
+      userId: "user-111",
+      // No grantId — e.g. guard is permissive
+      reason: "granted",
+    })
+    const rateLimiter = mockUserRateLimiter({
+      allowed: false,
+      reason: "rate_limited",
+      replyToUser: "Rate limited",
+    })
+    const agentChannelService = mockAgentChannelService("agent-aaa")
+    const router = mockRouter()
+    const enqueueJob = vi.fn().mockResolvedValue(undefined)
+    const logger = { info: vi.fn(), warn: vi.fn() }
+    const db = mockDb({ existingSession: { id: "session-1" } })
+
+    const dispatch = createMessageDispatch({
+      db,
+      agentChannelService,
+      router: router as never,
+      enqueueJob,
+      channelAuthGuard: guard,
+      userRateLimiter: rateLimiter,
+      logger,
+    })
+
+    await dispatch(makeRoutedMessage())
+
+    // Rate limiter skipped — no grantId means no per-user limits apply
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(rateLimiter.check).not.toHaveBeenCalled()
+
+    // Job created
     expect(enqueueJob).toHaveBeenCalledWith("job-123")
   })
 })

--- a/packages/control-plane/src/channels/message-dispatch.ts
+++ b/packages/control-plane/src/channels/message-dispatch.ts
@@ -18,7 +18,8 @@ import type { MessageRouter, RoutedMessage } from "@cortex/shared/channels"
 import type { Kysely } from "kysely"
 
 import type { AuthDecision, ChannelAuthGuard } from "../auth/channel-auth-guard.js"
-import type { Database } from "../db/types.js"
+import type { UserRateLimiter } from "../auth/user-rate-limiter.js"
+import type { Database, RateLimit, TokenBudget } from "../db/types.js"
 import type { AgentChannelService } from "./agent-channel-service.js"
 
 /** Pattern matching pairing codes (6-char uppercase alphanumeric). */
@@ -30,6 +31,7 @@ export interface MessageDispatchDeps {
   router: MessageRouter
   enqueueJob: (jobId: string) => Promise<void>
   channelAuthGuard?: ChannelAuthGuard
+  userRateLimiter?: UserRateLimiter
   logger?: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void }
 }
 
@@ -57,7 +59,15 @@ const TERMINAL_STATUSES: ReadonlySet<string> = new Set<JobStatus>([
 export function createMessageDispatch(
   deps: MessageDispatchDeps,
 ): (msg: RoutedMessage) => Promise<void> {
-  const { db, agentChannelService, router, enqueueJob, channelAuthGuard, logger = console } = deps
+  const {
+    db,
+    agentChannelService,
+    router,
+    enqueueJob,
+    channelAuthGuard,
+    userRateLimiter,
+    logger = console,
+  } = deps
 
   return async function dispatch(routed: RoutedMessage): Promise<void> {
     const { channelType, chatId } = routed.message
@@ -105,6 +115,37 @@ export function createMessageDispatch(
         logger.info(
           { agentId, channelType, chatId, reason: authDecision.reason },
           "Message blocked by ChannelAuthGuard",
+        )
+        return
+      }
+    }
+
+    // ── Per-user rate limit & token budget enforcement ──────────────────
+    if (userRateLimiter && authDecision?.allowed && authDecision.grantId) {
+      // Fetch grant's rate_limit and token_budget for cascade resolution
+      const grant = await db
+        .selectFrom("agent_user_grant")
+        .select(["rate_limit", "token_budget"])
+        .where("id", "=", authDecision.grantId)
+        .executeTakeFirst()
+
+      const grantRateLimit = grant?.rate_limit as RateLimit | null | undefined
+      const grantTokenBudget = grant?.token_budget as TokenBudget | null | undefined
+
+      const rateLimitDecision = await userRateLimiter.check(
+        authDecision.userId,
+        agentId,
+        grantRateLimit ?? undefined,
+        grantTokenBudget ?? undefined,
+      )
+
+      if (!rateLimitDecision.allowed) {
+        if (rateLimitDecision.replyToUser) {
+          await router.send(channelType, chatId, { text: rateLimitDecision.replyToUser })
+        }
+        logger.info(
+          { agentId, channelType, chatId, reason: rateLimitDecision.reason },
+          "Message blocked by rate limiter",
         )
         return
       }


### PR DESCRIPTION
## Summary
- Wire `UserRateLimiter.check()` into `createMessageDispatch()` — per-user rate limits and token budgets are now enforced after authorization but before session creation
- Update channel-authorization design doc status from Proposed to Implemented with a summary table marking all sub-tickets (T1–T8) as Done

## Context
All 9 sub-tickets (#334–#342) for the Channel Authorization epic were closed, but the `UserRateLimiter.check()` call was not wired into the dispatch pipeline. The service existed (#339) and `recordUsage()` was called in `agent-execute.ts`, but the pre-message enforcement check was missing.

## Changes
- `packages/control-plane/src/channels/message-dispatch.ts` — add optional `userRateLimiter` dep, fetch grant limits after auth, call `check()` before session creation
- `packages/control-plane/src/__tests__/message-dispatch.test.ts` — 5 new tests: rate_limited, budget_exceeded, allowed, skip-without-guard, skip-without-grantId
- `docs/design/channel-authorization.md` — status → Implemented, added ticket summary table

## Test plan
- [x] All 20 dispatch tests pass (15 existing + 5 new)
- [x] Full test suite passes (npx vitest run)
- [x] Typecheck clean (npm run typecheck)
- [x] Lint clean (npx eslint)
- [x] Build succeeds (npm run build)

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented per-user rate limiting in message dispatch, enforcing limits based on user grants and agent configurations.

* **Tests**
  * Added integration tests for rate-limiting scenarios, covering token budgets and permission flows.

* **Documentation**
  * Updated channel authorization design documentation with implementation status and progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->