### PR TITLE
fix(quarantine): exclude config errors from circuit breaker failure count (#450)

### DIFF
--- a/packages/control-plane/src/__tests__/agent-execute-circuit-breaker.test.ts
+++ b/packages/control-plane/src/__tests__/agent-execute-circuit-breaker.test.ts
@@ -81,8 +81,8 @@ interface MockDbReturns {
   job?: Record<string, unknown> | null
   /** selectFrom("agent").selectAll().where().executeTakeFirst() — returns the agent record */
   agent?: Record<string, unknown> | null
-  /** selectFrom("job").select("status").where("agent_id",...).orderBy(...).limit(...).execute() — recent jobs */
-  recentJobs?: Array<{ status: string }>
+  /** selectFrom("job").select(["status","error"]).where("agent_id",...).orderBy(...).limit(...).execute() — recent jobs */
+  recentJobs?: Array<{ status: string; error?: Record<string, unknown> | null }>
 }
 
 function makeMockDb(returns: MockDbReturns = {}) {
@@ -398,7 +398,7 @@ describe("agent-execute circuit breaker wiring", () => {
 
     const failedResult = createMockResult({
       status: "failed",
-      error: { message: "Agent crashed", classification: "permanent", partialExecution: false },
+      error: { message: "Agent crashed", classification: "transient", partialExecution: false },
     })
     const handle = createMockHandle(failedResult, events)
     const registry = makeMockRegistry(handle)
@@ -552,6 +552,107 @@ describe("agent-execute circuit breaker wiring", () => {
     await task({ jobId: "job-1" }, makeMockHelpers() as never)
 
     // Should NOT quarantine (3 < 5 threshold)
+    const agentQuarantine = db._setCalls.find(
+      (c) => c.table === "agent" && c.values.status === "QUARANTINED",
+    )
+    expect(agentQuarantine).toBeUndefined()
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(registry.routeTask).toHaveBeenCalled()
+  })
+
+  it("does not count permanent (config) errors toward quarantine (#450)", async () => {
+    // 2 prior runtime failures + this permanent (config) error should NOT quarantine
+    // because permanent errors represent config issues, not runtime failures.
+    const db = makeMockDb({
+      recentJobs: [{ status: "FAILED" }, { status: "FAILED" }],
+    })
+
+    const events: OutputEvent[] = [
+      { type: "text", timestamp: new Date().toISOString(), content: "Working..." },
+    ]
+
+    const failedResult = createMockResult({
+      status: "failed",
+      error: {
+        message: "Authentication failed — invalid API key",
+        classification: "permanent",
+        partialExecution: false,
+      },
+    })
+    const handle = createMockHandle(failedResult, events)
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // Agent should NOT be quarantined — permanent errors are config issues
+    const agentQuarantine = db._setCalls.find(
+      (c) => c.table === "agent" && c.values.status === "QUARANTINED",
+    )
+    expect(agentQuarantine).toBeUndefined()
+  })
+
+  it("skips config-error jobs during hydration (#450)", async () => {
+    // 3 prior FAILED jobs, but 1 has a PERMANENT error category (config error).
+    // Only 2 runtime failures should count → below threshold → no quarantine.
+    const db = makeMockDb({
+      recentJobs: [
+        { status: "FAILED", error: null },
+        { status: "FAILED", error: { category: "PERMANENT", message: "Auth failed" } },
+        { status: "FAILED", error: null },
+      ],
+    })
+
+    const events: OutputEvent[] = [
+      { type: "text", timestamp: new Date().toISOString(), content: "Done" },
+    ]
+    const handle = createMockHandle(createMockResult(), events)
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // Should NOT quarantine pre-dispatch: only 2 runtime failures (< 3 threshold)
+    const agentQuarantine = db._setCalls.find(
+      (c) => c.table === "agent" && c.values.status === "QUARANTINED",
+    )
+    expect(agentQuarantine).toBeUndefined()
+
+    // Backend SHOULD have been called
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(registry.routeTask).toHaveBeenCalled()
+  })
+
+  it("skips CONTEXT_BUDGET_EXCEEDED jobs during hydration (#450)", async () => {
+    // 3 prior FAILED jobs, but 1 has CONTEXT_BUDGET_EXCEEDED (config error).
+    const db = makeMockDb({
+      recentJobs: [
+        { status: "FAILED", error: null },
+        { status: "FAILED", error: { category: "CONTEXT_BUDGET_EXCEEDED", message: "too large" } },
+        { status: "FAILED", error: null },
+      ],
+    })
+
+    const events: OutputEvent[] = [
+      { type: "text", timestamp: new Date().toISOString(), content: "Done" },
+    ]
+    const handle = createMockHandle(createMockResult(), events)
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    // Should NOT quarantine: only 2 runtime failures
     const agentQuarantine = db._setCalls.find(
       (c) => c.table === "agent" && c.values.status === "QUARANTINED",
     )

--- a/packages/control-plane/src/__tests__/error-classifier.test.ts
+++ b/packages/control-plane/src/__tests__/error-classifier.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 
-import { classifyError, type ErrorClassification } from "../worker/error-classifier.js"
+import {
+  classifyError,
+  type ErrorClassification,
+  isConfigErrorCategory,
+} from "../worker/error-classifier.js"
 
 describe("classifyError", () => {
   describe("HTTP status codes", () => {
@@ -212,5 +216,35 @@ describe("classifyError", () => {
       expect(result).toHaveProperty("retryable")
       expect(result).toHaveProperty("message")
     })
+  })
+})
+
+describe("isConfigErrorCategory", () => {
+  it("returns true for PERMANENT", () => {
+    expect(isConfigErrorCategory("PERMANENT")).toBe(true)
+  })
+
+  it("returns true for CONTEXT_BUDGET_EXCEEDED", () => {
+    expect(isConfigErrorCategory("CONTEXT_BUDGET_EXCEEDED")).toBe(true)
+  })
+
+  it("returns true for QUARANTINED", () => {
+    expect(isConfigErrorCategory("QUARANTINED")).toBe(true)
+  })
+
+  it("returns false for TRANSIENT (runtime error)", () => {
+    expect(isConfigErrorCategory("TRANSIENT")).toBe(false)
+  })
+
+  it("returns false for TIMEOUT (runtime error)", () => {
+    expect(isConfigErrorCategory("TIMEOUT")).toBe(false)
+  })
+
+  it("returns false for RESOURCE (runtime error)", () => {
+    expect(isConfigErrorCategory("RESOURCE")).toBe(false)
+  })
+
+  it("returns false for UNKNOWN (runtime error)", () => {
+    expect(isConfigErrorCategory("UNKNOWN")).toBe(false)
   })
 })

--- a/packages/control-plane/src/worker/error-classifier.ts
+++ b/packages/control-plane/src/worker/error-classifier.ts
@@ -130,3 +130,31 @@ export function classifyError(error: unknown): ErrorClassification {
 
   return { category: "UNKNOWN", retryable: true, message: error.message }
 }
+
+// ---------------------------------------------------------------------------
+// Config-error detection (#450)
+// ---------------------------------------------------------------------------
+
+/**
+ * Job error categories that represent configuration / setup problems rather
+ * than runtime execution failures.  These should NOT count toward the
+ * agent-level circuit breaker's consecutive-failure threshold because they
+ * require operator intervention (fix credentials, adjust context budget, etc.)
+ * rather than automatic quarantine.
+ */
+const CONFIG_ERROR_CATEGORIES: ReadonlySet<string> = new Set([
+  "PERMANENT",
+  "CONTEXT_BUDGET_EXCEEDED",
+  "QUARANTINED",
+])
+
+/**
+ * Returns `true` when `category` represents a config / setup error that should
+ * be excluded from the circuit breaker failure counter.
+ *
+ * Accepts the uppercase categories stored in the job `error` JSONB column
+ * (e.g. `"PERMANENT"`, `"CONTEXT_BUDGET_EXCEEDED"`).
+ */
+export function isConfigErrorCategory(category: string): boolean {
+  return CONFIG_ERROR_CATEGORIES.has(category)
+}

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -47,7 +47,7 @@ import type { AgentEventEmitter } from "../../observability/event-emitter.js"
 import type { ExecutionRegistry } from "../../observability/execution-registry.js"
 import type { SSEConnectionManager } from "../../streaming/manager.js"
 import type { AgentOutputPayload } from "../../streaming/types.js"
-import { classifyError } from "../error-classifier.js"
+import { classifyError, isConfigErrorCategory } from "../error-classifier.js"
 import { startHeartbeat } from "../heartbeat.js"
 import { createMemoryScheduler } from "../memory-scheduler.js"
 import { calculateRunAt } from "../retry.js"
@@ -179,9 +179,10 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
         // Hydrate consecutive failure count from recent jobs.
         // If health_reset_at is set, ignore jobs completed before the reset
         // to avoid the quarantine death spiral (#443).
+        // Config/setup errors are excluded from the count (#450).
         let recentJobsQuery = db
           .selectFrom("job")
-          .select("status")
+          .select(["status", "error"])
           .where("agent_id", "=", agent.id)
           .where("completed_at", "is not", null)
 
@@ -192,8 +193,16 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
         const recentJobs = await recentJobsQuery.orderBy("completed_at", "desc").limit(10).execute()
 
         for (const rj of recentJobs) {
-          if (rj.status === "FAILED") agentCB.recordJobFailure()
-          else break
+          if (rj.status === "FAILED") {
+            // Config/setup errors should not count toward quarantine (#450)
+            const errCat = rj.error?.category
+            if (typeof errCat === "string" && isConfigErrorCategory(errCat)) {
+              continue
+            }
+            agentCB.recordJobFailure()
+          } else {
+            break
+          }
         }
 
         // ── Step 1c: Pre-dispatch quarantine check ──
@@ -800,25 +809,31 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
           if (success) {
             agentCB.recordJobSuccess()
           } else {
-            agentCB.recordJobFailure()
-            const postDecision = agentCB.shouldQuarantine()
-            if (postDecision.quarantine) {
-              rootSpan.addEvent("agent_quarantined_post_execution", {
-                "cortex.quarantine.reason": postDecision.reason,
-              })
-              recordCircuitBreakerTrip(agent.id, postDecision.reason)
+            // Config/setup errors (e.g. invalid credentials, permanent backend
+            // rejection) should not push the agent toward quarantine (#450).
+            const isConfig = result.error?.classification === "permanent"
 
-              if (lifecycleManager) {
-                await lifecycleManager.quarantine(agent.id, postDecision.reason).catch(() => {
-                  // best-effort
+            if (!isConfig) {
+              agentCB.recordJobFailure()
+              const postDecision = agentCB.shouldQuarantine()
+              if (postDecision.quarantine) {
+                rootSpan.addEvent("agent_quarantined_post_execution", {
+                  "cortex.quarantine.reason": postDecision.reason,
                 })
-              }
+                recordCircuitBreakerTrip(agent.id, postDecision.reason)
 
-              await db
-                .updateTable("agent")
-                .set({ status: "QUARANTINED" })
-                .where("id", "=", agent.id)
-                .execute()
+                if (lifecycleManager) {
+                  await lifecycleManager.quarantine(agent.id, postDecision.reason).catch(() => {
+                    // best-effort
+                  })
+                }
+
+                await db
+                  .updateTable("agent")
+                  .set({ status: "QUARANTINED" })
+                  .where("id", "=", agent.id)
+                  .execute()
+              }
             }
           }
 
@@ -991,7 +1006,8 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
         }
 
         // ── Circuit breaker: record failure in error path ──
-        if (agentCB && loadedAgentId) {
+        // Config/setup errors should not count toward quarantine (#450).
+        if (agentCB && loadedAgentId && !isConfigErrorCategory(classification.category)) {
           agentCB.recordJobFailure()
           const errDecision = agentCB.shouldQuarantine()
           if (errDecision.quarantine) {


### PR DESCRIPTION
## Summary
- Add `isConfigErrorCategory()` helper to error-classifier that identifies PERMANENT, CONTEXT_BUDGET_EXCEEDED, and QUARANTINED errors as config/setup issues
- Skip config errors in all three circuit breaker recording paths: hydration query, post-execution result, and catch-block error path
- Config errors no longer push agents toward auto-quarantine; only runtime errors (transient, timeout, resource) count toward the consecutive-failure threshold

Closes #450

## Test plan
- [x] New unit tests for `isConfigErrorCategory` (7 cases covering all categories)
- [x] New integration tests: permanent classification excluded from post-execution CB, PERMANENT and CONTEXT_BUDGET_EXCEEDED excluded during hydration
- [x] Existing "quarantines after failed execution at threshold" test updated to use transient classification
- [x] All 1658 tests pass, lint clean, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in the circuit-breaker system to prevent false quarantines by correctly categorizing configuration and setup errors separately from runtime failures, enhancing overall system reliability.

* **Tests**
  * Added comprehensive test coverage for error classification and circuit-breaker quarantine behavior with various error scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->