### PR TITLE
feat(channels): channel configuration UI + DB persistence (#258)

### DIFF
--- a/packages/control-plane/migrations/027_channel_config.down.sql
+++ b/packages/control-plane/migrations/027_channel_config.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS channel_config;

--- a/packages/control-plane/migrations/027_channel_config.up.sql
+++ b/packages/control-plane/migrations/027_channel_config.up.sql
@@ -1,0 +1,16 @@
+-- Channel configuration table — stores DB-backed config for channel adapters
+-- (Telegram, Discord, WhatsApp) with encrypted sensitive fields.
+
+CREATE TABLE channel_config (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  type          TEXT NOT NULL,                    -- telegram | discord | whatsapp
+  name          TEXT NOT NULL,                    -- human-readable label
+  config_enc    TEXT NOT NULL,                    -- AES-256-GCM encrypted JSONB (bot tokens, guild IDs, etc.)
+  enabled       BOOLEAN NOT NULL DEFAULT true,
+  created_by    UUID REFERENCES user_account(id) ON DELETE SET NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_channel_config_type ON channel_config (type);
+CREATE INDEX idx_channel_config_enabled ON channel_config (enabled) WHERE enabled = true;

--- a/packages/control-plane/src/__tests__/channel-config-service.test.ts
+++ b/packages/control-plane/src/__tests__/channel-config-service.test.ts
@@ -1,0 +1,298 @@
+import type { Kysely } from "kysely"
+import { describe, expect, it, vi } from "vitest"
+
+import { ChannelConfigService } from "../channels/channel-config-service.js"
+import type { Database } from "../db/types.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MASTER_KEY = "test-master-key-for-channel-config"
+
+function makeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "cccccccc-1111-2222-3333-444444444444",
+    type: "telegram",
+    name: "My Telegram Bot",
+    config_enc: "", // will be set in tests that need it
+    enabled: true,
+    created_by: "uuuuuuuu-1111-2222-3333-444444444444",
+    created_at: new Date("2026-03-01T00:00:00Z"),
+    updated_at: new Date("2026-03-01T00:00:00Z"),
+    ...overrides,
+  }
+}
+
+function selectChain(rows: Record<string, unknown>[]) {
+  const executeTakeFirst = vi.fn().mockResolvedValue(rows[0] ?? undefined)
+  const executeTakeFirstOrThrow = vi.fn().mockImplementation(() => {
+    if (rows.length === 0) throw new Error("No result")
+    return Promise.resolve(rows[0])
+  })
+  const execute = vi.fn().mockResolvedValue(rows)
+  const terminal = { execute, executeTakeFirst, executeTakeFirstOrThrow }
+  const orderBy = vi.fn().mockReturnValue(terminal)
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  whereFn.mockReturnValue({
+    where: whereFn,
+    orderBy,
+    ...terminal,
+  })
+  const selectAll = vi.fn().mockReturnValue({ where: whereFn, orderBy, ...terminal })
+  const select = vi.fn().mockReturnValue({ where: whereFn, orderBy, ...terminal })
+  return { selectAll, select, _where: whereFn, _executeTakeFirst: executeTakeFirst }
+}
+
+function insertChain(returnRow: Record<string, unknown>) {
+  const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(returnRow)
+  const returning = vi.fn().mockReturnValue({ executeTakeFirstOrThrow })
+  const values = vi.fn().mockReturnValue({ returning })
+  return { values }
+}
+
+function updateChain(returnRow: Record<string, unknown> | undefined) {
+  const executeTakeFirst = vi.fn().mockResolvedValue(returnRow ?? undefined)
+  const returning = vi.fn().mockReturnValue({ executeTakeFirst })
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  whereFn.mockReturnValue({ where: whereFn, returning })
+  const set = vi.fn().mockReturnValue({ where: whereFn, returning })
+  return { set }
+}
+
+function deleteChain(numDeletedRows = 1) {
+  const executeTakeFirst = vi.fn().mockResolvedValue({ numDeletedRows: BigInt(numDeletedRows) })
+  const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+  whereFn.mockReturnValue({ where: whereFn, executeTakeFirst })
+  return { where: whereFn }
+}
+
+function mockDb(
+  opts: {
+    selectRows?: Record<string, unknown>[]
+    insertReturn?: Record<string, unknown>
+    updateReturn?: Record<string, unknown> | null
+    deleteCount?: number
+  } = {},
+) {
+  const selectRows = opts.selectRows ?? [makeRow()]
+  const insertReturn = opts.insertReturn ?? makeRow()
+  const updateReturn = opts.updateReturn === null ? undefined : (opts.updateReturn ?? makeRow())
+  const deleteCount = opts.deleteCount ?? 1
+
+  return {
+    selectFrom: vi.fn().mockImplementation(() => selectChain(selectRows)),
+    insertInto: vi.fn().mockImplementation(() => insertChain(insertReturn)),
+    updateTable: vi.fn().mockImplementation(() => updateChain(updateReturn)),
+    deleteFrom: vi.fn().mockImplementation(() => deleteChain(deleteCount)),
+  } as unknown as Kysely<Database>
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ChannelConfigService", () => {
+  describe("list", () => {
+    it("returns channel config summaries", async () => {
+      const db = mockDb({ selectRows: [makeRow(), makeRow({ id: "other", name: "Second Bot" })] })
+      const service = new ChannelConfigService(db, MASTER_KEY)
+
+      const result = await service.list()
+
+      expect(result).toHaveLength(2)
+      expect(result[0]!.name).toBe("My Telegram Bot")
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(db.selectFrom).toHaveBeenCalledWith("channel_config")
+    })
+  })
+
+  describe("getById", () => {
+    it("returns a summary when found", async () => {
+      const db = mockDb()
+      const service = new ChannelConfigService(db, MASTER_KEY)
+
+      const result = await service.getById("cccccccc-1111-2222-3333-444444444444")
+
+      expect(result).toBeDefined()
+      expect(result!.type).toBe("telegram")
+    })
+
+    it("returns undefined when not found", async () => {
+      const db = mockDb({ selectRows: [] })
+      const service = new ChannelConfigService(db, MASTER_KEY)
+
+      const result = await service.getById("nonexistent")
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("getByIdFull", () => {
+    it("returns decrypted config", async () => {
+      // Create a config first to get an encrypted value, then read it back
+      const createRow = makeRow()
+      let capturedConfigEnc = ""
+      const insertDb = {
+        insertInto: vi.fn().mockImplementation(() => ({
+          values: vi.fn().mockImplementation((vals: Record<string, unknown>) => {
+            capturedConfigEnc = vals.config_enc as string
+            return {
+              returning: vi.fn().mockReturnValue({
+                executeTakeFirstOrThrow: vi.fn().mockResolvedValue(createRow),
+              }),
+            }
+          }),
+        })),
+        selectFrom: vi.fn(),
+        updateTable: vi.fn(),
+        deleteFrom: vi.fn(),
+      } as unknown as Kysely<Database>
+
+      const svc = new ChannelConfigService(insertDb, MASTER_KEY)
+      await svc.create("telegram", "Test Bot", { botToken: "123:ABC" }, null)
+
+      // Now use the encrypted value to test getByIdFull
+      const row = makeRow({ config_enc: capturedConfigEnc })
+      const readDb = mockDb({ selectRows: [row] })
+      const readSvc = new ChannelConfigService(readDb, MASTER_KEY)
+
+      const full = await readSvc.getByIdFull("cccccccc-1111-2222-3333-444444444444")
+
+      expect(full).toBeDefined()
+      expect(full!.config).toEqual({ botToken: "123:ABC" })
+      expect(full!.name).toBe("My Telegram Bot")
+    })
+  })
+
+  describe("create", () => {
+    it("inserts a new channel config with encrypted data", async () => {
+      const db = mockDb()
+      const service = new ChannelConfigService(db, MASTER_KEY)
+
+      const result = await service.create("telegram", "My Bot", { botToken: "tok" }, "user-1")
+
+      expect(result.type).toBe("telegram")
+      expect(result.name).toBe("My Telegram Bot") // from mock return
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(db.insertInto).toHaveBeenCalledWith("channel_config")
+    })
+  })
+
+  describe("update", () => {
+    it("returns updated summary", async () => {
+      const db = mockDb({ updateReturn: makeRow({ name: "Updated Bot" }) })
+      const service = new ChannelConfigService(db, MASTER_KEY)
+
+      const result = await service.update("cccccccc-1111-2222-3333-444444444444", {
+        name: "Updated Bot",
+      })
+
+      expect(result).toBeDefined()
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(db.updateTable).toHaveBeenCalledWith("channel_config")
+    })
+
+    it("returns undefined when not found", async () => {
+      const db = mockDb({ updateReturn: null })
+      const service = new ChannelConfigService(db, MASTER_KEY)
+
+      const result = await service.update("nonexistent", { name: "x" })
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("delete", () => {
+    it("returns true when deleted", async () => {
+      const db = mockDb()
+      const service = new ChannelConfigService(db, MASTER_KEY)
+
+      const result = await service.delete("cccccccc-1111-2222-3333-444444444444")
+
+      expect(result).toBe(true)
+    })
+
+    it("returns false when not found", async () => {
+      const db = mockDb({ deleteCount: 0 })
+      const service = new ChannelConfigService(db, MASTER_KEY)
+
+      const result = await service.delete("nonexistent")
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe("encryption round-trip", () => {
+    it("encrypts on create and decrypts on listEnabled", async () => {
+      // Track what gets inserted
+      let capturedConfigEnc = ""
+      const baseRow = makeRow()
+
+      const db = {
+        insertInto: vi.fn().mockImplementation(() => ({
+          values: vi.fn().mockImplementation((vals: Record<string, unknown>) => {
+            capturedConfigEnc = vals.config_enc as string
+            return {
+              returning: vi.fn().mockReturnValue({
+                executeTakeFirstOrThrow: vi.fn().mockResolvedValue(baseRow),
+              }),
+            }
+          }),
+        })),
+        selectFrom: vi.fn().mockImplementation(() => {
+          // Return the row with the captured encrypted config
+          const row = { ...baseRow, config_enc: capturedConfigEnc }
+          return selectChain([row])
+        }),
+        updateTable: vi.fn(),
+        deleteFrom: vi.fn(),
+      } as unknown as Kysely<Database>
+
+      const service = new ChannelConfigService(db, MASTER_KEY)
+
+      // Create with plain config
+      await service.create("telegram", "Test", { botToken: "secret-token-123" }, null)
+
+      // The encrypted value should NOT contain the plaintext
+      expect(capturedConfigEnc).not.toContain("secret-token-123")
+      expect(capturedConfigEnc.split(".")).toHaveLength(3) // iv.authTag.ciphertext
+
+      // Read back via listEnabled
+      const enabled = await service.listEnabled()
+      expect(enabled).toHaveLength(1)
+      expect(enabled[0]!.config).toEqual({ botToken: "secret-token-123" })
+    })
+
+    it("different master keys cannot decrypt each other's data", async () => {
+      let capturedConfigEnc = ""
+      const baseRow = makeRow()
+
+      const db1 = {
+        insertInto: vi.fn().mockImplementation(() => ({
+          values: vi.fn().mockImplementation((vals: Record<string, unknown>) => {
+            capturedConfigEnc = vals.config_enc as string
+            return {
+              returning: vi.fn().mockReturnValue({
+                executeTakeFirstOrThrow: vi.fn().mockResolvedValue(baseRow),
+              }),
+            }
+          }),
+        })),
+        selectFrom: vi.fn(),
+        updateTable: vi.fn(),
+        deleteFrom: vi.fn(),
+      } as unknown as Kysely<Database>
+
+      const svc1 = new ChannelConfigService(db1, "key-alpha")
+      await svc1.create("telegram", "Test", { botToken: "secret" }, null)
+
+      // Try to decrypt with a different key
+      const row = { ...baseRow, config_enc: capturedConfigEnc }
+      const db2 = mockDb({ selectRows: [row] })
+      const svc2 = new ChannelConfigService(db2, "key-beta")
+
+      await expect(svc2.getByIdFull("test-id")).rejects.toThrow()
+    })
+  })
+})

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -18,6 +18,7 @@ import { AuthHandoffService } from "./browser/auth-handoff.js"
 import { ScreenshotModeService } from "./browser/screenshot-mode.js"
 import { TraceCaptureService } from "./browser/trace-capture.js"
 import { AgentChannelService } from "./channels/agent-channel-service.js"
+import { ChannelConfigService } from "./channels/channel-config-service.js"
 import type { Config } from "./config.js"
 import type { Database } from "./db/types.js"
 import { FeedbackService } from "./feedback/service.js"
@@ -40,6 +41,7 @@ import { agentUserRoutes } from "./routes/agent-user-routes.js"
 import { agentRoutes } from "./routes/agents.js"
 import { approvalRoutes } from "./routes/approval.js"
 import { authRoutes } from "./routes/auth.js"
+import { channelRoutes } from "./routes/channels.js"
 import { chatRoutes } from "./routes/chat.js"
 import { credentialRoutes } from "./routes/credentials.js"
 import { dashboardRoutes } from "./routes/dashboard.js"
@@ -235,6 +237,18 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
       sessionService,
     }),
   )
+
+  // Register channel configuration routes (if master key available for encryption)
+  if (config.auth?.credentialMasterKey) {
+    const channelConfigService = new ChannelConfigService(db, config.auth.credentialMasterKey)
+    await app.register(
+      channelRoutes({
+        service: channelConfigService,
+        authConfig,
+        sessionService,
+      }),
+    )
+  }
 
   // Register agent user grant, pairing code, and access request routes
   const pairingService = new PairingService(db)

--- a/packages/control-plane/src/channels/channel-config-service.ts
+++ b/packages/control-plane/src/channels/channel-config-service.ts
@@ -1,0 +1,208 @@
+/**
+ * Channel Config Service
+ *
+ * CRUD operations for channel adapter configurations (Telegram, Discord,
+ * WhatsApp).  Sensitive config fields (bot tokens, API keys) are encrypted
+ * at rest using AES-256-GCM via the credential-encryption module.
+ */
+
+import type { Kysely } from "kysely"
+
+import {
+  decrypt,
+  deriveMasterKey,
+  encrypt,
+  type EncryptedValue,
+} from "../auth/credential-encryption.js"
+import type { ChannelConfig, ChannelType, Database } from "../db/types.js"
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Plain (decrypted) channel configuration values. */
+export interface ChannelConfigPlain {
+  /** Telegram: botToken; Discord: token; etc. */
+  [key: string]: unknown
+}
+
+/** Shape returned to the API — secrets masked. */
+export interface ChannelConfigSummary {
+  id: string
+  type: ChannelType
+  name: string
+  enabled: boolean
+  created_by: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+/** Shape returned when the full config is needed (e.g., by adapters). */
+export interface ChannelConfigFull extends ChannelConfigSummary {
+  config: ChannelConfigPlain
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class ChannelConfigService {
+  private readonly masterKey: Buffer
+
+  constructor(
+    private readonly db: Kysely<Database>,
+    masterKeyPassphrase: string,
+  ) {
+    this.masterKey = deriveMasterKey(masterKeyPassphrase)
+  }
+
+  /** List all channel configs (secrets masked). */
+  async list(): Promise<ChannelConfigSummary[]> {
+    const rows = await this.db
+      .selectFrom("channel_config")
+      .select(["id", "type", "name", "enabled", "created_by", "created_at", "updated_at"])
+      .orderBy("created_at", "desc")
+      .execute()
+
+    return rows as ChannelConfigSummary[]
+  }
+
+  /** Get a single config by ID (secrets masked). */
+  async getById(id: string): Promise<ChannelConfigSummary | undefined> {
+    const row = await this.db
+      .selectFrom("channel_config")
+      .select(["id", "type", "name", "enabled", "created_by", "created_at", "updated_at"])
+      .where("id", "=", id)
+      .executeTakeFirst()
+
+    return row as ChannelConfigSummary | undefined
+  }
+
+  /** Get a single config by ID with decrypted config (for runtime use). */
+  async getByIdFull(id: string): Promise<ChannelConfigFull | undefined> {
+    const row = await this.db
+      .selectFrom("channel_config")
+      .selectAll()
+      .where("id", "=", id)
+      .executeTakeFirst()
+
+    if (!row) return undefined
+    return this.toFull(row)
+  }
+
+  /** List all enabled configs with decrypted config (for adapter startup). */
+  async listEnabled(): Promise<ChannelConfigFull[]> {
+    const rows = await this.db
+      .selectFrom("channel_config")
+      .selectAll()
+      .where("enabled", "=", true)
+      .orderBy("created_at", "asc")
+      .execute()
+
+    return rows.map((r) => this.toFull(r))
+  }
+
+  /** Create a new channel config. Returns the summary (secrets masked). */
+  async create(
+    type: ChannelType,
+    name: string,
+    config: ChannelConfigPlain,
+    createdBy: string | null,
+  ): Promise<ChannelConfigSummary> {
+    const configEnc = this.encryptConfig(config)
+
+    const row = await this.db
+      .insertInto("channel_config")
+      .values({
+        type,
+        name,
+        config_enc: configEnc,
+        created_by: createdBy,
+      })
+      .returning(["id", "type", "name", "enabled", "created_by", "created_at", "updated_at"])
+      .executeTakeFirstOrThrow()
+
+    return row as ChannelConfigSummary
+  }
+
+  /** Update a channel config. Returns the updated summary or undefined if not found. */
+  async update(
+    id: string,
+    updates: {
+      name?: string
+      config?: ChannelConfigPlain
+      enabled?: boolean
+    },
+  ): Promise<ChannelConfigSummary | undefined> {
+    const setClause: Record<string, unknown> = { updated_at: new Date() }
+    if (updates.name !== undefined) setClause.name = updates.name
+    if (updates.enabled !== undefined) setClause.enabled = updates.enabled
+    if (updates.config !== undefined) {
+      setClause.config_enc = this.encryptConfig(updates.config)
+    }
+
+    const row = await this.db
+      .updateTable("channel_config")
+      .set(setClause)
+      .where("id", "=", id)
+      .returning(["id", "type", "name", "enabled", "created_by", "created_at", "updated_at"])
+      .executeTakeFirst()
+
+    return row as ChannelConfigSummary | undefined
+  }
+
+  /** Delete a channel config. Returns true if deleted. */
+  async delete(id: string): Promise<boolean> {
+    const result = await this.db
+      .deleteFrom("channel_config")
+      .where("id", "=", id)
+      .executeTakeFirst()
+
+    return Number(result.numDeletedRows) > 0
+  }
+
+  // ---------------------------------------------------------------------------
+  // Encryption helpers
+  // ---------------------------------------------------------------------------
+
+  private encryptConfig(config: ChannelConfigPlain): string {
+    const json = JSON.stringify(config)
+    const encrypted = encrypt(json, this.masterKey)
+    return serializeEncrypted(encrypted)
+  }
+
+  private decryptConfig(stored: string): ChannelConfigPlain {
+    const payload = deserializeEncrypted(stored)
+    const json = decrypt(payload, this.masterKey)
+    return JSON.parse(json) as ChannelConfigPlain
+  }
+
+  private toFull(row: ChannelConfig): ChannelConfigFull {
+    return {
+      id: row.id,
+      type: row.type,
+      name: row.name,
+      enabled: row.enabled,
+      created_by: row.created_by,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+      config: this.decryptConfig(row.config_enc),
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Serialization helpers (same format as credential-encryption.ts)
+// ---------------------------------------------------------------------------
+
+function serializeEncrypted(value: EncryptedValue): string {
+  return `${value.iv}.${value.authTag}.${value.ciphertext}`
+}
+
+function deserializeEncrypted(stored: string): EncryptedValue {
+  const parts = stored.split(".")
+  if (parts.length !== 3) {
+    throw new Error("Invalid encrypted value format")
+  }
+  return { iv: parts[0]!, authTag: parts[1]!, ciphertext: parts[2]! }
+}

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -819,6 +819,26 @@ export type AgentEvent = Selectable<AgentEventTable>
 export type NewAgentEvent = Insertable<AgentEventTable>
 
 // ---------------------------------------------------------------------------
+// Table: channel_config
+// ---------------------------------------------------------------------------
+export type ChannelType = "telegram" | "discord" | "whatsapp"
+
+export interface ChannelConfigTable {
+  id: Generated<string>
+  type: ChannelType
+  name: string
+  config_enc: string
+  enabled: ColumnType<boolean, boolean | undefined, boolean>
+  created_by: string | null
+  created_at: ColumnType<Date, Date | undefined, never>
+  updated_at: ColumnType<Date, Date | undefined, Date>
+}
+
+export type ChannelConfig = Selectable<ChannelConfigTable>
+export type NewChannelConfig = Insertable<ChannelConfigTable>
+export type ChannelConfigUpdate = Updateable<ChannelConfigTable>
+
+// ---------------------------------------------------------------------------
 // Database interface — register all tables here.
 // ---------------------------------------------------------------------------
 export interface Database {
@@ -851,4 +871,5 @@ export interface Database {
   agent_user_grant: AgentUserGrantTable
   access_request: AccessRequestTable
   user_usage_ledger: UserUsageLedgerTable
+  channel_config: ChannelConfigTable
 }

--- a/packages/control-plane/src/routes/channels.ts
+++ b/packages/control-plane/src/routes/channels.ts
@@ -1,0 +1,193 @@
+/**
+ * Channel Configuration Routes
+ *
+ * GET    /channels          — List configured channels (summaries, no secrets)
+ * POST   /channels          — Add a new channel configuration
+ * GET    /channels/:id      — Get a single channel config
+ * PUT    /channels/:id      — Update a channel config
+ * DELETE /channels/:id      — Remove a channel config
+ */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
+
+import type { SessionService } from "../auth/session-service.js"
+import type { ChannelConfigService } from "../channels/channel-config-service.js"
+import type { ChannelType } from "../db/types.js"
+import {
+  type AuthMiddlewareOptions,
+  createRequireAuth,
+  createRequireRole,
+  type PreHandler,
+} from "../middleware/auth.js"
+import type { AuthConfig } from "../middleware/types.js"
+
+// ---------------------------------------------------------------------------
+// Route types
+// ---------------------------------------------------------------------------
+
+interface ChannelIdParams {
+  id: string
+}
+
+interface CreateChannelBody {
+  type: string
+  name: string
+  config: Record<string, unknown>
+}
+
+interface UpdateChannelBody {
+  name?: string
+  config?: Record<string, unknown>
+  enabled?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+const VALID_CHANNEL_TYPES = new Set<string>(["telegram", "discord", "whatsapp"])
+
+export interface ChannelRouteDeps {
+  service: ChannelConfigService
+  authConfig: AuthConfig
+  sessionService?: SessionService
+}
+
+export function channelRoutes(deps: ChannelRouteDeps) {
+  const { service, authConfig, sessionService } = deps
+
+  const authOpts: AuthMiddlewareOptions = { config: authConfig, sessionService }
+  const requireAuth: PreHandler = createRequireAuth(authOpts)
+  const requireOperator: PreHandler = createRequireRole("operator")
+
+  return function register(app: FastifyInstance): void {
+    // -----------------------------------------------------------------
+    // GET /channels — List all channel configs (masked)
+    // -----------------------------------------------------------------
+    app.get(
+      "/channels",
+      { preHandler: [requireAuth, requireOperator] },
+      async (_request: FastifyRequest, reply: FastifyReply) => {
+        const channels = await service.list()
+        return reply.status(200).send({ channels })
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // POST /channels — Create a new channel config
+    // -----------------------------------------------------------------
+    app.post<{ Body: CreateChannelBody }>(
+      "/channels",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          body: {
+            type: "object",
+            properties: {
+              type: { type: "string", minLength: 1 },
+              name: { type: "string", minLength: 1 },
+              config: { type: "object" },
+            },
+            required: ["type", "name", "config"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Body: CreateChannelBody }>, reply: FastifyReply) => {
+        const { type, name, config } = request.body
+
+        if (!VALID_CHANNEL_TYPES.has(type)) {
+          return reply.status(400).send({
+            error: "bad_request",
+            message: `Invalid channel type '${type}'. Must be one of: ${[...VALID_CHANNEL_TYPES].join(", ")}`,
+          })
+        }
+
+        const channel = await service.create(type as ChannelType, name, config, null)
+        return reply.status(201).send({ channel })
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // GET /channels/:id — Get a single channel config
+    // -----------------------------------------------------------------
+    app.get<{ Params: ChannelIdParams }>(
+      "/channels/:id",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: { id: { type: "string" } },
+            required: ["id"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: ChannelIdParams }>, reply: FastifyReply) => {
+        const channel = await service.getById(request.params.id)
+        if (!channel) {
+          return reply.status(404).send({ error: "not_found", message: "Channel config not found" })
+        }
+        return reply.status(200).send({ channel })
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // PUT /channels/:id — Update a channel config
+    // -----------------------------------------------------------------
+    app.put<{ Params: ChannelIdParams; Body: UpdateChannelBody }>(
+      "/channels/:id",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: { id: { type: "string" } },
+            required: ["id"],
+          },
+          body: {
+            type: "object",
+            properties: {
+              name: { type: "string", minLength: 1 },
+              config: { type: "object" },
+              enabled: { type: "boolean" },
+            },
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{ Params: ChannelIdParams; Body: UpdateChannelBody }>,
+        reply: FastifyReply,
+      ) => {
+        const channel = await service.update(request.params.id, request.body)
+        if (!channel) {
+          return reply.status(404).send({ error: "not_found", message: "Channel config not found" })
+        }
+        return reply.status(200).send({ channel })
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // DELETE /channels/:id — Remove a channel config
+    // -----------------------------------------------------------------
+    app.delete<{ Params: ChannelIdParams }>(
+      "/channels/:id",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: { id: { type: "string" } },
+            required: ["id"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: ChannelIdParams }>, reply: FastifyReply) => {
+        const deleted = await service.delete(request.params.id)
+        if (!deleted) {
+          return reply.status(404).send({ error: "not_found", message: "Channel config not found" })
+        }
+        return reply.status(200).send({ status: "deleted" })
+      },
+    )
+  }
+}

--- a/packages/dashboard/src/app/agents/[agentId]/page.tsx
+++ b/packages/dashboard/src/app/agents/[agentId]/page.tsx
@@ -5,6 +5,7 @@ import { use, useCallback, useMemo, useState } from "react"
 import { AgentConsole } from "@/components/agents/agent-console"
 import { AgentHeader } from "@/components/agents/agent-header"
 import { AgentJobsTab } from "@/components/agents/agent-jobs-tab"
+import { ChannelBindingTab } from "@/components/agents/channel-binding-tab"
 import { ChatPanel } from "@/components/agents/chat-panel"
 import { CredentialBindingPanel } from "@/components/agents/credential-binding"
 import { type LifecycleStep, LifecycleTimeline } from "@/components/agents/lifecycle-timeline"
@@ -32,6 +33,7 @@ const MOBILE_TABS = [
   "Chat",
   "Details",
   "Jobs",
+  "Channels",
   "Credentials",
   "Browser",
   "Memory",
@@ -341,6 +343,11 @@ export default function AgentDetailPage({ params }: Props): React.JSX.Element {
           </div>
         )}
         {mobileTab === "Jobs" && <AgentJobsTab agentId={agentId} />}
+        {mobileTab === "Channels" && (
+          <div className="flex flex-col gap-4">
+            <ChannelBindingTab agentId={agentId} />
+          </div>
+        )}
         {mobileTab === "Credentials" && (
           <div className="flex flex-col gap-4">
             <CredentialBindingPanel agentId={agentId} />

--- a/packages/dashboard/src/app/settings/page.tsx
+++ b/packages/dashboard/src/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation"
 import { Suspense, useCallback, useEffect, useState } from "react"
 
 import { useAuth } from "@/components/auth-provider"
+import { ChannelConfigSection } from "@/components/settings/channel-config-section"
 import { useOAuthPopup } from "@/hooks/use-oauth-popup"
 import {
   type Credential,
@@ -300,6 +301,9 @@ function SettingsInner() {
           )}
         </div>
       </section>
+
+      {/* Channels */}
+      <ChannelConfigSection />
 
       {/* OAuth popup / code-paste fallback dialog */}
       {popupProvider && popup.status !== "idle" && popup.status !== "success" && (

--- a/packages/dashboard/src/components/agents/channel-binding-tab.tsx
+++ b/packages/dashboard/src/components/agents/channel-binding-tab.tsx
@@ -1,0 +1,203 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import {
+  type AgentChannelBinding,
+  bindAgentChannel,
+  listAgentChannels,
+  unbindAgentChannel,
+} from "@/lib/api-client"
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface ChannelBindingTabProps {
+  agentId: string
+}
+
+const CHANNEL_TYPES = ["telegram", "discord", "whatsapp"] as const
+
+export function ChannelBindingTab({ agentId }: ChannelBindingTabProps) {
+  const [bindings, setBindings] = useState<AgentChannelBinding[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showAdd, setShowAdd] = useState(false)
+  const [formType, setFormType] = useState("telegram")
+  const [formChatId, setFormChatId] = useState("")
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchBindings = useCallback(async () => {
+    try {
+      const res = await listAgentChannels(agentId)
+      setBindings(res.bindings ?? [])
+    } catch {
+      // silent
+    } finally {
+      setLoading(false)
+    }
+  }, [agentId])
+
+  useEffect(() => {
+    void fetchBindings()
+  }, [fetchBindings])
+
+  const handleBind = useCallback(async () => {
+    if (!formChatId.trim()) return
+    setSaving(true)
+    setError(null)
+    try {
+      await bindAgentChannel(agentId, formType, formChatId.trim())
+      setShowAdd(false)
+      setFormChatId("")
+      void fetchBindings()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to bind channel")
+    } finally {
+      setSaving(false)
+    }
+  }, [agentId, formType, formChatId, fetchBindings])
+
+  const handleUnbind = useCallback(
+    async (bindingId: string) => {
+      try {
+        await unbindAgentChannel(agentId, bindingId)
+        void fetchBindings()
+      } catch {
+        // silent
+      }
+    },
+    [agentId, fetchBindings],
+  )
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-8">
+        <div className="size-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-text-main">Channel Bindings</h3>
+          <p className="text-xs text-text-muted">
+            Bind this agent to chat channels so it receives messages.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowAdd(true)}
+          className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-content hover:bg-primary/90 transition-colors"
+        >
+          Bind Channel
+        </button>
+      </div>
+
+      {/* Existing bindings */}
+      <div className="space-y-2">
+        {bindings.map((b) => (
+          <div
+            key={b.id}
+            className="flex items-center justify-between rounded-lg border border-surface-border p-3"
+          >
+            <div className="flex items-center gap-2">
+              <span className="inline-block rounded-full bg-secondary px-2 py-0.5 text-[10px] font-bold uppercase text-text-muted">
+                {b.channel_type}
+              </span>
+              <span className="font-mono text-sm text-text-main">{b.chat_id}</span>
+              {b.is_default && (
+                <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-bold uppercase text-primary">
+                  Default
+                </span>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => void handleUnbind(b.id)}
+              className="rounded-lg px-3 py-1 text-xs font-medium text-danger hover:bg-danger/10 transition-colors"
+            >
+              Unbind
+            </button>
+          </div>
+        ))}
+
+        {bindings.length === 0 && (
+          <p className="py-4 text-center text-sm text-text-muted">
+            No channels bound. Bind a channel to start receiving messages.
+          </p>
+        )}
+      </div>
+
+      {/* Add binding modal */}
+      {showAdd && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+          <div className="mx-4 w-full max-w-sm rounded-xl border border-surface-border bg-surface-light p-6 shadow-xl">
+            <h3 className="text-lg font-semibold text-text-main">Bind Channel</h3>
+
+            {error && (
+              <div className="mt-3 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
+                {error}
+              </div>
+            )}
+
+            <div className="mt-4 space-y-3">
+              <div>
+                <label className="mb-1 block text-xs font-medium text-text-muted">
+                  Channel Type
+                </label>
+                <select
+                  value={formType}
+                  onChange={(e) => setFormType(e.target.value)}
+                  className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                >
+                  {CHANNEL_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {t.charAt(0).toUpperCase() + t.slice(1)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-medium text-text-muted">Chat ID</label>
+                <input
+                  type="text"
+                  value={formChatId}
+                  onChange={(e) => setFormChatId(e.target.value)}
+                  className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main placeholder:text-text-muted/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  placeholder="e.g., 123456789"
+                  autoFocus
+                />
+              </div>
+            </div>
+
+            <div className="mt-6 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowAdd(false)
+                  setFormChatId("")
+                  setError(null)
+                }}
+                className="rounded-lg px-4 py-2 text-sm text-text-muted hover:bg-secondary transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleBind()}
+                disabled={saving || !formChatId.trim()}
+                className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-content hover:bg-primary/90 disabled:opacity-50 transition-colors"
+              >
+                {saving ? "Binding..." : "Bind"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/settings/channel-config-section.tsx
+++ b/packages/dashboard/src/components/settings/channel-config-section.tsx
@@ -1,0 +1,305 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import {
+  type ChannelConfigSummary,
+  createChannelConfig,
+  deleteChannelConfig,
+  listChannelConfigs,
+  updateChannelConfig,
+} from "@/lib/api-client"
+
+// ---------------------------------------------------------------------------
+// Channel type metadata
+// ---------------------------------------------------------------------------
+
+const CHANNEL_TYPES = [
+  { id: "telegram", label: "Telegram", fields: ["botToken"] },
+  { id: "discord", label: "Discord", fields: ["token", "guildIds"] },
+  { id: "whatsapp", label: "WhatsApp", fields: ["apiKey", "phoneNumberId"] },
+] as const
+
+type ChannelTypeId = (typeof CHANNEL_TYPES)[number]["id"]
+
+// ---------------------------------------------------------------------------
+// Form state
+// ---------------------------------------------------------------------------
+
+interface AddChannelForm {
+  type: ChannelTypeId
+  name: string
+  config: Record<string, string>
+}
+
+const EMPTY_FORM: AddChannelForm = { type: "telegram", name: "", config: {} }
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ChannelConfigSection() {
+  const [channels, setChannels] = useState<ChannelConfigSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showAdd, setShowAdd] = useState(false)
+  const [form, setForm] = useState<AddChannelForm>(EMPTY_FORM)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchChannels = useCallback(async () => {
+    try {
+      const res = await listChannelConfigs()
+      setChannels(res.channels ?? [])
+    } catch {
+      // API may not be available if CREDENTIAL_MASTER_KEY is not set
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchChannels()
+  }, [fetchChannels])
+
+  const handleCreate = useCallback(async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      await createChannelConfig({
+        type: form.type,
+        name: form.name,
+        config: form.config,
+      })
+      setShowAdd(false)
+      setForm(EMPTY_FORM)
+      void fetchChannels()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create channel")
+    } finally {
+      setSaving(false)
+    }
+  }, [form, fetchChannels])
+
+  const handleToggle = useCallback(
+    async (ch: ChannelConfigSummary) => {
+      try {
+        await updateChannelConfig(ch.id, { enabled: !ch.enabled })
+        void fetchChannels()
+      } catch {
+        // silent
+      }
+    },
+    [fetchChannels],
+  )
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      try {
+        await deleteChannelConfig(id)
+        void fetchChannels()
+      } catch {
+        // silent
+      }
+    },
+    [fetchChannels],
+  )
+
+  const selectedType = CHANNEL_TYPES.find((t) => t.id === form.type)!
+
+  if (loading) {
+    return (
+      <section className="rounded-xl border border-surface-border bg-surface-light p-6">
+        <h2 className="text-lg font-semibold text-text-main">Channels</h2>
+        <div className="mt-4 flex justify-center py-4">
+          <div className="size-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section className="rounded-xl border border-surface-border bg-surface-light p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-text-main">Channels</h2>
+          <p className="mt-1 text-sm text-text-muted">
+            Configure chat channel adapters. Bot tokens are encrypted at rest.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowAdd(true)}
+          className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-content hover:bg-primary/90 transition-colors"
+        >
+          Add Channel
+        </button>
+      </div>
+
+      {/* Channel list */}
+      <div className="mt-4 space-y-3">
+        {channels.map((ch) => (
+          <div
+            key={ch.id}
+            className="flex items-center justify-between rounded-lg border border-surface-border p-4"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold text-text-main">{ch.name}</span>
+                <span className="inline-block rounded-full bg-secondary px-2 py-0.5 text-[10px] font-bold uppercase text-text-muted">
+                  {ch.type}
+                </span>
+                <span
+                  className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-bold uppercase ${ch.enabled ? "bg-success/10 text-success" : "bg-secondary text-text-muted"}`}
+                >
+                  {ch.enabled ? "Enabled" : "Disabled"}
+                </span>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void handleToggle(ch)}
+                className="rounded-lg px-3 py-1.5 text-xs font-medium text-text-muted hover:bg-secondary transition-colors"
+              >
+                {ch.enabled ? "Disable" : "Enable"}
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleDelete(ch.id)}
+                className="rounded-lg px-3 py-1.5 text-xs font-medium text-danger hover:bg-danger/10 transition-colors"
+              >
+                Remove
+              </button>
+            </div>
+          </div>
+        ))}
+
+        {channels.length === 0 && (
+          <p className="py-4 text-center text-sm text-text-muted">
+            No channels configured. Add a Telegram, Discord, or WhatsApp channel to get started.
+          </p>
+        )}
+      </div>
+
+      {/* Add channel modal */}
+      {showAdd && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+          <div className="mx-4 w-full max-w-md rounded-xl border border-surface-border bg-surface-light p-6 shadow-xl">
+            <h3 className="text-lg font-semibold text-text-main">Add Channel</h3>
+
+            {error && (
+              <div className="mt-3 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
+                {error}
+              </div>
+            )}
+
+            <div className="mt-4 space-y-3">
+              {/* Channel type */}
+              <div>
+                <label className="mb-1 block text-xs font-medium text-text-muted">
+                  Channel Type
+                </label>
+                <select
+                  value={form.type}
+                  onChange={(e) =>
+                    setForm({ ...form, type: e.target.value as ChannelTypeId, config: {} })
+                  }
+                  className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                >
+                  {CHANNEL_TYPES.map((t) => (
+                    <option key={t.id} value={t.id}>
+                      {t.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Name */}
+              <div>
+                <label className="mb-1 block text-xs font-medium text-text-muted">Name</label>
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main placeholder:text-text-muted/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  placeholder="e.g., Production Telegram Bot"
+                />
+              </div>
+
+              {/* Dynamic config fields based on type */}
+              {selectedType.fields.map((field) => (
+                <div key={field}>
+                  <label className="mb-1 block text-xs font-medium text-text-muted">
+                    {formatFieldLabel(field)}
+                  </label>
+                  <input
+                    type={isSecretField(field) ? "password" : "text"}
+                    value={form.config[field] ?? ""}
+                    onChange={(e) =>
+                      setForm({ ...form, config: { ...form.config, [field]: e.target.value } })
+                    }
+                    className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main placeholder:text-text-muted/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    placeholder={getFieldPlaceholder(field)}
+                  />
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-6 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowAdd(false)
+                  setForm(EMPTY_FORM)
+                  setError(null)
+                }}
+                className="rounded-lg px-4 py-2 text-sm text-text-muted hover:bg-secondary transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleCreate()}
+                disabled={saving || !form.name.trim()}
+                className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-content hover:bg-primary/90 disabled:opacity-50 transition-colors"
+              >
+                {saving ? "Saving..." : "Add Channel"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatFieldLabel(field: string): string {
+  const labels: Record<string, string> = {
+    botToken: "Bot Token",
+    token: "Bot Token",
+    guildIds: "Guild IDs (comma-separated)",
+    apiKey: "API Key",
+    phoneNumberId: "Phone Number ID",
+  }
+  return labels[field] ?? field
+}
+
+function getFieldPlaceholder(field: string): string {
+  const placeholders: Record<string, string> = {
+    botToken: "123456:ABC-DEF...",
+    token: "MTA2...",
+    guildIds: "123456789012345678",
+    apiKey: "your-api-key",
+    phoneNumberId: "1234567890",
+  }
+  return placeholders[field] ?? ""
+}
+
+function isSecretField(field: string): boolean {
+  return ["botToken", "token", "apiKey"].includes(field)
+}

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -35,6 +35,10 @@ import {
   TraceStateSchema,
   TraceStopResponseSchema,
 } from "./schemas/browser"
+import {
+  ChannelConfigListResponseSchema,
+  ChannelConfigResponseSchema,
+} from "./schemas/channel-config"
 import { AgentChannelBindingListResponseSchema } from "./schemas/channels"
 import { ContentListResponseSchema } from "./schemas/content"
 import {
@@ -1193,4 +1197,53 @@ export async function releaseAgent(
     body: { ...(resetCircuitBreaker != null ? { resetCircuitBreaker } : {}) },
     schema: ReleaseResponseSchema,
   })
+}
+
+// ---------------------------------------------------------------------------
+// Channel configuration endpoint functions
+// ---------------------------------------------------------------------------
+
+export type { ChannelConfigSummary } from "./schemas/channel-config"
+
+export async function listChannelConfigs(): Promise<{
+  channels: import("./schemas/channel-config").ChannelConfigSummary[]
+}> {
+  return apiFetch("/channels", { schema: ChannelConfigListResponseSchema })
+}
+
+export async function getChannelConfig(
+  id: string,
+): Promise<{ channel: import("./schemas/channel-config").ChannelConfigSummary }> {
+  return apiFetch(`/channels/${id}`, { schema: ChannelConfigResponseSchema })
+}
+
+export async function createChannelConfig(body: {
+  type: string
+  name: string
+  config: Record<string, unknown>
+}): Promise<{ channel: import("./schemas/channel-config").ChannelConfigSummary }> {
+  return apiFetch("/channels", {
+    method: "POST",
+    body,
+    schema: ChannelConfigResponseSchema,
+  })
+}
+
+export async function updateChannelConfig(
+  id: string,
+  body: {
+    name?: string
+    config?: Record<string, unknown>
+    enabled?: boolean
+  },
+): Promise<{ channel: import("./schemas/channel-config").ChannelConfigSummary }> {
+  return apiFetch(`/channels/${id}`, {
+    method: "PUT",
+    body,
+    schema: ChannelConfigResponseSchema,
+  })
+}
+
+export async function deleteChannelConfig(id: string): Promise<unknown> {
+  return apiFetch(`/channels/${id}`, { method: "DELETE", schema: z.unknown() })
 }

--- a/packages/dashboard/src/lib/schemas/channel-config.ts
+++ b/packages/dashboard/src/lib/schemas/channel-config.ts
@@ -1,0 +1,21 @@
+import { z } from "zod"
+
+export const ChannelConfigSchema = z.object({
+  id: z.string(),
+  type: z.enum(["telegram", "discord", "whatsapp"]),
+  name: z.string(),
+  enabled: z.boolean(),
+  created_by: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export const ChannelConfigListResponseSchema = z.object({
+  channels: z.array(ChannelConfigSchema),
+})
+
+export const ChannelConfigResponseSchema = z.object({
+  channel: ChannelConfigSchema,
+})
+
+export type ChannelConfigSummary = z.infer<typeof ChannelConfigSchema>


### PR DESCRIPTION
## Summary
- Adds a `channel_config` table (migration 027) for DB-backed channel adapter configuration (Telegram, Discord, WhatsApp)
- Bot tokens and sensitive config fields are encrypted at rest using AES-256-GCM via `CREDENTIAL_MASTER_KEY`
- Full CRUD API at `/channels` with operator-level auth
- Dashboard Settings page gets a "Channels" section for adding/enabling/disabling/removing channel configs
- Agent detail page gets a "Channels" tab for managing agent-to-channel bindings

## Test plan
- [x] 11 new unit tests: CRUD operations, encryption round-trip, key isolation
- [x] Full test suite passes (1560 tests, 0 failures)
- [x] TypeScript typecheck clean
- [x] ESLint clean (no new warnings/errors)
- [x] Build succeeds

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added channel configuration management in Settings, allowing users to configure and manage chat channels (Telegram, Discord, WhatsApp).
  * Added channel binding interface on agent detail pages, enabling users to bind agents to specific channels.
  * Channel configurations support enable/disable toggling and removal.

* **Tests**
  * Added comprehensive test suite for channel configuration service with encryption and CRUD operation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->