### PR TITLE
fix(authz): surface denial feedback and operator visibility for allowlist agents (#448)

### DIFF
--- a/packages/control-plane/src/__tests__/agent-routes.test.ts
+++ b/packages/control-plane/src/__tests__/agent-routes.test.ts
@@ -78,6 +78,7 @@ function mockDb(
     agents?: Record<string, unknown>[]
     jobs?: Record<string, unknown>[]
     agentEvents?: Record<string, unknown>[]
+    grantRows?: Record<string, unknown>[]
     insertedAgent?: Record<string, unknown>
     updatedAgent?: Record<string, unknown> | null
     insertedJob?: Record<string, unknown>
@@ -87,6 +88,7 @@ function mockDb(
     agents = [makeAgent()],
     jobs = [],
     agentEvents = [],
+    grantRows = [],
     insertedAgent = makeAgent(),
     updatedAgent = makeAgent(),
     insertedJob = makeJob(),
@@ -112,20 +114,22 @@ function mockDb(
     const selectAll = vi
       .fn()
       .mockReturnValue({ where: whereFn, orderBy, limit, offset, ...terminal })
-    // Count queries use select(fn.countAll().as("total")) — return { total: rows.length }
+    // Count queries use select(fn.countAll().as("total"|"cnt")) — return { total, cnt }
     // Regular selects (e.g. select("id")) still need where/executeTakeFirst
-    const countResult = { total: rows.length }
+    const countResult = { total: rows.length, cnt: rows.length }
     const selectTerminal = {
       executeTakeFirst,
       executeTakeFirstOrThrow: vi.fn().mockResolvedValue(countResult),
       execute,
     }
+    const groupBy = vi.fn().mockReturnValue(selectTerminal)
     const selectWhereFn: ReturnType<typeof vi.fn> = vi.fn()
     selectWhereFn.mockReturnValue({
       where: selectWhereFn,
+      groupBy,
       ...selectTerminal,
     })
-    const select = vi.fn().mockReturnValue({ where: selectWhereFn, ...selectTerminal })
+    const select = vi.fn().mockReturnValue({ where: selectWhereFn, groupBy, ...selectTerminal })
     return { selectAll, select }
   }
 
@@ -156,6 +160,7 @@ function mockDb(
       if (table === "agent") return selectChain(agents)
       if (table === "job") return selectChain(jobs)
       if (table === "agent_event") return selectChain(agentEvents)
+      if (table === "agent_user_grant") return selectChain(grantRows)
       return selectChain([])
     }),
     insertInto: vi.fn().mockImplementation((table: string) => {
@@ -387,6 +392,86 @@ describe("GET /agents/:id", () => {
     const cs = body.costSummary as { byModel: Record<string, number> }
     expect(cs.byModel["claude-3-opus"]).toBeCloseTo(0.012)
     expect(cs.byModel["claude-3-sonnet"]).toBeCloseTo(0.005)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: authWarnings + grantCount (#448)
+// ---------------------------------------------------------------------------
+
+describe("authWarnings and grantCount (#448)", () => {
+  it("GET /agents includes authWarnings for allowlist agent with zero grants", async () => {
+    const { app } = await buildTestApp({
+      agents: [makeAgent({ auth_model: "allowlist" })],
+      grantRows: [],
+    })
+
+    const res = await app.inject({ method: "GET", url: "/agents" })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const agent = body.agents[0] as Record<string, unknown>
+    expect(agent.grantCount).toBe(0)
+    expect(agent.authWarnings).toEqual([
+      "Allowlist agent has zero grants — all messages will be denied.",
+    ])
+  })
+
+  it("GET /agents returns empty authWarnings for open agent", async () => {
+    const { app } = await buildTestApp({
+      agents: [makeAgent({ auth_model: "open" })],
+    })
+
+    const res = await app.inject({ method: "GET", url: "/agents" })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const agent = body.agents[0] as Record<string, unknown>
+    expect(agent.authWarnings).toEqual([])
+  })
+
+  it("GET /agents/:id includes authWarnings for allowlist agent with zero grants", async () => {
+    const { app } = await buildTestApp({
+      agents: [makeAgent({ auth_model: "allowlist" })],
+      grantRows: [],
+    })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.grantCount).toBe(0)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.authWarnings).toEqual([
+      "Allowlist agent has zero grants — all messages will be denied.",
+    ])
+  })
+
+  it("GET /agents/:id returns empty authWarnings when allowlist agent has grants", async () => {
+    const { app } = await buildTestApp({
+      agents: [makeAgent({ auth_model: "allowlist" })],
+      grantRows: [{ agent_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", cnt: 2 }],
+    })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.authWarnings).toEqual([])
   })
 })
 

--- a/packages/control-plane/src/__tests__/message-dispatch.test.ts
+++ b/packages/control-plane/src/__tests__/message-dispatch.test.ts
@@ -7,6 +7,7 @@ import type { RateLimitDecision, UserRateLimiter } from "../auth/user-rate-limit
 import type { AgentChannelService } from "../channels/agent-channel-service.js"
 import { createMessageDispatch, watchJobCompletion } from "../channels/message-dispatch.js"
 import type { Database } from "../db/types.js"
+import type { AgentEventEmitter } from "../observability/event-emitter.js"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -148,6 +149,15 @@ function mockUserRateLimiter(decision: RateLimitDecision) {
     recordUsage: vi.fn().mockResolvedValue(undefined),
     getUsageSummary: vi.fn(),
   } as unknown as UserRateLimiter
+}
+
+function mockEventEmitter() {
+  return {
+    emit: vi.fn().mockResolvedValue({ eventId: "evt-1" }),
+    emitStart: vi.fn(),
+    flush: vi.fn(),
+    dispose: vi.fn(),
+  } as unknown as AgentEventEmitter
 }
 
 // ---------------------------------------------------------------------------
@@ -629,6 +639,75 @@ describe("ChannelAuthGuard integration", () => {
     expect(enqueueJob).toHaveBeenCalled()
   })
 
+  it("emits message_denied event when guard denies access", async () => {
+    const guard = mockChannelAuthGuard({
+      allowed: false,
+      userId: "user-111",
+      reason: "denied",
+      replyToUser: "This agent is private.",
+    })
+    const emitter = mockEventEmitter()
+    const agentChannelService = mockAgentChannelService("agent-aaa")
+    const router = mockRouter()
+    const enqueueJob = vi.fn()
+    const logger = { info: vi.fn(), warn: vi.fn() }
+    const db = mockDb({ existingSession: { id: "session-1" } })
+
+    const dispatch = createMessageDispatch({
+      db,
+      agentChannelService,
+      router: router as never,
+      enqueueJob,
+      channelAuthGuard: guard,
+      eventEmitter: emitter,
+      logger,
+    })
+
+    await dispatch(makeRoutedMessage())
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(emitter.emit).toHaveBeenCalledWith({
+      agentId: "agent-aaa",
+      eventType: "message_denied",
+      actor: "system",
+      payload: {
+        reason: "denied",
+        channelType: "telegram",
+        chatId: "chat-42",
+        userId: "user-111",
+      },
+    })
+  })
+
+  it("does not emit event when no eventEmitter provided", async () => {
+    const guard = mockChannelAuthGuard({
+      allowed: false,
+      userId: "user-111",
+      reason: "denied",
+      replyToUser: "Private.",
+    })
+    const agentChannelService = mockAgentChannelService("agent-aaa")
+    const router = mockRouter()
+    const enqueueJob = vi.fn()
+    const logger = { info: vi.fn(), warn: vi.fn() }
+    const db = mockDb({ existingSession: { id: "session-1" } })
+
+    const dispatch = createMessageDispatch({
+      db,
+      agentChannelService,
+      router: router as never,
+      enqueueJob,
+      channelAuthGuard: guard,
+      // no eventEmitter
+      logger,
+    })
+
+    // Should not throw
+    await dispatch(makeRoutedMessage())
+
+    expect(router.send).toHaveBeenCalled()
+  })
+
   it("skips guard when channelAuthGuard is not provided", async () => {
     const agentChannelService = mockAgentChannelService("agent-aaa")
     const router = mockRouter()
@@ -734,6 +813,53 @@ describe("UserRateLimiter integration", () => {
       text: "You've reached the token budget (100000 tokens per day). Please try again later.",
     })
     expect(enqueueJob).not.toHaveBeenCalled()
+  })
+
+  it("emits message_denied event when rate limit exceeded", async () => {
+    const guard = mockChannelAuthGuard({
+      allowed: true,
+      userId: "user-111",
+      grantId: "grant-999",
+      reason: "granted",
+    })
+    const rateLimiter = mockUserRateLimiter({
+      allowed: false,
+      reason: "rate_limited",
+      replyToUser: "Rate limited.",
+      retryAfterSeconds: 3600,
+    })
+    const emitter = mockEventEmitter()
+    const agentChannelService = mockAgentChannelService("agent-aaa")
+    const router = mockRouter()
+    const enqueueJob = vi.fn()
+    const logger = { info: vi.fn(), warn: vi.fn() }
+    const db = mockDb({ existingSession: { id: "session-1" } })
+
+    const dispatch = createMessageDispatch({
+      db,
+      agentChannelService,
+      router: router as never,
+      enqueueJob,
+      channelAuthGuard: guard,
+      userRateLimiter: rateLimiter,
+      eventEmitter: emitter,
+      logger,
+    })
+
+    await dispatch(makeRoutedMessage())
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(emitter.emit).toHaveBeenCalledWith({
+      agentId: "agent-aaa",
+      eventType: "message_denied",
+      actor: "system",
+      payload: {
+        reason: "rate_limited",
+        channelType: "telegram",
+        chatId: "chat-42",
+        userId: "user-111",
+      },
+    })
   })
 
   it("allows message through when rate limiter approves", async () => {

--- a/packages/control-plane/src/channels/message-dispatch.ts
+++ b/packages/control-plane/src/channels/message-dispatch.ts
@@ -20,6 +20,7 @@ import type { Kysely } from "kysely"
 import type { AuthDecision, ChannelAuthGuard } from "../auth/channel-auth-guard.js"
 import type { UserRateLimiter } from "../auth/user-rate-limiter.js"
 import type { Database, RateLimit, TokenBudget } from "../db/types.js"
+import type { AgentEventEmitter } from "../observability/event-emitter.js"
 import type { AgentChannelService } from "./agent-channel-service.js"
 
 /** Pattern matching pairing codes (6-char uppercase alphanumeric). */
@@ -32,6 +33,7 @@ export interface MessageDispatchDeps {
   enqueueJob: (jobId: string) => Promise<void>
   channelAuthGuard?: ChannelAuthGuard
   userRateLimiter?: UserRateLimiter
+  eventEmitter?: AgentEventEmitter
   logger?: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void }
 }
 
@@ -66,6 +68,7 @@ export function createMessageDispatch(
     enqueueJob,
     channelAuthGuard,
     userRateLimiter,
+    eventEmitter,
     logger = console,
   } = deps
 
@@ -112,6 +115,19 @@ export function createMessageDispatch(
         if (authDecision.replyToUser) {
           await router.send(channelType, chatId, { text: authDecision.replyToUser })
         }
+        if (eventEmitter) {
+          await eventEmitter.emit({
+            agentId,
+            eventType: "message_denied",
+            actor: "system",
+            payload: {
+              reason: authDecision.reason,
+              channelType,
+              chatId,
+              userId: authDecision.userId,
+            },
+          })
+        }
         logger.info(
           { agentId, channelType, chatId, reason: authDecision.reason },
           "Message blocked by ChannelAuthGuard",
@@ -142,6 +158,19 @@ export function createMessageDispatch(
       if (!rateLimitDecision.allowed) {
         if (rateLimitDecision.replyToUser) {
           await router.send(channelType, chatId, { text: rateLimitDecision.replyToUser })
+        }
+        if (eventEmitter) {
+          await eventEmitter.emit({
+            agentId,
+            eventType: "message_denied",
+            actor: "system",
+            payload: {
+              reason: rateLimitDecision.reason,
+              channelType,
+              chatId,
+              userId: authDecision.userId,
+            },
+          })
         }
         logger.info(
           { agentId, channelType, chatId, reason: rateLimitDecision.reason },

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -788,6 +788,7 @@ export type AgentEventType =
   | "kill_requested"
   | "checkpoint_created"
   | "error"
+  | "message_denied"
   | "session_start"
   | "session_end"
 

--- a/packages/control-plane/src/routes/agents.ts
+++ b/packages/control-plane/src/routes/agents.ts
@@ -207,9 +207,10 @@ export function agentRoutes(deps: AgentRouteDeps) {
 
         const costMap = new Map<string, number>()
         const jobMap = new Map<string, string>()
+        const grantCountMap = new Map<string, number>()
 
         if (agents.length > 0) {
-          const [costEvents, runningJobs] = await Promise.all([
+          const [costEvents, runningJobs, grantCounts] = await Promise.all([
             db
               .selectFrom("agent_event")
               .selectAll()
@@ -222,6 +223,13 @@ export function agentRoutes(deps: AgentRouteDeps) {
               .where("agent_id", "in", agentIds)
               .where("status", "=", "RUNNING" as JobStatus)
               .execute(),
+            db
+              .selectFrom("agent_user_grant")
+              .select(["agent_id", db.fn.countAll<number>().as("cnt")])
+              .where("agent_id", "in", agentIds)
+              .where("revoked_at", "is", null)
+              .groupBy("agent_id")
+              .execute(),
           ])
 
           for (const e of costEvents) {
@@ -233,16 +241,28 @@ export function agentRoutes(deps: AgentRouteDeps) {
               jobMap.set(j.agent_id, j.id)
             }
           }
+
+          for (const g of grantCounts) {
+            grantCountMap.set(g.agent_id, Number(g.cnt))
+          }
         }
 
         const enrichedAgents = agents.map((a) => {
           const hasRunningJob = jobMap.has(a.id)
+          const authModel = a.auth_model ?? "allowlist"
+          const grantCount = grantCountMap.get(a.id) ?? 0
+          const authWarnings: string[] = []
+          if (authModel === "allowlist" && grantCount === 0) {
+            authWarnings.push("Allowlist agent has zero grants — all messages will be denied.")
+          }
           return {
             ...a,
             lifecycle_state: deriveLifecycleState(a.status, hasRunningJob),
             costToday: costMap.get(a.id) ?? 0,
             healthStatus: mapAgentHealthStatus(a.status),
             runningJobId: jobMap.get(a.id) ?? null,
+            grantCount,
+            authWarnings,
           }
         })
 
@@ -286,8 +306,8 @@ export function agentRoutes(deps: AgentRouteDeps) {
           return reply.status(404).send({ error: "not_found", message: "Agent not found" })
         }
 
-        // Fetch latest job, events, and running job in parallel
-        const [latestJob, agentEvents, runningJob] = await Promise.all([
+        // Fetch latest job, events, running job, and active grant count in parallel
+        const [latestJob, agentEvents, runningJob, grantCountRow] = await Promise.all([
           db
             .selectFrom("job")
             .selectAll()
@@ -308,6 +328,12 @@ export function agentRoutes(deps: AgentRouteDeps) {
             .where("status", "=", "RUNNING" as JobStatus)
             .limit(1)
             .executeTakeFirst(),
+          db
+            .selectFrom("agent_user_grant")
+            .select(db.fn.countAll<number>().as("cnt"))
+            .where("agent_id", "=", agent.id)
+            .where("revoked_at", "is", null)
+            .executeTakeFirstOrThrow(),
         ])
 
         // Build cost summary
@@ -351,6 +377,13 @@ export function agentRoutes(deps: AgentRouteDeps) {
           typeof cbConfig?.maxConsecutiveFailures === "number" ? cbConfig.maxConsecutiveFailures : 3
         const tripped = consecutiveFailures >= maxFailures
 
+        const authModel = agent.auth_model ?? "allowlist"
+        const grantCount = Number(grantCountRow.cnt)
+        const authWarnings: string[] = []
+        if (authModel === "allowlist" && grantCount === 0) {
+          authWarnings.push("Allowlist agent has zero grants — all messages will be denied.")
+        }
+
         return reply.status(200).send({
           ...agent,
           lifecycle_state: deriveLifecycleState(agent.status, !!runningJob),
@@ -358,6 +391,8 @@ export function agentRoutes(deps: AgentRouteDeps) {
           costSummary: { totalToday, totalAllTime, byModel },
           healthStatus: mapAgentHealthStatus(agent.status),
           runningJobId: runningJob?.id ?? null,
+          grantCount,
+          authWarnings,
           circuitBreakerState: {
             tripped,
             consecutiveFailures,


### PR DESCRIPTION
## Summary
- Emit `message_denied` agent event on auth/rate-limit denial so operators can see blocked messages in the event stream
- Enrich `GET /agents` and `GET /agents/:id` responses with `grantCount` and `authWarnings` (warns when an allowlist agent has zero grants — all messages will be denied)
- Add `message_denied` to `AgentEventType` union type

## Test plan
- [x] New unit tests for `message_denied` event emission on auth denial (message-dispatch)
- [x] New unit tests for `message_denied` event emission on rate-limit denial (message-dispatch)
- [x] New unit tests for `authWarnings` and `grantCount` in `GET /agents` and `GET /agents/:id` (agent-routes)
- [x] All 1647 existing tests pass
- [x] Lint, typecheck, and build clean

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent list and detail endpoints now expose grant counts and authentication warnings for improved visibility into agent access control.
  * Message denial events are now emitted when access is denied by authorization or rate-limiting checks.

* **Tests**
  * Added comprehensive test coverage for grant-related warnings and message denial event scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->