### PR TITLE
fix(channels): prevent duplicate channel creation with same type+name (#424)

### DIFF
--- a/packages/control-plane/migrations/028_channel_config_unique_type_name.down.sql
+++ b/packages/control-plane/migrations/028_channel_config_unique_type_name.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS uq_channel_config_type_name;

--- a/packages/control-plane/migrations/028_channel_config_unique_type_name.up.sql
+++ b/packages/control-plane/migrations/028_channel_config_unique_type_name.up.sql
@@ -1,0 +1,3 @@
+-- Prevent duplicate channel configs with the same type + name.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_channel_config_type_name
+  ON channel_config (type, name);

--- a/packages/control-plane/src/__tests__/channel-config-routes.test.ts
+++ b/packages/control-plane/src/__tests__/channel-config-routes.test.ts
@@ -1,0 +1,108 @@
+import Fastify from "fastify"
+import { describe, expect, it, vi } from "vitest"
+
+import type { ChannelConfigService } from "../channels/channel-config-service.js"
+import type { AuthConfig } from "../middleware/types.js"
+import { channelRoutes } from "../routes/channels.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEV_AUTH_CONFIG: AuthConfig = {
+  requireAuth: false,
+  apiKeys: [],
+}
+
+function makeSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "cccccccc-1111-2222-3333-444444444444",
+    type: "telegram",
+    name: "My Telegram Bot",
+    enabled: true,
+    created_by: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  }
+}
+
+function mockService(overrides: Partial<ChannelConfigService> = {}): ChannelConfigService {
+  return {
+    list: vi.fn().mockResolvedValue([makeSummary()]),
+    getById: vi.fn().mockResolvedValue(makeSummary()),
+    getByIdFull: vi.fn().mockResolvedValue(undefined),
+    listEnabled: vi.fn().mockResolvedValue([]),
+    findByTypeName: vi.fn().mockResolvedValue(undefined),
+    create: vi.fn().mockResolvedValue(makeSummary()),
+    update: vi.fn().mockResolvedValue(makeSummary()),
+    delete: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  } as unknown as ChannelConfigService
+}
+
+async function buildTestApp(serviceOverrides: Partial<ChannelConfigService> = {}) {
+  const app = Fastify({ logger: false })
+  const service = mockService(serviceOverrides)
+
+  await app.register(channelRoutes({ service, authConfig: DEV_AUTH_CONFIG }))
+
+  return { app, service }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /channels — duplicate detection
+// ---------------------------------------------------------------------------
+
+describe("POST /channels — duplicate detection", () => {
+  it("returns 409 when a channel with the same type+name exists", async () => {
+    const { app } = await buildTestApp({
+      findByTypeName: vi.fn().mockResolvedValue(makeSummary()),
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/channels",
+      payload: { type: "telegram", name: "My Telegram Bot", config: { botToken: "tok" } },
+    })
+
+    expect(res.statusCode).toBe(409)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.error).toBe("conflict")
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.message).toContain("already exists")
+  })
+
+  it("creates channel when no duplicate exists", async () => {
+    const { app, service } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/channels",
+      payload: { type: "telegram", name: "New Bot", config: { botToken: "tok" } },
+    })
+
+    expect(res.statusCode).toBe(201)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(service.create).toHaveBeenCalled()
+  })
+
+  it("allows same name for different channel types", async () => {
+    const { app, service } = await buildTestApp({
+      // findByTypeName returns undefined = no match for the queried type+name
+      findByTypeName: vi.fn().mockResolvedValue(undefined),
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/channels",
+      payload: { type: "discord", name: "My Telegram Bot", config: { token: "tok" } },
+    })
+
+    expect(res.statusCode).toBe(201)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(service.create).toHaveBeenCalled()
+  })
+})

--- a/packages/control-plane/src/__tests__/channel-config-service.test.ts
+++ b/packages/control-plane/src/__tests__/channel-config-service.test.ts
@@ -107,6 +107,27 @@ describe("ChannelConfigService", () => {
     })
   })
 
+  describe("findByTypeName", () => {
+    it("returns a summary when a match exists", async () => {
+      const db = mockDb()
+      const service = new ChannelConfigService(db, MASTER_KEY)
+
+      const result = await service.findByTypeName("telegram", "My Telegram Bot")
+
+      expect(result).toBeDefined()
+      expect(result!.type).toBe("telegram")
+    })
+
+    it("returns undefined when no match", async () => {
+      const db = mockDb({ selectRows: [] })
+      const service = new ChannelConfigService(db, MASTER_KEY)
+
+      const result = await service.findByTypeName("telegram", "Nonexistent")
+
+      expect(result).toBeUndefined()
+    })
+  })
+
   describe("getById", () => {
     it("returns a summary when found", async () => {
       const db = mockDb()

--- a/packages/control-plane/src/channels/channel-config-service.ts
+++ b/packages/control-plane/src/channels/channel-config-service.ts
@@ -102,6 +102,18 @@ export class ChannelConfigService {
     return rows.map((r) => this.toFull(r))
   }
 
+  /** Check whether a channel config with the given type + name already exists. */
+  async findByTypeName(type: ChannelType, name: string): Promise<ChannelConfigSummary | undefined> {
+    const row = await this.db
+      .selectFrom("channel_config")
+      .select(["id", "type", "name", "enabled", "created_by", "created_at", "updated_at"])
+      .where("type", "=", type)
+      .where("name", "=", name)
+      .executeTakeFirst()
+
+    return row as ChannelConfigSummary | undefined
+  }
+
   /** Create a new channel config. Returns the summary (secrets masked). */
   async create(
     type: ChannelType,

--- a/packages/control-plane/src/routes/channels.ts
+++ b/packages/control-plane/src/routes/channels.ts
@@ -102,6 +102,14 @@ export function channelRoutes(deps: ChannelRouteDeps) {
           })
         }
 
+        const existing = await service.findByTypeName(type as ChannelType, name)
+        if (existing) {
+          return reply.status(409).send({
+            error: "conflict",
+            message: `A ${type} channel named '${name}' already exists`,
+          })
+        }
+
         const channel = await service.create(type as ChannelType, name, config, null)
         return reply.status(201).send({ channel })
       },

--- a/packages/dashboard/src/components/settings/channel-config-section.tsx
+++ b/packages/dashboard/src/components/settings/channel-config-section.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import {
   type ChannelConfigSummary,
@@ -102,6 +102,13 @@ export function ChannelConfigSection() {
       }
     },
     [fetchChannels],
+  )
+
+  const isDuplicate = useMemo(
+    () =>
+      form.name.trim() !== "" &&
+      channels.some((ch) => ch.type === form.type && ch.name === form.name.trim()),
+    [channels, form.type, form.name],
   )
 
   const selectedType = CHANNEL_TYPES.find((t) => t.id === form.type)!
@@ -222,9 +229,14 @@ export function ChannelConfigSection() {
                   type="text"
                   value={form.name}
                   onChange={(e) => setForm({ ...form, name: e.target.value })}
-                  className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main placeholder:text-text-muted/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  className={`w-full rounded-lg border bg-surface-dark px-3 py-2 text-sm text-text-main placeholder:text-text-muted/50 focus:outline-none focus:ring-1 ${isDuplicate ? "border-danger focus:border-danger focus:ring-danger" : "border-surface-border focus:border-primary focus:ring-primary"}`}
                   placeholder="e.g., Production Telegram Bot"
                 />
+                {isDuplicate && (
+                  <p className="mt-1 text-xs text-danger">
+                    A {form.type} channel with this name already exists.
+                  </p>
+                )}
               </div>
 
               {/* Dynamic config fields based on type */}
@@ -261,7 +273,7 @@ export function ChannelConfigSection() {
               <button
                 type="button"
                 onClick={() => void handleCreate()}
-                disabled={saving || !form.name.trim()}
+                disabled={saving || !form.name.trim() || isDuplicate}
                 className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-content hover:bg-primary/90 disabled:opacity-50 transition-colors"
               >
                 {saving ? "Saving..." : "Add Channel"}


### PR DESCRIPTION
Closes #424

**Changes:**
- Migration 028: unique index on (type, name)
- Service: findByTypeName() lookup
- Route: 409 Conflict on duplicate
- Dashboard: client-side duplicate detection with inline error
- Tests: 5 new (route + service)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added duplicate channel detection that prevents creation of channels with identical type and name combinations, providing validation feedback in the dashboard

* **Tests**
  * Added comprehensive test coverage for duplicate detection across API and service layers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->