### PR TITLE
fix: revert dev principal userId, keep chat FK safety via ensureUserAccount

### DIFF
--- a/packages/control-plane/src/middleware/auth.ts
+++ b/packages/control-plane/src/middleware/auth.ts
@@ -28,8 +28,7 @@ const ROLE_MAP: Record<string, string[]> = {
 }
 
 const DEV_PRINCIPAL: Principal = {
-  // Must be UUID-like because DB/session paths expect user_account_id UUIDs.
-  userId: "00000000-0000-4000-8000-000000000001",
+  userId: "dev-user",
   roles: ["operator", "approver", "admin"],
   displayName: "Dev User (no auth configured)",
   authMethod: "api_key",


### PR DESCRIPTION
Reverts dev-user UUID change that broke 3 test suites. Chat FK integrity preserved via ensureUserAccount in chat route.