### PR TITLE
fix(channels): block deletion of in-use channels, support ?force=true (#425)

### DIFF
--- a/packages/control-plane/src/__tests__/channel-config-routes.test.ts
+++ b/packages/control-plane/src/__tests__/channel-config-routes.test.ts
@@ -37,6 +37,8 @@ function mockService(overrides: Partial<ChannelConfigService> = {}): ChannelConf
     create: vi.fn().mockResolvedValue(makeSummary()),
     update: vi.fn().mockResolvedValue(makeSummary()),
     delete: vi.fn().mockResolvedValue(true),
+    getBindingsByChannelType: vi.fn().mockResolvedValue([]),
+    removeBindingsByChannelType: vi.fn().mockResolvedValue(0),
     ...overrides,
   } as unknown as ChannelConfigService
 }
@@ -104,5 +106,96 @@ describe("POST /channels — duplicate detection", () => {
     expect(res.statusCode).toBe(201)
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(service.create).toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: DELETE /channels/:id — binding safety check
+// ---------------------------------------------------------------------------
+
+describe("DELETE /channels/:id — binding safety check", () => {
+  it("returns 409 when channel has active agent bindings", async () => {
+    const bindings = [
+      { agent_id: "aaaa-1111", chat_id: "chat-1" },
+      { agent_id: "aaaa-2222", chat_id: "chat-2" },
+    ]
+    const { app } = await buildTestApp({
+      getById: vi.fn().mockResolvedValue(makeSummary()),
+      getBindingsByChannelType: vi.fn().mockResolvedValue(bindings),
+    })
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/channels/cccccccc-1111-2222-3333-444444444444",
+    })
+
+    expect(res.statusCode).toBe(409)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.error).toBe("conflict")
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.message).toContain("agent(s) bound")
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.bound_agents).toEqual(["aaaa-1111", "aaaa-2222"])
+  })
+
+  it("returns 200 when channel has no bindings", async () => {
+    const { app, service } = await buildTestApp({
+      getById: vi.fn().mockResolvedValue(makeSummary()),
+      getBindingsByChannelType: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(true),
+    })
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/channels/cccccccc-1111-2222-3333-444444444444",
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.status).toBe("deleted")
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(service.delete).toHaveBeenCalledWith("cccccccc-1111-2222-3333-444444444444")
+  })
+
+  it("returns 404 when channel does not exist", async () => {
+    const { app } = await buildTestApp({
+      getById: vi.fn().mockResolvedValue(undefined),
+    })
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/channels/nonexistent-id",
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+
+  it("force=true cascades delete of bindings then channel", async () => {
+    const bindings = [{ agent_id: "aaaa-1111", chat_id: "chat-1" }]
+    const { app, service } = await buildTestApp({
+      getById: vi.fn().mockResolvedValue(makeSummary()),
+      getBindingsByChannelType: vi.fn().mockResolvedValue(bindings),
+      removeBindingsByChannelType: vi.fn().mockResolvedValue(1),
+      delete: vi.fn().mockResolvedValue(true),
+    })
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/channels/cccccccc-1111-2222-3333-444444444444?force=true",
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.status).toBe("deleted")
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(service.removeBindingsByChannelType).toHaveBeenCalledWith("telegram")
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(service.delete).toHaveBeenCalledWith("cccccccc-1111-2222-3333-444444444444")
   })
 })

--- a/packages/control-plane/src/channels/channel-config-service.ts
+++ b/packages/control-plane/src/channels/channel-config-service.ts
@@ -167,31 +167,33 @@ export class ChannelConfigService {
 
   /** Delete a channel config. Returns true if deleted. */
   async delete(id: string): Promise<boolean> {
-    const channel = await this.db
-      .selectFrom("channel_config")
-      .select(["id", "type"])
-      .where("id", "=", id)
-      .executeTakeFirst()
-
-    if (!channel) return false
-
-    // Safety guard: do not allow deleting channel config while bindings of that type exist.
-    const inUse = await this.db
-      .selectFrom("agent_channel_binding")
-      .select((eb) => eb.fn.countAll<string>().as("total"))
-      .where("channel_type", "=", channel.type)
-      .executeTakeFirstOrThrow()
-
-    if (Number(inUse.total) > 0) {
-      throw new Error(`Cannot delete channel type='${channel.type}' while agent bindings exist`)
-    }
-
     const result = await this.db
       .deleteFrom("channel_config")
       .where("id", "=", id)
       .executeTakeFirst()
 
     return Number(result.numDeletedRows) > 0
+  }
+
+  /** Return agent bindings for a given channel type. */
+  async getBindingsByChannelType(
+    channelType: string,
+  ): Promise<{ agent_id: string; chat_id: string }[]> {
+    return this.db
+      .selectFrom("agent_channel_binding")
+      .select(["agent_id", "chat_id"])
+      .where("channel_type", "=", channelType)
+      .execute()
+  }
+
+  /** Remove all agent bindings for a channel type (for force-delete). */
+  async removeBindingsByChannelType(channelType: string): Promise<number> {
+    const result = await this.db
+      .deleteFrom("agent_channel_binding")
+      .where("channel_type", "=", channelType)
+      .executeTakeFirst()
+
+    return Number(result.numDeletedRows)
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/control-plane/src/routes/channels.ts
+++ b/packages/control-plane/src/routes/channels.ts
@@ -29,6 +29,10 @@ interface ChannelIdParams {
   id: string
 }
 
+interface DeleteChannelQuery {
+  force?: string
+}
+
 interface CreateChannelBody {
   type: string
   name: string
@@ -177,7 +181,7 @@ export function channelRoutes(deps: ChannelRouteDeps) {
     // -----------------------------------------------------------------
     // DELETE /channels/:id — Remove a channel config
     // -----------------------------------------------------------------
-    app.delete<{ Params: ChannelIdParams }>(
+    app.delete<{ Params: ChannelIdParams; Querystring: DeleteChannelQuery }>(
       "/channels/:id",
       {
         preHandler: [requireAuth, requireOperator],
@@ -187,10 +191,39 @@ export function channelRoutes(deps: ChannelRouteDeps) {
             properties: { id: { type: "string" } },
             required: ["id"],
           },
+          querystring: {
+            type: "object",
+            properties: { force: { type: "string" } },
+          },
         },
       },
-      async (request: FastifyRequest<{ Params: ChannelIdParams }>, reply: FastifyReply) => {
-        const deleted = await service.delete(request.params.id)
+      async (
+        request: FastifyRequest<{ Params: ChannelIdParams; Querystring: DeleteChannelQuery }>,
+        reply: FastifyReply,
+      ) => {
+        const { id } = request.params
+        const force = request.query.force === "true"
+
+        const channel = await service.getById(id)
+        if (!channel) {
+          return reply.status(404).send({ error: "not_found", message: "Channel config not found" })
+        }
+
+        const bindings = await service.getBindingsByChannelType(channel.type)
+        if (bindings.length > 0 && !force) {
+          const agentIds = [...new Set(bindings.map((b) => b.agent_id))]
+          return reply.status(409).send({
+            error: "conflict",
+            message: `Cannot delete channel '${channel.name}': ${agentIds.length} agent(s) bound to channel type '${channel.type}'`,
+            bound_agents: agentIds,
+          })
+        }
+
+        if (bindings.length > 0) {
+          await service.removeBindingsByChannelType(channel.type)
+        }
+
+        const deleted = await service.delete(id)
         if (!deleted) {
           return reply.status(404).send({ error: "not_found", message: "Channel config not found" })
         }


### PR DESCRIPTION
Closes #425

**Changes:**
- DELETE /channels/:id now checks for active agent_channel_binding rows
- Returns 409 with bound_agents list if bindings exist
- Supports ?force=true to cascade-delete bindings first
- 4 new tests (409 with bindings, 200 clean, 404, force cascade)
- 1597 tests pass, lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Channel deletion now prevents accidental removal when active bindings exist; conflict response includes bound agent details
  * Added force parameter option to enable deletion of channels with active bindings

* **Bug Fixes**
  * Channel deletion API properly validates binding status before removal and returns appropriate status codes (404 for missing channels, 409 for conflicts)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->