### PR TITLE
fix(ui): wire Disconnect button on credential settings (#445)

### DIFF
--- a/packages/control-plane/src/__tests__/credential-routes.test.ts
+++ b/packages/control-plane/src/__tests__/credential-routes.test.ts
@@ -371,3 +371,35 @@ describe("GET /credentials?class=tool_specific", () => {
     expect(credentialService.listToolSecrets).not.toHaveBeenCalled()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Tests: DELETE /credentials/:id
+// ---------------------------------------------------------------------------
+
+describe("DELETE /credentials/:id", () => {
+  it("deletes a credential and returns ok", async () => {
+    const { app, credentialService } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/credentials/${CRED_ID}`,
+      headers: withSession(),
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body).toEqual({ ok: true })
+    expect(credentialService.deleteCredential).toHaveBeenCalledWith("user-1", CRED_ID)
+  })
+
+  it("returns 401 without auth", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/credentials/${CRED_ID}`,
+    })
+
+    expect(res.statusCode).toBe(401)
+  })
+})

--- a/packages/dashboard/src/__tests__/settings-providers.test.ts
+++ b/packages/dashboard/src/__tests__/settings-providers.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from "vitest"
 
+import type { Credential, ProviderInfo } from "@/lib/api-client"
+
 /**
  * Tests for the code-paste provider set used in the settings page.
  * Validates the static mapping is correct without requiring React rendering.
  */
 
 const CODE_PASTE_PROVIDER_IDS = new Set(["google-antigravity", "openai-codex", "anthropic"])
+
+/**
+ * credentialLabel — mirrors the helper in settings/page.tsx.
+ * Duplicated here so we can test without importing the React component.
+ */
+function credentialLabel(cred: Credential, providers: ProviderInfo[]): string {
+  if (cred.displayLabel) return cred.displayLabel
+  return providers.find((p) => p.id === cred.provider)?.name ?? cred.provider
+}
 
 describe("settings page code-paste providers", () => {
   it("identifies google-antigravity as a code-paste provider", () => {
@@ -28,5 +39,46 @@ describe("settings page code-paste providers", () => {
 
   it("contains exactly 3 providers", () => {
     expect(CODE_PASTE_PROVIDER_IDS.size).toBe(3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// credentialLabel helper
+// ---------------------------------------------------------------------------
+
+const STUB_PROVIDERS: ProviderInfo[] = [
+  { id: "openai", name: "OpenAI", authType: "api_key", description: "OpenAI LLM provider" },
+  { id: "anthropic", name: "Anthropic", authType: "oauth", description: "Anthropic LLM provider" },
+]
+
+function makeCred(overrides: Partial<Credential> = {}): Credential {
+  return {
+    id: "cred-1",
+    provider: "openai",
+    credentialType: "api_key",
+    displayLabel: null,
+    maskedKey: "****1234",
+    status: "active",
+    accountId: null,
+    lastUsedAt: null,
+    createdAt: "2026-03-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("credentialLabel", () => {
+  it("returns displayLabel when present", () => {
+    const cred = makeCred({ displayLabel: "My Production Key" })
+    expect(credentialLabel(cred, STUB_PROVIDERS)).toBe("My Production Key")
+  })
+
+  it("falls back to provider name when displayLabel is null", () => {
+    const cred = makeCred({ provider: "anthropic", displayLabel: null })
+    expect(credentialLabel(cred, STUB_PROVIDERS)).toBe("Anthropic")
+  })
+
+  it("falls back to raw provider id when provider is unknown", () => {
+    const cred = makeCred({ provider: "unknown-llm", displayLabel: null })
+    expect(credentialLabel(cred, STUB_PROVIDERS)).toBe("unknown-llm")
   })
 })

--- a/packages/dashboard/src/app/settings/page.tsx
+++ b/packages/dashboard/src/app/settings/page.tsx
@@ -16,6 +16,12 @@ import {
   saveProviderApiKey,
 } from "@/lib/api-client"
 
+/** Find a human-readable label for a credential (provider name or display label). */
+function credentialLabel(cred: Credential, providers: ProviderInfo[]): string {
+  if (cred.displayLabel) return cred.displayLabel
+  return providers.find((p) => p.id === cred.provider)?.name ?? cred.provider
+}
+
 /** Code-paste providers that use the init/exchange flow. */
 const CODE_PASTE_PROVIDER_IDS = new Set(["google-antigravity", "openai-codex", "anthropic"])
 
@@ -39,6 +45,13 @@ function SettingsInner() {
   } | null>(null)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // Disconnect credential state
+  const [disconnectConfirm, setDisconnectConfirm] = useState<{
+    id: string
+    label: string
+  } | null>(null)
+  const [disconnecting, setDisconnecting] = useState(false)
 
   // Code-paste fallback state (shown when popup cannot read the redirect URL)
   const [popupProvider, setPopupProvider] = useState<string | null>(null)
@@ -138,15 +151,21 @@ function SettingsInner() {
     }
   }, [apiKeyForm, fetchData])
 
-  // Delete credential
+  // Delete credential (called after user confirms)
   const handleDeleteCredential = useCallback(
     async (id: string) => {
+      setDisconnecting(true)
+      setError(null)
       try {
         await apiDeleteCredential(id)
-      } catch {
-        // Ignore — re-fetch will show current state
+        setDisconnectConfirm(null)
+        void fetchData()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to disconnect credential")
+        setDisconnectConfirm(null)
+      } finally {
+        setDisconnecting(false)
       }
-      void fetchData()
     },
     [fetchData],
   )
@@ -217,6 +236,12 @@ function SettingsInner() {
           Connect your LLM provider accounts. Credentials are encrypted with AES-256-GCM.
         </p>
 
+        {error && !apiKeyForm && (
+          <div className="mt-3 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
+            {error}
+          </div>
+        )}
+
         <div className="mt-4 space-y-3">
           {providers.map((p) => {
             const cred = getCredentialForProvider(p.id)
@@ -259,7 +284,12 @@ function SettingsInner() {
                   {cred ? (
                     <button
                       type="button"
-                      onClick={() => void handleDeleteCredential(cred.id)}
+                      onClick={() =>
+                        setDisconnectConfirm({
+                          id: cred.id,
+                          label: credentialLabel(cred, providers),
+                        })
+                      }
                       className="rounded-lg px-3 py-1.5 text-xs font-medium text-danger hover:bg-danger/10 transition-colors"
                     >
                       Disconnect
@@ -304,6 +334,37 @@ function SettingsInner() {
 
       {/* Channels */}
       <ChannelConfigSection />
+
+      {/* Disconnect credential confirmation dialog */}
+      {disconnectConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+          <div className="mx-4 w-full max-w-sm rounded-xl border border-surface-border bg-surface-light p-6 shadow-xl">
+            <h3 className="text-lg font-semibold text-text-main">Disconnect Provider</h3>
+            <p className="mt-2 text-sm text-text-muted">
+              Are you sure you want to disconnect
+              <strong> &ldquo;{disconnectConfirm.label}&rdquo;</strong>?
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setDisconnectConfirm(null)}
+                disabled={disconnecting}
+                className="rounded-lg px-4 py-2 text-sm text-text-muted hover:bg-secondary transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleDeleteCredential(disconnectConfirm.id)}
+                disabled={disconnecting}
+                className="rounded-lg bg-danger px-4 py-2 text-sm font-medium text-white hover:bg-danger/90 disabled:opacity-50 transition-colors"
+              >
+                {disconnecting ? "Disconnecting..." : "Disconnect"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* OAuth popup / code-paste fallback dialog */}
       {popupProvider && popup.status !== "idle" && popup.status !== "success" && (


### PR DESCRIPTION
## Summary
- Fixes the Disconnect button in credential settings that silently swallowed all errors and performed no visible action on click
- Adds a confirmation dialog before deletion (matching the channel Remove button pattern from #427)
- Surfaces API errors in an inline error banner instead of silently ignoring them
- Adds loading/disabled state while the delete request is in flight

Closes #445

## Test plan
- [x] `credentialLabel` helper unit tests (3 cases: displayLabel, provider name fallback, unknown provider fallback)
- [x] `DELETE /credentials/:id` route tests (success + 401 without auth)
- [x] All 1608 control-plane tests pass
- [x] All 456 dashboard tests pass
- [x] ESLint + TypeScript typecheck pass on both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added confirmation dialog when disconnecting credentials to prevent accidental removal
  * Enhanced error notifications for credential management operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->