### PR TITLE
fix(ui): add credentialClass to schemas and filter settings page (#446)

### DIFF
--- a/packages/dashboard/fixtures/api-responses/channels-list.json
+++ b/packages/dashboard/fixtures/api-responses/channels-list.json
@@ -1,0 +1,22 @@
+{
+  "channels": [
+    {
+      "id": "ch-001-telegram",
+      "type": "telegram",
+      "name": "Support Bot",
+      "enabled": true,
+      "created_by": "u-admin-001",
+      "created_at": "2025-02-01T00:00:00.000Z",
+      "updated_at": "2025-02-15T10:30:00.000Z"
+    },
+    {
+      "id": "ch-002-discord",
+      "type": "discord",
+      "name": "Dev Server",
+      "enabled": false,
+      "created_by": null,
+      "created_at": "2025-03-01T00:00:00.000Z",
+      "updated_at": "2025-03-01T00:00:00.000Z"
+    }
+  ]
+}

--- a/packages/dashboard/fixtures/api-responses/credentials-list.json
+++ b/packages/dashboard/fixtures/api-responses/credentials-list.json
@@ -4,6 +4,8 @@
       "id": "f6a7b8c9-d0e1-2345-fabc-456789012345",
       "provider": "openai",
       "credentialType": "api_key",
+      "credentialClass": "llm_provider",
+      "toolName": null,
       "displayLabel": "Production Key",
       "maskedKey": "sk-...xyz",
       "status": "active",

--- a/packages/dashboard/fixtures/api-responses/providers-list.json
+++ b/packages/dashboard/fixtures/api-responses/providers-list.json
@@ -11,6 +11,20 @@
       "name": "OpenAI",
       "authType": "api_key",
       "description": "GPT models via direct API key"
+    },
+    {
+      "id": "google-workspace",
+      "name": "Google Workspace",
+      "authType": "oauth",
+      "description": "Google Calendar, Gmail, Drive (acting as the user)",
+      "credentialClass": "user_service"
+    },
+    {
+      "id": "brave",
+      "name": "Brave Search",
+      "authType": "api_key",
+      "description": "Brave Search API for web search tools",
+      "credentialClass": "tool_specific"
     }
   ]
 }

--- a/packages/dashboard/src/__tests__/schema-contract.test.ts
+++ b/packages/dashboard/src/__tests__/schema-contract.test.ts
@@ -16,6 +16,7 @@ import agentDetailFixture from "../../fixtures/api-responses/agent-detail.json"
 import agentsListFixture from "../../fixtures/api-responses/agents-list.json"
 import approvalsListFixture from "../../fixtures/api-responses/approvals-list.json"
 import browserObserveFixture from "../../fixtures/api-responses/browser-observe.json"
+import channelsListFixture from "../../fixtures/api-responses/channels-list.json"
 import contentListFixture from "../../fixtures/api-responses/content-list.json"
 import credentialsListFixture from "../../fixtures/api-responses/credentials-list.json"
 import jobsListFixture from "../../fixtures/api-responses/jobs-list.json"
@@ -33,6 +34,7 @@ import {
 } from "../lib/schemas/agents"
 import { ApprovalListResponseSchema, ApprovalRequestSchema } from "../lib/schemas/approvals"
 import { BrowserSessionSchema } from "../lib/schemas/browser"
+import { ChannelConfigListResponseSchema, ChannelConfigSchema } from "../lib/schemas/channel-config"
 import { ContentListResponseSchema } from "../lib/schemas/content"
 import {
   CredentialListResponseSchema,
@@ -200,7 +202,7 @@ describe("API-Dashboard contract tests", () => {
   describe("GET /credentials/providers — ProviderListResponseSchema", () => {
     it("parses the fixture successfully", () => {
       const result = ProviderListResponseSchema.parse(providersListFixture)
-      expect(result.providers).toHaveLength(2)
+      expect(result.providers).toHaveLength(4)
     })
 
     it("does not silently drop provider fields", () => {
@@ -284,6 +286,21 @@ describe("API-Dashboard contract tests", () => {
     })
   })
 
+  describe("GET /channels — ChannelConfigListResponseSchema", () => {
+    it("parses the fixture successfully", () => {
+      const result = ChannelConfigListResponseSchema.parse(channelsListFixture)
+      expect(result.channels).toHaveLength(2)
+      expect(result.channels[0]?.type).toBe("telegram")
+      expect(result.channels[1]?.enabled).toBe(false)
+    })
+
+    it("does not silently drop channel config fields", () => {
+      for (const channel of channelsListFixture.channels) {
+        assertContractMatch(ChannelConfigSchema, channel, `Channel ${channel.id}`)
+      }
+    })
+  })
+
   // ---------------------------------------------------------------------------
   // Strict schema variants — detect extra/missing fields
   // ---------------------------------------------------------------------------
@@ -319,6 +336,13 @@ describe("API-Dashboard contract tests", () => {
       const strict = makeStrict(MemoryRecordSchema)
       for (const record of memorySearchFixture.results) {
         expect(() => strict.parse(record)).not.toThrow()
+      }
+    })
+
+    it("ChannelConfigSchema.strict() accepts fixture exactly", () => {
+      const strict = makeStrict(ChannelConfigSchema)
+      for (const channel of channelsListFixture.channels) {
+        expect(() => strict.parse(channel)).not.toThrow()
       }
     })
   })

--- a/packages/dashboard/src/__tests__/settings-providers.test.ts
+++ b/packages/dashboard/src/__tests__/settings-providers.test.ts
@@ -82,3 +82,65 @@ describe("credentialLabel", () => {
     expect(credentialLabel(cred, STUB_PROVIDERS)).toBe("unknown-llm")
   })
 })
+
+// ---------------------------------------------------------------------------
+// LLM provider filtering — mirrors the filter in settings/page.tsx
+// ---------------------------------------------------------------------------
+
+describe("settings page LLM provider filter", () => {
+  const ALL_PROVIDERS: ProviderInfo[] = [
+    { id: "openai", name: "OpenAI", authType: "api_key", description: "GPT models" },
+    { id: "anthropic", name: "Anthropic", authType: "oauth", description: "Claude models" },
+    {
+      id: "google-workspace",
+      name: "Google Workspace",
+      authType: "oauth",
+      description: "Google services",
+      credentialClass: "user_service",
+    },
+    {
+      id: "brave",
+      name: "Brave Search",
+      authType: "api_key",
+      description: "Web search",
+      credentialClass: "tool_specific",
+    },
+    {
+      id: "google-ai-studio",
+      name: "Google AI Studio",
+      authType: "api_key",
+      description: "Gemini",
+      credentialClass: "llm_provider",
+    },
+  ]
+
+  function filterLlmProviders(providers: ProviderInfo[]): ProviderInfo[] {
+    return providers.filter((p) => !p.credentialClass || p.credentialClass === "llm_provider")
+  }
+
+  it("includes providers without credentialClass (legacy LLM providers)", () => {
+    const result = filterLlmProviders(ALL_PROVIDERS)
+    expect(result.map((p) => p.id)).toContain("openai")
+    expect(result.map((p) => p.id)).toContain("anthropic")
+  })
+
+  it("includes providers with credentialClass === 'llm_provider'", () => {
+    const result = filterLlmProviders(ALL_PROVIDERS)
+    expect(result.map((p) => p.id)).toContain("google-ai-studio")
+  })
+
+  it("excludes user_service providers", () => {
+    const result = filterLlmProviders(ALL_PROVIDERS)
+    expect(result.map((p) => p.id)).not.toContain("google-workspace")
+  })
+
+  it("excludes tool_specific providers", () => {
+    const result = filterLlmProviders(ALL_PROVIDERS)
+    expect(result.map((p) => p.id)).not.toContain("brave")
+  })
+
+  it("returns correct count", () => {
+    const result = filterLlmProviders(ALL_PROVIDERS)
+    expect(result).toHaveLength(3)
+  })
+})

--- a/packages/dashboard/src/app/settings/page.tsx
+++ b/packages/dashboard/src/app/settings/page.tsx
@@ -181,6 +181,13 @@ function SettingsInner() {
   const getCredentialForProvider = (providerId: string) =>
     credentials.find((c) => c.provider === providerId)
 
+  // Only show LLM providers in the "Connected Providers" section.
+  // User services (google-workspace, github-user, slack-user) and
+  // tool-specific providers (brave) are managed separately.
+  const llmProviders = providers.filter(
+    (p) => !p.credentialClass || p.credentialClass === "llm_provider",
+  )
+
   return (
     <div className="space-y-8">
       {/* Header */}
@@ -243,7 +250,7 @@ function SettingsInner() {
         )}
 
         <div className="mt-4 space-y-3">
-          {providers.map((p) => {
+          {llmProviders.map((p) => {
             const cred = getCredentialForProvider(p.id)
             const isOAuth = p.authType === "oauth"
             const isCodePaste = CODE_PASTE_PROVIDER_IDS.has(p.id)
@@ -324,9 +331,9 @@ function SettingsInner() {
             )
           })}
 
-          {providers.length === 0 && (
+          {llmProviders.length === 0 && (
             <p className="py-4 text-center text-sm text-text-muted">
-              No providers configured. Configure provider credentials in the control plane.
+              No LLM providers configured. Configure provider credentials in the control plane.
             </p>
           )}
         </div>

--- a/packages/dashboard/src/lib/schemas/credentials.ts
+++ b/packages/dashboard/src/lib/schemas/credentials.ts
@@ -5,12 +5,15 @@ export const ProviderInfoSchema = z.object({
   name: z.string(),
   authType: z.enum(["oauth", "api_key"]),
   description: z.string(),
+  credentialClass: z.string().optional(),
 })
 
 export const CredentialSchema = z.object({
   id: z.string(),
   provider: z.string(),
   credentialType: z.string(),
+  credentialClass: z.string().optional(),
+  toolName: z.string().nullable().optional(),
   displayLabel: z.string().nullable(),
   maskedKey: z.string().nullable(),
   status: z.string(),


### PR DESCRIPTION
## Summary
- The Settings page showed all providers (including `user_service` and `tool_specific` types like Google Workspace, GitHub, Slack, Brave) in the "Connected LLM Providers" section, causing incorrect rendering
- Root cause: the dashboard Zod schemas silently stripped the `credentialClass` field returned by the API, so the UI could not distinguish provider categories
- Adds `credentialClass` (optional) to `ProviderInfoSchema` and `CredentialSchema`, and `toolName` (nullable, optional) to `CredentialSchema`
- Filters the settings page provider list to only show LLM providers (no `credentialClass` or `credentialClass === "llm_provider"`)
- Updates contract test fixtures to match real API response shapes (providers now include `credentialClass`, credentials include `credentialClass` + `toolName`)
- Adds channel config fixture + contract tests (previously untested)

Closes #446

## Test plan
- [x] 464 dashboard tests pass (up from 456 — 8 new tests)
- [x] 1608 control-plane tests pass
- [x] ESLint + TypeScript typecheck clean
- [x] `next build` succeeds
- [x] New contract tests: channel config schema parsing + strict mode
- [x] New unit tests: LLM provider filter (5 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)