### PR TITLE
fix(quarantine): reset circuit breaker on release to break death spiral

### DIFF
--- a/packages/control-plane/migrations/029_agent_health_reset_at.down.sql
+++ b/packages/control-plane/migrations/029_agent_health_reset_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent DROP COLUMN IF EXISTS health_reset_at;

--- a/packages/control-plane/migrations/029_agent_health_reset_at.up.sql
+++ b/packages/control-plane/migrations/029_agent_health_reset_at.up.sql
@@ -1,0 +1,5 @@
+-- Add health_reset_at to the agent table.
+-- When set, the circuit breaker hydration query ignores jobs completed
+-- before this timestamp, breaking the quarantine death spiral (#443).
+ALTER TABLE agent
+  ADD COLUMN health_reset_at TIMESTAMPTZ;

--- a/packages/control-plane/src/__tests__/agent-execute-circuit-breaker.test.ts
+++ b/packages/control-plane/src/__tests__/agent-execute-circuit-breaker.test.ts
@@ -560,4 +560,55 @@ describe("agent-execute circuit breaker wiring", () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(registry.routeTask).toHaveBeenCalled()
   })
+
+  it("does not quarantine when health_reset_at filters out prior failures (#443)", async () => {
+    // Agent has health_reset_at set — simulates release from quarantine.
+    // The hydration query filters jobs completed before health_reset_at,
+    // so recentJobs comes back empty even though there were prior failures.
+    const db = makeMockDb({
+      agent: {
+        id: "agent-1",
+        name: "TestAgent",
+        slug: "test-agent",
+        role: "developer",
+        description: null,
+        status: "ACTIVE",
+        model_config: {},
+        skill_config: {},
+        resource_limits: {},
+        config: null,
+        health_reset_at: new Date(),
+      },
+      // After filtering, no recent jobs remain (all old failures are excluded)
+      recentJobs: [],
+    })
+
+    const events: OutputEvent[] = [
+      { type: "text", timestamp: new Date().toISOString(), content: "Done!" },
+    ]
+
+    const handle = createMockHandle(createMockResult(), events)
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // Agent should NOT be quarantined
+    const agentQuarantine = db._setCalls.find(
+      (c) => c.table === "agent" && c.values.status === "QUARANTINED",
+    )
+    expect(agentQuarantine).toBeUndefined()
+
+    // Job should be COMPLETED
+    const jobComplete = db._setCalls.find(
+      (c) => c.table === "job" && c.values.status === "COMPLETED",
+    )
+    expect(jobComplete).toBeDefined()
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(registry.routeTask).toHaveBeenCalled()
+  })
 })

--- a/packages/control-plane/src/__tests__/agent-lifecycle-routes.test.ts
+++ b/packages/control-plane/src/__tests__/agent-lifecycle-routes.test.ts
@@ -376,6 +376,86 @@ describe("POST /agents/:agentId/release", () => {
 })
 
 // ---------------------------------------------------------------------------
+// Tests: POST /agents/:agentId/reset-health (#443)
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/:agentId/reset-health", () => {
+  it("resets health for an existing agent", async () => {
+    const app = Fastify({ logger: false })
+
+    const agentRow = {
+      id: AGENT_ID,
+      status: "ACTIVE",
+      health_reset_at: new Date(),
+    }
+
+    const db = {
+      selectFrom: vi.fn(),
+      updateTable: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returningAll: vi.fn().mockReturnValue({
+              executeTakeFirst: vi.fn().mockResolvedValue(agentRow),
+            }),
+            execute: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    } as unknown as Kysely<Database>
+
+    await app.register(
+      agentLifecycleRoutes({
+        db,
+        authConfig: DEV_AUTH_CONFIG,
+      }),
+    )
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/reset-health`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.agentId).toBe(AGENT_ID)
+    expect(body.healthResetAt).toBeDefined()
+  })
+
+  it("returns 404 when agent does not exist", async () => {
+    const app = Fastify({ logger: false })
+
+    const db = {
+      selectFrom: vi.fn(),
+      updateTable: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returningAll: vi.fn().mockReturnValue({
+              executeTakeFirst: vi.fn().mockResolvedValue(null),
+            }),
+            execute: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    } as unknown as Kysely<Database>
+
+    await app.register(
+      agentLifecycleRoutes({
+        db,
+        authConfig: DEV_AUTH_CONFIG,
+      }),
+    )
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/reset-health`,
+    })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.json().error).toBe("not_found")
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Tests: POST /agents/:agentId/boot?mode=safe
 // ---------------------------------------------------------------------------
 

--- a/packages/control-plane/src/__tests__/lifecycle-quarantine.test.ts
+++ b/packages/control-plane/src/__tests__/lifecycle-quarantine.test.ts
@@ -178,6 +178,26 @@ describe("AgentLifecycleManager quarantine/release", () => {
     expect(updateCalls.some((c: string[]) => c[0] === "agent")).toBe(true)
   })
 
+  it("release sets health_reset_at to break quarantine death spiral (#443)", async () => {
+    configureDbForBoot(db)
+    await manager.boot("agent-1", "job-1")
+    manager.run("agent-1", "job-1")
+    await manager.quarantine("agent-1", "failures")
+
+    // Reset mock to track release calls
+    ;(db.updateTable as ReturnType<typeof vi.fn>).mockClear()
+    db._mockChain.set.mockClear()
+
+    await manager.release("agent-1")
+
+    // Verify that set() was called with health_reset_at
+    const setCalls = db._mockChain.set.mock.calls as Array<[Record<string, unknown>]>
+    const agentSetCall = setCalls.find(
+      (c) => c[0].status === "ACTIVE" && c[0].health_reset_at instanceof Date,
+    )
+    expect(agentSetCall).toBeDefined()
+  })
+
   it("release with resetCrashDetector clears crash history", async () => {
     configureDbForBoot(db)
     await manager.boot("agent-1", "job-1")

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -99,6 +99,7 @@ export interface AgentTable {
   >
   auth_model: ColumnType<AgentAuthModel, AgentAuthModel | undefined, AgentAuthModel>
   status: ColumnType<AgentStatus, AgentStatus | undefined, AgentStatus>
+  health_reset_at: ColumnType<Date | null, Date | null | undefined, Date | null>
   created_at: ColumnType<Date, Date | undefined, never>
   updated_at: ColumnType<Date, Date | undefined, never>
 }

--- a/packages/control-plane/src/lifecycle/manager.ts
+++ b/packages/control-plane/src/lifecycle/manager.ts
@@ -411,8 +411,12 @@ export class AgentLifecycleManager {
 
     ctx.stateMachine.transition("DRAINING", "Released from quarantine")
 
-    // Restore DB agent status
-    await this.db.updateTable("agent").set({ status: "ACTIVE" }).where("id", "=", agentId).execute()
+    // Restore DB agent status and reset circuit breaker history (#443)
+    await this.db
+      .updateTable("agent")
+      .set({ status: "ACTIVE", health_reset_at: new Date() })
+      .where("id", "=", agentId)
+      .execute()
 
     if (resetCrashDetector) {
       this.crashDetector.resetCrashes(agentId)

--- a/packages/control-plane/src/routes/agent-lifecycle.ts
+++ b/packages/control-plane/src/routes/agent-lifecycle.ts
@@ -217,7 +217,7 @@ export function agentLifecycleRoutes(deps: AgentLifecycleRouteDeps) {
           // Agent not currently managed — DB-only release
           await db
             .updateTable("agent")
-            .set({ status: "ACTIVE" })
+            .set({ status: "ACTIVE", health_reset_at: new Date() })
             .where("id", "=", agentId)
             .execute()
         }
@@ -226,6 +226,42 @@ export function agentLifecycleRoutes(deps: AgentLifecycleRouteDeps) {
           agentId,
           state: "DRAINING",
           releasedAt: new Date().toISOString(),
+        })
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // POST /agents/:agentId/reset-health — reset circuit breaker (#443)
+    // -----------------------------------------------------------------
+    app.post<{ Params: AgentParams }>(
+      "/agents/:agentId/reset-health",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: { agentId: { type: "string" } },
+            required: ["agentId"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: AgentParams }>, reply: FastifyReply) => {
+        const { agentId } = request.params
+
+        const result = await db
+          .updateTable("agent")
+          .set({ health_reset_at: new Date() })
+          .where("id", "=", agentId)
+          .returningAll()
+          .executeTakeFirst()
+
+        if (!result) {
+          return reply.status(404).send({ error: "not_found", message: "Agent not found" })
+        }
+
+        return reply.status(200).send({
+          agentId,
+          healthResetAt: (result.health_reset_at as Date).toISOString(),
         })
       },
     )

--- a/packages/control-plane/src/routes/agents.ts
+++ b/packages/control-plane/src/routes/agents.ts
@@ -617,7 +617,13 @@ export function agentRoutes(deps: AgentRouteDeps) {
         if (body.channel_permissions !== undefined)
           updateValues.channel_permissions = body.channel_permissions
         if (body.config !== undefined) updateValues.config = body.config
-        if (body.status !== undefined) updateValues.status = body.status
+        if (body.status !== undefined) {
+          updateValues.status = body.status
+          // Reset circuit breaker history when (re-)activating an agent (#443)
+          if (body.status === "ACTIVE") {
+            updateValues.health_reset_at = new Date()
+          }
+        }
 
         if (Object.keys(updateValues).length === 0) {
           return reply.status(400).send({ error: "bad_request", message: "No fields to update" })

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -176,15 +176,20 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
         const cbConfig = resolveCircuitBreakerConfig(agent.resource_limits)
         agentCB = new AgentCircuitBreaker(agent.id, cbConfig)
 
-        // Hydrate consecutive failure count from recent jobs
-        const recentJobs = await db
+        // Hydrate consecutive failure count from recent jobs.
+        // If health_reset_at is set, ignore jobs completed before the reset
+        // to avoid the quarantine death spiral (#443).
+        let recentJobsQuery = db
           .selectFrom("job")
           .select("status")
           .where("agent_id", "=", agent.id)
           .where("completed_at", "is not", null)
-          .orderBy("completed_at", "desc")
-          .limit(10)
-          .execute()
+
+        if (agent.health_reset_at) {
+          recentJobsQuery = recentJobsQuery.where("completed_at", ">", agent.health_reset_at)
+        }
+
+        const recentJobs = await recentJobsQuery.orderBy("completed_at", "desc").limit(10).execute()
 
         for (const rj of recentJobs) {
           if (rj.status === "FAILED") agentCB.recordJobFailure()


### PR DESCRIPTION
## Summary
- Adds `health_reset_at` timestamp column to the agent table (migration 029) to track when the circuit breaker was last reset
- Hydration query in `agent-execute` now filters out jobs completed before `health_reset_at`, breaking the quarantine death spiral where all recent FAILED jobs caused immediate re-quarantine
- `PUT /agents/:id` with `status: "ACTIVE"` automatically sets `health_reset_at`
- `POST /agents/:agentId/release` sets `health_reset_at` on both lifecycle-managed and DB-only paths
- New `POST /agents/:agentId/reset-health` endpoint for explicit circuit breaker reset without requiring quarantine state

Closes #443

## Test plan
- [x] Existing 1636 tests pass (no regressions)
- [x] New test: hydration skips prior failures when `health_reset_at` is set
- [x] New test: `release()` sets `health_reset_at` on the DB update
- [x] New test: `POST /agents/:agentId/reset-health` returns 200 with timestamp
- [x] New test: `POST /agents/:agentId/reset-health` returns 404 for missing agent
- [x] Lint, typecheck, and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent health reset capability to break prolonged quarantine cycles
  * New POST /agents/:agentId/reset-health endpoint to reset agent health state
  * Circuit breaker now filters out pre-reset job history when evaluating quarantine status

* **Tests**
  * Added comprehensive test coverage for health reset functionality and circuit breaker behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->