### PR TITLE
fix(agent): wire credentialService into worker so bound LLM credentials are resolved

### DIFF
--- a/packages/control-plane/src/__tests__/agent-execute-credential-wiring.test.ts
+++ b/packages/control-plane/src/__tests__/agent-execute-credential-wiring.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for credential wiring in agent-execute (issue #444).
+ *
+ * Verifies:
+ * - credentialService is used to resolve LLM credentials from agent_credential_binding
+ * - llmCredential is set on the task when a binding + valid token exist
+ * - Falls back gracefully when no binding exists
+ * - Falls back gracefully when getAccessToken returns null
+ */
+
+import type {
+  BackendRegistry,
+  ExecutionHandle,
+  ExecutionResult,
+  ExecutionTask,
+  OutputEvent,
+} from "@cortex/shared/backends"
+import { describe, expect, it, vi } from "vitest"
+
+import type { CredentialService } from "../auth/credential-service.js"
+import { type AgentExecuteDeps, createAgentExecuteTask } from "../worker/tasks/agent-execute.js"
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function createMockResult(overrides: Partial<ExecutionResult> = {}): ExecutionResult {
+  return {
+    taskId: "test-task",
+    status: "completed",
+    exitCode: 0,
+    summary: "done",
+    fileChanges: [],
+    stdout: "",
+    stderr: "",
+    tokenUsage: {
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.001,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    },
+    artifacts: [],
+    durationMs: 500,
+    ...overrides,
+  }
+}
+
+function createMockHandle(
+  result: ExecutionResult = createMockResult(),
+  events: OutputEvent[] = [],
+): ExecutionHandle {
+  return {
+    taskId: result.taskId,
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async *events() {
+      for (const event of events) {
+        yield event
+      }
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async result() {
+      return result
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async cancel() {
+      // no-op
+    },
+  }
+}
+
+interface MockDbOptions {
+  job?: Record<string, unknown> | null
+  agent?: Record<string, unknown> | null
+  recentJobs?: Array<{ status: string }>
+  /** The binding row returned by selectFrom("agent_credential_binding")...executeTakeFirst() */
+  credentialBinding?: Record<string, unknown> | null
+}
+
+function makeMockDb(opts: MockDbOptions = {}) {
+  const defaultJob = {
+    id: "job-1",
+    agent_id: "agent-1",
+    status: "SCHEDULED",
+    attempt: 0,
+    max_attempts: 3,
+    timeout_seconds: 300,
+    session_id: null,
+    payload: { prompt: "test task", goalType: "code_edit" },
+    error: null,
+    result: null,
+    started_at: null,
+    completed_at: null,
+    heartbeat_at: null,
+    approval_expires_at: null,
+  }
+
+  const defaultAgent = {
+    id: "agent-1",
+    name: "TestAgent",
+    slug: "test-agent",
+    role: "developer",
+    description: null,
+    status: "ACTIVE",
+    model_config: {},
+    skill_config: {},
+    resource_limits: {},
+    config: null,
+    health_reset_at: null,
+  }
+
+  const job = opts.job !== undefined ? opts.job : defaultJob
+  const agent = opts.agent !== undefined ? opts.agent : defaultAgent
+  const recentJobs = opts.recentJobs ?? []
+  const credentialBinding = opts.credentialBinding ?? null
+
+  function createChain(tableName: string, isSelect: boolean) {
+    const chain: Record<string, unknown> = {}
+
+    for (const method of [
+      "select",
+      "selectAll",
+      "set",
+      "where",
+      "innerJoin",
+      "returning",
+      "orderBy",
+      "limit",
+    ]) {
+      chain[method] = vi.fn().mockReturnValue(chain)
+    }
+
+    chain.executeTakeFirst = vi.fn().mockImplementation(() => {
+      if (tableName === "job") return Promise.resolve(job)
+      if (tableName === "agent") return Promise.resolve(agent)
+      if (tableName === "agent_credential_binding") return Promise.resolve(credentialBinding)
+      if (tableName === "approval_request") return Promise.resolve(null)
+      return Promise.resolve(null)
+    })
+
+    chain.executeTakeFirstOrThrow = vi.fn().mockImplementation(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return (chain.executeTakeFirst as ReturnType<typeof vi.fn>)()
+    })
+
+    chain.execute = vi.fn().mockImplementation(() => {
+      if (isSelect && tableName === "job") {
+        return Promise.resolve(recentJobs)
+      }
+      return Promise.resolve([])
+    })
+
+    return chain
+  }
+
+  const db = {
+    selectFrom: vi.fn((table: string) => createChain(table, true)),
+    updateTable: vi.fn((table: string) => createChain(table, false)),
+  }
+
+  return db
+}
+
+function makeMockRegistry(handle: ExecutionHandle = createMockHandle()) {
+  const executeTaskSpy = vi.fn().mockResolvedValue(handle)
+  return {
+    registry: {
+      routeTask: vi.fn().mockReturnValue({
+        backend: {
+          backendId: "mock-backend",
+          executeTask: executeTaskSpy,
+        },
+        providerId: "mock-provider",
+      }),
+      acquirePermit: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      recordOutcome: vi.fn(),
+    } as unknown as BackendRegistry,
+    executeTaskSpy,
+  }
+}
+
+function makeMockHelpers() {
+  return {
+    addJob: vi.fn(),
+    job: { id: "worker-job-1" },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    withPgClient: vi.fn(),
+  }
+}
+
+function makeMockCredentialService(
+  getAccessTokenResult: { token: string; credentialId: string } | null = {
+    token: "resolved-oauth-token",
+    credentialId: "cred-abc",
+  },
+) {
+  return {
+    getAccessToken: vi.fn().mockResolvedValue(getAccessTokenResult),
+    getToolSecret: vi.fn().mockResolvedValue(null),
+  } as unknown as CredentialService
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("agent-execute credential wiring (#444)", () => {
+  it("resolves llmCredential from agent_credential_binding when credentialService is provided", async () => {
+    const db = makeMockDb({
+      credentialBinding: {
+        user_account_id: "user-owner-1",
+        provider: "google-antigravity",
+        credential_class: "llm_provider",
+      },
+    })
+    const { registry, executeTaskSpy } = makeMockRegistry()
+    const credentialService = makeMockCredentialService()
+
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+      credentialService,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // Verify getAccessToken was called with the binding's user + provider
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(credentialService.getAccessToken).toHaveBeenCalledWith(
+      "user-owner-1",
+      "google-antigravity",
+    )
+
+    // Verify the task passed to executeTask has llmCredential set
+    expect(executeTaskSpy).toHaveBeenCalled()
+    const executedTask = executeTaskSpy.mock.calls[0][0] as ExecutionTask
+    expect(executedTask.constraints.llmCredential).toEqual({
+      provider: "google-antigravity",
+      token: "resolved-oauth-token",
+      credentialId: "cred-abc",
+    })
+  })
+
+  it("falls back to env var when no credential binding exists", async () => {
+    const db = makeMockDb({
+      credentialBinding: null, // No binding
+    })
+    const { registry, executeTaskSpy } = makeMockRegistry()
+    const credentialService = makeMockCredentialService()
+
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+      credentialService,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // getAccessToken should NOT be called when there's no binding
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(credentialService.getAccessToken).not.toHaveBeenCalled()
+
+    // Task should not have llmCredential set
+    expect(executeTaskSpy).toHaveBeenCalled()
+    const executedTask = executeTaskSpy.mock.calls[0][0] as ExecutionTask
+    expect(executedTask.constraints.llmCredential).toBeUndefined()
+  })
+
+  it("falls back gracefully when getAccessToken returns null", async () => {
+    const db = makeMockDb({
+      credentialBinding: {
+        user_account_id: "user-owner-1",
+        provider: "google-antigravity",
+        credential_class: "llm_provider",
+      },
+    })
+    const { registry, executeTaskSpy } = makeMockRegistry()
+    const credentialService = makeMockCredentialService(null) // Token resolution fails
+
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+      credentialService,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // getAccessToken was called but returned null
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(credentialService.getAccessToken).toHaveBeenCalled()
+
+    // Task should not have llmCredential (falls back to env var)
+    expect(executeTaskSpy).toHaveBeenCalled()
+    const executedTask = executeTaskSpy.mock.calls[0][0] as ExecutionTask
+    expect(executedTask.constraints.llmCredential).toBeUndefined()
+  })
+
+  it("proceeds without credential resolution when credentialService is not injected", async () => {
+    const db = makeMockDb()
+    const { registry, executeTaskSpy } = makeMockRegistry()
+
+    // No credentialService provided — simulates the pre-fix behavior
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // Task should be dispatched, just without llmCredential
+    expect(executeTaskSpy).toHaveBeenCalled()
+    const executedTask = executeTaskSpy.mock.calls[0][0] as ExecutionTask
+    expect(executedTask.constraints.llmCredential).toBeUndefined()
+  })
+})

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -110,6 +110,10 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
   const eventEmitter = new AgentEventEmitter(db, sseManager)
   const executionRegistry = new ExecutionRegistry()
 
+  // Credential service — must be created before worker so agent_execute can
+  // resolve per-job LLM credentials from agent_credential_binding (#444).
+  const credentialService = config.auth ? new CredentialService(db, config.auth) : undefined
+
   // Start Graphile Worker alongside Fastify — shared pg.Pool
   const runner = await createWorker({
     pgPool: pool,
@@ -120,6 +124,7 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
     concurrency: config.workerConcurrency,
     mcpToolRouter,
     authConfig: config.auth,
+    credentialService,
     eventEmitter,
     executionRegistry,
   })
@@ -163,13 +168,11 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
   // Load auth configuration for approval gate endpoints
   const authConfig = loadAuthConfig()
 
-  // Session service + credential service (if OAuth is configured)
+  // Session service (if OAuth is configured)
   let sessionService: SessionService | undefined
-  let credentialService: CredentialService | undefined
 
   if (config.auth) {
     sessionService = new SessionService(db, config.auth.sessionMaxAge)
-    credentialService = new CredentialService(db, config.auth)
 
     // Clean up expired sessions on startup
     sessionService.cleanupExpired().catch(() => {

--- a/packages/control-plane/src/worker/index.ts
+++ b/packages/control-plane/src/worker/index.ts
@@ -15,6 +15,7 @@ import { run, type Runner, type TaskList } from "graphile-worker"
 import type { Kysely } from "kysely"
 import type { Pool } from "pg"
 
+import type { CredentialService } from "../auth/credential-service.js"
 import type { AuthOAuthConfig } from "../config.js"
 import type { Database } from "../db/types.js"
 import type { McpToolRouter } from "../mcp/tool-router.js"
@@ -45,6 +46,8 @@ export interface WorkerOptions {
   eventEmitter?: AgentEventEmitter
   /** Optional execution registry for tracking in-flight handles. */
   executionRegistry?: ExecutionRegistry
+  /** Optional credential service for resolving per-job LLM credentials from agent bindings. */
+  credentialService?: CredentialService
 }
 
 /**
@@ -64,6 +67,7 @@ export async function createWorker(options: WorkerOptions): Promise<Runner> {
     authConfig,
     eventEmitter,
     executionRegistry,
+    credentialService,
   } = options
 
   const workerConcurrency =
@@ -77,6 +81,7 @@ export async function createWorker(options: WorkerOptions): Promise<Runner> {
       sessionBufferFactory,
       memoryExtractThreshold,
       mcpToolRouter,
+      credentialService,
       eventEmitter,
       executionRegistry,
     }),

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -392,6 +392,13 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                 const cs = credentialService
                 const auditCtx = { agentId: agent.id, jobId: job.id }
                 tokenRefresher = buildTokenRefresher(cs, db, auditCtx)
+              } else {
+                rootSpan.addEvent("credential_unusable", {
+                  "cortex.credential.provider": binding.provider,
+                  "cortex.credential.reason":
+                    "Bound LLM credential exists but getAccessToken returned null " +
+                    "(token may be expired, revoked, or missing)",
+                })
               }
             }
             // If no binding exists, fall back to env var LLM_API_KEY (backward compat)


### PR DESCRIPTION
## Summary
Fixes #444

- `credentialService` was never passed through `WorkerOptions` → `createAgentExecuteTask`, so the credential resolution block (`if (credentialService)`) was always skipped
- Agents with active `agent_credential_binding` rows fell through to the generic "No LLM credential available" error despite visible bindings via the API
- Moved `CredentialService` construction above `createWorker` in `app.ts` (was created after), added it to `WorkerOptions`, and forwarded it to `createAgentExecuteTask`
- Added a tracing span event when a binding exists but `getAccessToken` returns null, so operators can see *why* the credential was unusable (expired, revoked, etc.)

## Test plan
- [x] New unit tests: `agent-execute-credential-wiring.test.ts` (4 tests covering binding resolution, no-binding fallback, null-token fallback, missing-service backward compat)
- [x] Existing tests: all 1640 tests pass (97 files)
- [x] Lint: 0 errors
- [x] Typecheck: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credentials are now properly resolved and applied during task execution.
  * System reports when credentials become unusable (expired, revoked, or missing).

* **Tests**
  * Added comprehensive tests validating credential binding and resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->