### PR TITLE
fix(api-client): only set Content-Type when body present (#463)

### DIFF
--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -262,8 +262,9 @@ async function apiFetch<T>(
     maxRetries = MAX_RETRIES,
   } = options
 
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
+  const headers: Record<string, string> = {}
+  if (body) {
+    headers["Content-Type"] = "application/json"
   }
 
   // Session-based CSRF token (stored by auth flow)


### PR DESCRIPTION
Closes #463

Root cause: apiFetch() unconditionally set Content-Type: application/json on all requests. Bodyless DELETE/GET requests triggered Fastify FST_ERR_CTP_EMPTY_JSON_BODY.

Fix: Only set the header when body is defined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request handling by ensuring the Content-Type header is only included when necessary. This resolves potential issues with API calls that don't require a request body.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->