### PR TITLE
fix(ui/agents): repair Users tab grant management (#449)

### DIFF
--- a/packages/control-plane/src/__tests__/agent-user-routes.test.ts
+++ b/packages/control-plane/src/__tests__/agent-user-routes.test.ts
@@ -231,6 +231,7 @@ function mockDb(opts: MockDbOptions = {}) {
       chain.where = vi.fn().mockReturnValue(chain)
       chain.returningAll = vi.fn().mockReturnValue(chain)
       chain.executeTakeFirst = vi.fn().mockResolvedValue(updatedGrant)
+      chain.executeTakeFirstOrThrow = vi.fn().mockResolvedValue(updatedGrant)
       return chain
     }),
   }
@@ -343,6 +344,28 @@ describe("POST /agents/:agentId/users", () => {
     expect(res.statusCode).toBe(409)
     const body = res.json()
     expect(body.error).toBe("conflict")
+  })
+
+  it("re-activates a revoked grant instead of inserting (re-invite)", async () => {
+    const revokedGrant = makeGrant({ revoked_at: new Date("2026-03-01") })
+    const reactivatedGrant = makeGrant({ revoked_at: null, origin: "dashboard_invite" })
+    const { app, db } = await buildTestApp({
+      existingGrant: revokedGrant,
+      updatedGrant: reactivatedGrant,
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/users`,
+      payload: { user_account_id: USER_ID },
+    })
+
+    expect(res.statusCode).toBe(201)
+    const body = res.json()
+    expect(body.grant).toBeDefined()
+    expect(body.grant.revoked_at).toBeNull()
+    // Should update, not insert
+    expect(db.updateTable).toHaveBeenCalled()
   })
 
   it("validates required user_account_id", async () => {

--- a/packages/control-plane/src/routes/agent-user-routes.ts
+++ b/packages/control-plane/src/routes/agent-user-routes.ts
@@ -207,20 +207,40 @@ export function agentUserRoutes(deps: AgentUserRouteDeps) {
         const body = request.body
         const principal = (request as AuthenticatedRequest).principal
 
-        // Check for duplicate active grant
+        // Check for any existing grant (active or revoked)
         const existing = await db
           .selectFrom("agent_user_grant")
           .selectAll()
           .where("agent_id", "=", agentId)
           .where("user_account_id", "=", body.user_account_id)
-          .where("revoked_at", "is", null)
           .executeTakeFirst()
 
-        if (existing) {
+        if (existing && !existing.revoked_at) {
           return reply.status(409).send({
             error: "conflict",
             message: "User already has an active grant for this agent",
           })
+        }
+
+        // Re-activate a previously revoked grant instead of inserting
+        // (UNIQUE constraint on agent_id + user_account_id prevents duplicates)
+        if (existing) {
+          const grant = await db
+            .updateTable("agent_user_grant")
+            .set({
+              access_level: body.access_level ?? "write",
+              origin: "dashboard_invite" as const,
+              granted_by: principal.userId,
+              rate_limit: body.rate_limit ?? null,
+              token_budget: body.token_budget ?? null,
+              expires_at: body.expires_at ? new Date(body.expires_at) : null,
+              revoked_at: null,
+            })
+            .where("id", "=", existing.id)
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+          return reply.status(201).send({ grant })
         }
 
         const grant = await db

--- a/packages/dashboard/src/__tests__/agent-users.test.ts
+++ b/packages/dashboard/src/__tests__/agent-users.test.ts
@@ -75,20 +75,22 @@ const ACCESS_REQUEST_FIXTURE = {
   channel_mapping_id: "cm-001",
   status: "pending" as const,
   message_preview: "Hello, can I use this agent?",
+  reviewed_by: null,
+  reviewed_at: null,
   deny_reason: null,
   created_at: "2026-03-05T10:00:00.000Z",
-  resolved_at: null,
 }
 
 const PAIRING_CODE_FIXTURE = {
   id: "pc-001",
   agent_id: "a-001",
   code: "ABCD-1234",
-  generated_by: "u-admin",
+  created_by: "u-admin",
   created_at: "2026-03-06T08:00:00.000Z",
   expires_at: "2026-03-07T08:00:00.000Z",
   redeemed_at: null,
   redeemed_by: null,
+  revoked_at: null,
 }
 
 // ---------------------------------------------------------------------------
@@ -140,7 +142,8 @@ describe("Agent-user schema tests", () => {
         ...ACCESS_REQUEST_FIXTURE,
         status: "denied" as const,
         deny_reason: "Not authorized",
-        resolved_at: "2026-03-05T11:00:00.000Z",
+        reviewed_by: "u-admin",
+        reviewed_at: "2026-03-05T11:00:00.000Z",
       }
       const result = AccessRequestSchema.parse(denied)
       expect(result.deny_reason).toBe("Not authorized")

--- a/packages/dashboard/src/lib/schemas/users.ts
+++ b/packages/dashboard/src/lib/schemas/users.ts
@@ -83,9 +83,10 @@ export const AccessRequestSchema = z.object({
   channel_mapping_id: z.string().nullable(),
   status: z.enum(["pending", "approved", "denied"]),
   message_preview: z.string().nullable(),
+  reviewed_by: z.string().nullable(),
+  reviewed_at: z.string().nullable(),
   deny_reason: z.string().nullable(),
   created_at: z.string(),
-  resolved_at: z.string().nullable(),
 })
 
 export type AccessRequest = z.infer<typeof AccessRequestSchema>
@@ -96,13 +97,14 @@ export type AccessRequest = z.infer<typeof AccessRequestSchema>
 
 export const PairingCodeSchema = z.object({
   id: z.string(),
-  agent_id: z.string(),
+  agent_id: z.string().nullable(),
   code: z.string(),
-  generated_by: z.string().nullable(),
+  created_by: z.string(),
   created_at: z.string(),
   expires_at: z.string(),
   redeemed_at: z.string().nullable(),
   redeemed_by: z.string().nullable(),
+  revoked_at: z.string().nullable(),
 })
 
 export type PairingCode = z.infer<typeof PairingCodeSchema>


### PR DESCRIPTION
## Summary

Fixes #449 — Agent Users tab grant management was not functional due to three bugs:

- **AccessRequestSchema field mismatch**: Frontend Zod schema expected `resolved_at` but the DB column is `reviewed_at`. Every `listAccessRequests` call threw a parse error, breaking the pending-approval queue. Also added missing `reviewed_by` field.
- **PairingCodeSchema field mismatch**: Frontend expected `generated_by` but the DB column is `created_by`. Same Zod parse failure broke pairing-code listing. Also added missing `revoked_at` field and fixed `agent_id` nullability.
- **Re-invite of revoked users failed**: `agent_user_grant` has a `UNIQUE(agent_id, user_account_id)` constraint. The POST route only checked for active grants before INSERT, so re-inviting a previously revoked user hit a DB constraint error. Now detects revoked rows and re-activates via UPDATE instead.

## Test plan

- [x] Backend: 24/24 agent-user-routes tests pass (1 new: re-invite scenario)
- [x] Frontend: 26/26 agent-users schema + API client tests pass (fixtures updated)
- [x] Full suite: 1648 backend + 464 dashboard tests pass
- [x] Lint, typecheck, build all clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now reactivate previously revoked grants by re-inviting agents, instead of creating duplicate entries. Active grants remain protected with conflict response as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->