### PR TITLE
fix(dashboard): preserve oauth redirects in API proxy

### DIFF
--- a/packages/dashboard/src/app/api/[...path]/route.ts
+++ b/packages/dashboard/src/app/api/[...path]/route.ts
@@ -24,6 +24,7 @@ async function proxyRequest(
   const init: RequestInit = {
     method: request.method,
     headers,
+    redirect: "manual",
   }
 
   // Forward body for non-GET/HEAD requests


### PR DESCRIPTION
## Summary\n- preserve upstream redirect responses in dashboard API proxy by setting fetch redirect mode to manual\n- fixes OAuth login flow rendering provider HTML at /api/auth/login/:provider\n\n## Why\nDashboard proxy was returning 200 provider HTML instead of relaying 302 + Location back to browser, causing blank screen on login endpoint.\n\n## Validation\n- curl /api/auth/login/github should return 302 with Location header (not 200 HTML body) after deploy\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTTP redirects in API requests to ensure explicit redirect management instead of automatic following.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->