### PR TITLE
fix(auth): normalise non-UUID principal.userId to deterministic UUID

### DIFF
--- a/packages/control-plane/src/__tests__/agent-credential-routes.test.ts
+++ b/packages/control-plane/src/__tests__/agent-credential-routes.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest"
 import type { Database } from "../db/types.js"
 import type { AuthConfig } from "../middleware/types.js"
 import { agentCredentialRoutes } from "../routes/agent-credentials.js"
+import { ensureUuid } from "../util/name-uuid.js"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -17,7 +18,7 @@ const DEV_AUTH_CONFIG: AuthConfig = {
 
 const AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 const CRED_ID = "cccccccc-1111-2222-3333-444444444444"
-const USER_ID = "dev-user"
+const USER_ID = ensureUuid("dev-user")
 const BINDING_ID = "bbbbbbbb-1111-2222-3333-444444444444"
 
 function makeCredential(overrides: Record<string, unknown> = {}) {

--- a/packages/control-plane/src/__tests__/agent-user-routes.test.ts
+++ b/packages/control-plane/src/__tests__/agent-user-routes.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest"
 import { AccessRequestConflictError } from "../auth/access-request-service.js"
 import type { AuthConfig } from "../middleware/types.js"
 import { agentUserRoutes } from "../routes/agent-user-routes.js"
+import { ensureUuid } from "../util/name-uuid.js"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -438,7 +439,7 @@ describe("POST /agents/:agentId/pairing-codes", () => {
     const body = res.json()
     expect(body.code).toBe("ABC123")
     expect(body.expiresAt).toBeDefined()
-    expect(pairing.generate).toHaveBeenCalledWith(AGENT_ID, "dev-user")
+    expect(pairing.generate).toHaveBeenCalledWith(AGENT_ID, ensureUuid("dev-user"))
   })
 })
 
@@ -506,7 +507,7 @@ describe("PATCH /agents/:agentId/access-requests/:requestId", () => {
     const body = res.json()
     expect(body.request.status).toBe("approved")
     expect(body.request.grant_id).toBe(GRANT_ID)
-    expect(arService.approve).toHaveBeenCalledWith(REQUEST_ID, "dev-user")
+    expect(arService.approve).toHaveBeenCalledWith(REQUEST_ID, ensureUuid("dev-user"))
   })
 
   it("denies a request", async () => {
@@ -521,7 +522,11 @@ describe("PATCH /agents/:agentId/access-requests/:requestId", () => {
     expect(res.statusCode).toBe(200)
     const body = res.json()
     expect(body.request.status).toBe("denied")
-    expect(arService.deny).toHaveBeenCalledWith(REQUEST_ID, "dev-user", "Not authorized")
+    expect(arService.deny).toHaveBeenCalledWith(
+      REQUEST_ID,
+      ensureUuid("dev-user"),
+      "Not authorized",
+    )
   })
 
   it("returns 409 on conflict", async () => {

--- a/packages/control-plane/src/__tests__/approval-auth-routes.test.ts
+++ b/packages/control-plane/src/__tests__/approval-auth-routes.test.ts
@@ -6,6 +6,7 @@ import { hashApiKey } from "../middleware/api-keys.js"
 import type { AuthConfig } from "../middleware/types.js"
 import { approvalRoutes } from "../routes/approval.js"
 import type { SSEConnectionManager } from "../streaming/manager.js"
+import { ensureUuid } from "../util/name-uuid.js"
 
 // ---------------------------------------------------------------------------
 // Test keys & auth config
@@ -231,7 +232,7 @@ describe("Approval routes with auth", () => {
 
       // The service should have been called with the principal's userId
       const decideCall = (mockService.decide as ReturnType<typeof vi.fn>).mock.calls[0]
-      expect(decideCall![2]).toBe("user-approver") // decidedBy from auth
+      expect(decideCall![2]).toBe(ensureUuid("user-approver")) // decidedBy from auth
     })
 
     it("does not accept decidedBy from body — field removed from schema", async () => {
@@ -244,7 +245,7 @@ describe("Approval routes with auth", () => {
 
       const decideCall = (mockService.decide as ReturnType<typeof vi.fn>).mock.calls[0]
       // decidedBy must come from auth principal, not body
-      expect(decideCall![2]).toBe("user-approver")
+      expect(decideCall![2]).toBe(ensureUuid("user-approver"))
     })
 
     it("passes actor metadata to service", async () => {
@@ -266,7 +267,7 @@ describe("Approval routes with auth", () => {
         userAgent: string
       }
       expect(actorMetadata).toBeDefined()
-      expect(actorMetadata.userId).toBe("user-approver")
+      expect(actorMetadata.userId).toBe(ensureUuid("user-approver"))
       expect(actorMetadata.displayName).toBe("Approver Key")
       expect(actorMetadata.authMethod).toBe("api_key")
       expect(actorMetadata.userAgent).toBe("TestClient/1.0")
@@ -315,7 +316,7 @@ describe("Approval routes with auth", () => {
       })
 
       const call = (mockService.decideByToken as ReturnType<typeof vi.fn>).mock.calls[0]
-      expect(call![2]).toBe("user-approver")
+      expect(call![2]).toBe(ensureUuid("user-approver"))
     })
 
     it("passes actor metadata for token-based decide", async () => {
@@ -329,7 +330,7 @@ describe("Approval routes with auth", () => {
       const call = (mockService.decideByToken as ReturnType<typeof vi.fn>).mock.calls[0]
       const actorMetadata = call![5] as { userId: string }
       expect(actorMetadata).toBeDefined()
-      expect(actorMetadata.userId).toBe("user-approver")
+      expect(actorMetadata.userId).toBe(ensureUuid("user-approver"))
     })
   })
 
@@ -557,6 +558,6 @@ describe("Approval routes in dev mode (no auth)", () => {
     })
 
     const decideCall = (mockService.decide as ReturnType<typeof vi.fn>).mock.calls[0]
-    expect(decideCall![2]).toBe("dev-user")
+    expect(decideCall![2]).toBe(ensureUuid("dev-user"))
   })
 })

--- a/packages/control-plane/src/__tests__/auth-middleware.test.ts
+++ b/packages/control-plane/src/__tests__/auth-middleware.test.ts
@@ -4,6 +4,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { findApiKey, hashApiKey, loadAuthConfig } from "../middleware/api-keys.js"
 import { createRequireAuth, createRequireRole } from "../middleware/auth.js"
 import type { ApiKeyRecord, AuthConfig, AuthenticatedRequest } from "../middleware/types.js"
+import { ensureUuid } from "../util/name-uuid.js"
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 // ---------------------------------------------------------------------------
 // hashApiKey
@@ -185,7 +188,8 @@ describe("requireAuth middleware", () => {
       headers: { authorization: `Bearer ${TEST_KEY}` },
     })
     expect(res.statusCode).toBe(200)
-    expect(res.json<{ userId: string }>().userId).toBe("user-1")
+    // Non-UUID config userId "user-1" is normalised to a deterministic UUID
+    expect(res.json<{ userId: string }>().userId).toBe(ensureUuid("user-1"))
     expect(res.json<{ roles: string[] }>().roles).toEqual(["operator", "approver"])
   })
 
@@ -196,7 +200,7 @@ describe("requireAuth middleware", () => {
       headers: { "x-api-key": TEST_KEY },
     })
     expect(res.statusCode).toBe(200)
-    expect(res.json<{ userId: string }>().userId).toBe("user-1")
+    expect(res.json<{ userId: string }>().userId).toBe(ensureUuid("user-1"))
   })
 
   it("prefers Authorization header over X-API-Key", async () => {
@@ -209,7 +213,7 @@ describe("requireAuth middleware", () => {
       },
     })
     expect(res.statusCode).toBe(200)
-    expect(res.json<{ userId: string }>().userId).toBe("user-1")
+    expect(res.json<{ userId: string }>().userId).toBe(ensureUuid("user-1"))
   })
 })
 
@@ -242,10 +246,13 @@ describe("requireAuth dev mode", () => {
     await app.close()
   })
 
-  it("allows requests without credentials in dev mode", async () => {
+  it("allows requests without credentials in dev mode and assigns a valid UUID", async () => {
     const res = await app.inject({ method: "GET", url: "/protected" })
     expect(res.statusCode).toBe(200)
-    expect(res.json<{ userId: string }>().userId).toBe("dev-user")
+    // "dev-user" is normalised to a deterministic UUID for DB FK integrity
+    const userId = res.json<{ userId: string }>().userId
+    expect(userId).toMatch(UUID_RE)
+    expect(userId).toBe(ensureUuid("dev-user"))
   })
 
   it("allows requests with invalid credentials in dev mode", async () => {
@@ -255,7 +262,7 @@ describe("requireAuth dev mode", () => {
       headers: { authorization: "Bearer bad-key" },
     })
     expect(res.statusCode).toBe(200)
-    expect(res.json<{ userId: string }>().userId).toBe("dev-user")
+    expect(res.json<{ userId: string }>().userId).toMatch(UUID_RE)
   })
 })
 

--- a/packages/control-plane/src/__tests__/name-uuid.test.ts
+++ b/packages/control-plane/src/__tests__/name-uuid.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+
+import { ensureUuid, toNameUuid } from "../util/name-uuid.js"
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+describe("toNameUuid", () => {
+  it("produces a valid UUID-shaped string", () => {
+    expect(toNameUuid("dev-user")).toMatch(UUID_RE)
+  })
+
+  it("is deterministic", () => {
+    expect(toNameUuid("dev-user")).toBe(toNameUuid("dev-user"))
+  })
+
+  it("different inputs produce different UUIDs", () => {
+    expect(toNameUuid("dev-user")).not.toBe(toNameUuid("api-user"))
+  })
+
+  it("sets version nibble to 4", () => {
+    const uuid = toNameUuid("test-input")
+    // Third group starts with the version nibble
+    expect(uuid.split("-")[2]![0]).toBe("4")
+  })
+
+  it("sets variant bits to 10xx", () => {
+    const uuid = toNameUuid("test-input")
+    const variantNibble = parseInt(uuid.split("-")[3]![0]!, 16)
+    // Variant 10xx means the high two bits are 10 → value 8, 9, a, or b
+    expect(variantNibble).toBeGreaterThanOrEqual(8)
+    expect(variantNibble).toBeLessThanOrEqual(0xb)
+  })
+})
+
+describe("ensureUuid", () => {
+  it("returns valid UUIDs unchanged", () => {
+    const uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    expect(ensureUuid(uuid)).toBe(uuid)
+  })
+
+  it("converts non-UUID strings to a UUID", () => {
+    const result = ensureUuid("dev-user")
+    expect(result).toMatch(UUID_RE)
+    expect(result).not.toBe("dev-user")
+  })
+
+  it("converts non-UUID strings deterministically", () => {
+    expect(ensureUuid("user-1")).toBe(ensureUuid("user-1"))
+  })
+
+  it("produces the same result as toNameUuid for non-UUID inputs", () => {
+    expect(ensureUuid("dev-user")).toBe(toNameUuid("dev-user"))
+  })
+})

--- a/packages/control-plane/src/middleware/auth.ts
+++ b/packages/control-plane/src/middleware/auth.ts
@@ -15,6 +15,7 @@ import type { FastifyReply, FastifyRequest } from "fastify"
 
 import type { SessionService } from "../auth/session-service.js"
 import { CSRF_HEADER, SESSION_COOKIE_NAME } from "../auth/session-service.js"
+import { ensureUuid } from "../util/name-uuid.js"
 import { findApiKey } from "./api-keys.js"
 import type { AuthConfig, AuthenticatedRequest, Principal } from "./types.js"
 
@@ -28,7 +29,7 @@ const ROLE_MAP: Record<string, string[]> = {
 }
 
 const DEV_PRINCIPAL: Principal = {
-  userId: "dev-user",
+  userId: ensureUuid("dev-user"),
   roles: ["operator", "approver", "admin"],
   displayName: "Dev User (no auth configured)",
   authMethod: "api_key",
@@ -97,7 +98,7 @@ export function createRequireAuth(configOrOptions: AuthConfig | AuthMiddlewareOp
       const record = findApiKey(plaintextKey, config.apiKeys)
       if (record) {
         const principal: Principal = {
-          userId: record.userId,
+          userId: ensureUuid(record.userId),
           roles: record.roles,
           displayName: record.label,
           authMethod: "api_key",

--- a/packages/control-plane/src/routes/chat.ts
+++ b/packages/control-plane/src/routes/chat.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto"
-
 /**
  * Chat Routes
  *
@@ -23,6 +21,7 @@ import {
 } from "../middleware/auth.js"
 import type { AuthConfig } from "../middleware/types.js"
 import type { AuthenticatedRequest } from "../middleware/types.js"
+import { ensureUuid } from "../util/name-uuid.js"
 
 // ---------------------------------------------------------------------------
 // Route types
@@ -124,15 +123,13 @@ export function chatRoutes(deps: ChatRouteDeps) {
           })
         }
 
-        // Resolve user from auth principal
+        // Resolve user from auth principal (ensureUuid is defence-in-depth;
+        // the auth middleware already normalises principal.userId to a UUID).
         const principal = (request as AuthenticatedRequest).principal
-        const rawUserId = principal?.userId ?? "api-user"
-        // Map non-UUID principal IDs to a deterministic UUID for DB FK integrity.
-        const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-        const userAccountId = UUID_RE.test(rawUserId) ? rawUserId : toNameUuid(rawUserId)
+        const userAccountId = ensureUuid(principal?.userId ?? "api-user")
 
         // Ensure principal user exists for session FK integrity (dev/api-key modes).
-        await ensureUserAccount(db, userAccountId, principal?.displayName ?? rawUserId)
+        await ensureUserAccount(db, userAccountId, principal?.displayName ?? "api-user")
 
         // Per-agent authorization guard
         if (channelAuthGuard) {
@@ -262,24 +259,6 @@ export function chatRoutes(deps: ChatRouteDeps) {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Derive a deterministic UUID v4-shaped identifier from an arbitrary string.
- * Uses SHA-256, sets version nibble to 4 and variant bits to 10xx.
- */
-function toNameUuid(name: string): string {
-  const hex = createHash("sha256").update(name).digest("hex")
-  // Format as UUID, set version=4 and variant=10xx
-  const raw = hex.slice(0, 32)
-  const parts = [
-    raw.slice(0, 8),
-    raw.slice(8, 12),
-    "4" + raw.slice(13, 16), // version nibble
-    ((parseInt(raw[16]!, 16) & 0x3) | 0x8).toString(16) + raw.slice(17, 20), // variant
-    raw.slice(20, 32),
-  ]
-  return parts.join("-")
-}
 
 async function ensureUserAccount(
   db: Kysely<Database>,

--- a/packages/control-plane/src/util/name-uuid.ts
+++ b/packages/control-plane/src/util/name-uuid.ts
@@ -1,0 +1,35 @@
+/**
+ * Deterministic UUID generation from arbitrary strings.
+ *
+ * Used to convert non-UUID identifiers (e.g. "dev-user", "user-1")
+ * into valid UUID v4-shaped strings suitable for PostgreSQL UUID columns.
+ */
+
+import { createHash } from "node:crypto"
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * Derive a deterministic UUID v4-shaped identifier from an arbitrary string.
+ * Uses SHA-256, sets version nibble to 4 and variant bits to 10xx.
+ */
+export function toNameUuid(name: string): string {
+  const hex = createHash("sha256").update(name).digest("hex")
+  const raw = hex.slice(0, 32)
+  const parts = [
+    raw.slice(0, 8),
+    raw.slice(8, 12),
+    "4" + raw.slice(13, 16), // version nibble
+    ((parseInt(raw[16]!, 16) & 0x3) | 0x8).toString(16) + raw.slice(17, 20), // variant
+    raw.slice(20, 32),
+  ]
+  return parts.join("-")
+}
+
+/**
+ * Return the input unchanged if it is already a valid UUID;
+ * otherwise derive a deterministic UUID via `toNameUuid`.
+ */
+export function ensureUuid(raw: string): string {
+  return UUID_RE.test(raw) ? raw : toNameUuid(raw)
+}


### PR DESCRIPTION
## Summary

Closes #431.

- **Root cause**: `DEV_PRINCIPAL` (dev mode) and API-key principals used bare strings like `"dev-user"` / `"user-1"` as `userId`, which broke any route that passed the value to a PostgreSQL UUID column (e.g. `session.user_account_id`, credential audit logs).
- **Fix**: New `ensureUuid()` utility (`src/util/name-uuid.ts`) converts non-UUID strings to a deterministic SHA-256-derived UUID. Applied in the auth middleware so **all** downstream routes receive a valid UUID principal — not just the chat route (which had a band-aid fix via #441/#442).
- `chat.ts` retains `ensureUuid` as defence-in-depth but no longer carries its own local `toNameUuid` helper.

## Files changed

| File | Change |
|------|--------|
| `src/util/name-uuid.ts` | **New** — `toNameUuid()` and `ensureUuid()` utility |
| `src/middleware/auth.ts` | Wrap `DEV_PRINCIPAL.userId` and API-key `record.userId` with `ensureUuid()` |
| `src/routes/chat.ts` | Replace inline `toNameUuid` with imported `ensureUuid`; remove local helper |
| `src/__tests__/name-uuid.test.ts` | **New** — 9 tests for the utility |
| `src/__tests__/auth-middleware.test.ts` | Update assertions to expect UUID userId |
| `src/__tests__/approval-auth-routes.test.ts` | Update `decidedBy` / `actorMetadata.userId` assertions |
| `src/__tests__/agent-credential-routes.test.ts` | Match mock `user_account_id` to UUID |
| `src/__tests__/agent-user-routes.test.ts` | Update mock expectations for principal.userId |

## Test plan

- [x] `npx vitest run` — 1632 passed, 1 skipped
- [x] `npx eslint` on all changed files — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)