### PR TITLE
feat(oauth): complete Google Antigravity OAuth flow from dashboard

### DIFF
--- a/packages/control-plane/src/__tests__/auth-connect-callback.test.ts
+++ b/packages/control-plane/src/__tests__/auth-connect-callback.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for the /auth/connect/callback/:provider redirect-flow handler.
+ *
+ * Validates that:
+ * - google-antigravity triggers Antigravity project discovery before storing tokens
+ * - other providers store tokens without project discovery
+ */
+import Fastify from "fastify"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockDiscoverProject = vi.hoisted(() => vi.fn().mockResolvedValue("my-gcp-project-123"))
+const mockExchangeCode = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    access_token: "goog-access-token",
+    refresh_token: "goog-refresh-token",
+    expires_in: 3600,
+    token_type: "Bearer",
+    scope: "cloud-platform",
+  }),
+)
+const mockDecodeState = vi.hoisted(() =>
+  vi.fn().mockReturnValue({
+    nonce: "test-nonce",
+    provider: "google-antigravity",
+    flow: "connect",
+  }),
+)
+
+vi.mock("../auth/antigravity-project.js", () => ({
+  discoverAntigravityProject: mockDiscoverProject,
+}))
+
+vi.mock("../auth/oauth-service.js", () => ({
+  exchangeCodeForTokens: mockExchangeCode,
+  decodeOAuthState: mockDecodeState,
+  encodeOAuthState: vi.fn().mockReturnValue("encoded-state"),
+  buildAuthorizeUrl: vi.fn().mockReturnValue("https://accounts.google.com/o/oauth2/v2/auth?test"),
+  fetchUserProfile: vi.fn(),
+  generateCodeVerifier: vi.fn().mockReturnValue("test-verifier"),
+  generateCodeChallenge: vi.fn().mockReturnValue("test-challenge"),
+}))
+
+import type { AuthOAuthConfig } from "../config.js"
+import { authRoutes } from "../routes/auth.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MOCK_AUTH_CONFIG: AuthOAuthConfig = {
+  credentialMasterKey: "test-master-key-32chars-minimum!",
+  dashboardUrl: "http://localhost:3100",
+  sessionMaxAge: 86400,
+  googleAntigravity: {
+    clientId: "test-client-id",
+    clientSecret: "test-client-secret",
+  },
+  googleWorkspace: {
+    clientId: "ws-client-id",
+    clientSecret: "ws-client-secret",
+  },
+}
+
+function mockCredentialService() {
+  return {
+    storeOAuthCredential: vi.fn().mockResolvedValue({
+      id: "cred-1",
+      provider: "google-antigravity",
+      credentialType: "oauth",
+      status: "active",
+    }),
+  }
+}
+
+function mockSessionService() {
+  return {
+    validateSession: vi.fn().mockResolvedValue({
+      session: {
+        id: "sess-1",
+        csrf_token: "csrf-tok",
+        user_account_id: "user-1",
+        expires_at: new Date(Date.now() + 86400_000),
+        created_at: new Date(),
+        last_active_at: new Date(),
+      },
+      user: {
+        userId: "user-1",
+        role: "operator",
+        displayName: "Test User",
+        email: "test@example.com",
+        avatarUrl: null,
+      },
+    }),
+    validateCsrf: vi.fn().mockReturnValue(true),
+    createSession: vi.fn(),
+    deleteSession: vi.fn(),
+  }
+}
+
+function mockDb() {
+  return {
+    insertInto: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) }),
+    }),
+  }
+}
+
+async function buildTestApp() {
+  const app = Fastify({ logger: false })
+  const credentialService = mockCredentialService()
+  const sessionService = mockSessionService()
+  const db = mockDb()
+
+  await app.register(
+    authRoutes({
+      db: db as never,
+      authConfig: MOCK_AUTH_CONFIG,
+      sessionService: sessionService as never,
+      credentialService: credentialService as never,
+    }),
+  )
+
+  return { app, credentialService, sessionService }
+}
+
+function withSession(headers: Record<string, string> = {}) {
+  return { cookie: "cortex_session=sess-1", ...headers }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /auth/connect/callback/:provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Restore default mock return values after clearAllMocks
+    mockDiscoverProject.mockResolvedValue("my-gcp-project-123")
+    mockExchangeCode.mockResolvedValue({
+      access_token: "goog-access-token",
+      refresh_token: "goog-refresh-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+      scope: "cloud-platform",
+    })
+    mockDecodeState.mockReturnValue({
+      nonce: "test-nonce",
+      provider: "google-antigravity",
+      flow: "connect",
+    })
+  })
+
+  it("calls discoverAntigravityProject for google-antigravity and passes accountId", async () => {
+    const { app, credentialService } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/auth/connect/callback/google-antigravity?code=test-code&state=valid-state",
+      headers: withSession(),
+    })
+
+    // Should redirect to settings with connected param
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe("http://localhost:3100/settings?connected=google-antigravity")
+
+    // discoverAntigravityProject should have been called with the access token
+    expect(mockDiscoverProject).toHaveBeenCalledWith("goog-access-token")
+
+    // storeOAuthCredential should include the discovered accountId
+    expect(credentialService.storeOAuthCredential).toHaveBeenCalledWith(
+      "user-1",
+      "google-antigravity",
+      expect.objectContaining({
+        access_token: "goog-access-token",
+        refresh_token: "goog-refresh-token",
+      }),
+      expect.objectContaining({
+        accountId: "my-gcp-project-123",
+      }),
+    )
+  })
+
+  it("does NOT call discoverAntigravityProject for google-workspace", async () => {
+    mockDecodeState.mockReturnValueOnce({
+      nonce: "test-nonce",
+      provider: "google-workspace",
+      flow: "connect",
+    })
+
+    const { app, credentialService } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/auth/connect/callback/google-workspace?code=test-code&state=valid-state",
+      headers: withSession(),
+    })
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe("http://localhost:3100/settings?connected=google-workspace")
+
+    // discoverAntigravityProject must NOT have been called
+    expect(mockDiscoverProject).not.toHaveBeenCalled()
+
+    // storeOAuthCredential should have accountId undefined
+    expect(credentialService.storeOAuthCredential).toHaveBeenCalledWith(
+      "user-1",
+      "google-workspace",
+      expect.anything(),
+      expect.objectContaining({
+        accountId: undefined,
+        credentialClass: "user_service",
+      }),
+    )
+  })
+
+  it("returns 401 without auth session", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/auth/connect/callback/google-antigravity?code=test-code&state=valid-state",
+      // No session cookie
+    })
+
+    expect(res.statusCode).toBe(401)
+  })
+
+  it("redirects to settings with error on invalid state", async () => {
+    mockDecodeState.mockReturnValueOnce(null)
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/auth/connect/callback/google-antigravity?code=test-code&state=bad-state",
+      headers: withSession(),
+    })
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe("http://localhost:3100/settings?error=invalid_state")
+  })
+
+  it("redirects to settings with error when provider is not configured", async () => {
+    mockDecodeState.mockReturnValueOnce({
+      nonce: "test-nonce",
+      provider: "unknown-provider",
+      flow: "connect",
+    })
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/auth/connect/callback/unknown-provider?code=test-code&state=valid-state",
+      headers: withSession(),
+    })
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe(
+      "http://localhost:3100/settings?error=provider_not_configured",
+    )
+  })
+
+  it("redirects to settings with error on token exchange failure", async () => {
+    mockExchangeCode.mockRejectedValueOnce(new Error("Token exchange failed"))
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/auth/connect/callback/google-antigravity?code=bad-code&state=valid-state",
+      headers: withSession(),
+    })
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe("http://localhost:3100/settings?error=connect_failed")
+  })
+})

--- a/packages/control-plane/src/routes/auth.ts
+++ b/packages/control-plane/src/routes/auth.ts
@@ -322,12 +322,14 @@ export function authRoutes(deps: AuthRouteDeps) {
 
     /**
      * GET /auth/connect/callback/:provider — handle LLM provider OAuth callback
+     * Requires active session (the browser carries the session cookie through the redirect).
      */
     app.get<{
       Params: { provider: string }
       Querystring: { code?: string; state?: string; error?: string }
     }>(
       "/auth/connect/callback/:provider",
+      { preHandler: [requireAuth] },
       async (
         request: FastifyRequest<{
           Params: { provider: string }
@@ -377,9 +379,16 @@ export function authRoutes(deps: AuthRouteDeps) {
             codeVerifier,
           })
 
+          // Provider-specific post-exchange actions
+          let accountId: string | undefined
+          if (provider === "google-antigravity") {
+            accountId = await discoverAntigravityProject(tokens.access_token)
+          }
+
           // Detect credential class and scopes from user service provider registry
           const userServiceDef = getUserServiceProvider(provider)
           await credentialService.storeOAuthCredential(principal.userId, provider, tokens, {
+            accountId,
             credentialClass: userServiceDef?.credentialClass,
             scopes: userServiceDef?.defaultScopes,
           })

--- a/packages/dashboard/src/app/settings/page.tsx
+++ b/packages/dashboard/src/app/settings/page.tsx
@@ -181,12 +181,11 @@ function SettingsInner() {
   const getCredentialForProvider = (providerId: string) =>
     credentials.find((c) => c.provider === providerId)
 
-  // Only show LLM providers in the "Connected Providers" section.
-  // User services (google-workspace, github-user, slack-user) and
-  // tool-specific providers (brave) are managed separately.
+  // Split providers by credential class for separate UI sections.
   const llmProviders = providers.filter(
     (p) => !p.credentialClass || p.credentialClass === "llm_provider",
   )
+  const userServiceProviders = providers.filter((p) => p.credentialClass === "user_service")
 
   return (
     <div className="space-y-8">
@@ -285,6 +284,16 @@ function SettingsInner() {
                   {cred?.maskedKey && (
                     <p className="mt-1 font-mono text-xs text-text-muted">{cred.maskedKey}</p>
                   )}
+                  {cred?.accountId && (
+                    <p className="mt-1 text-xs text-text-muted">
+                      Project: <span className="font-mono">{cred.accountId}</span>
+                    </p>
+                  )}
+                  {cred?.lastUsedAt && (
+                    <p className="mt-0.5 text-xs text-text-muted">
+                      Last used: {new Date(cred.lastUsedAt).toLocaleString()}
+                    </p>
+                  )}
                 </div>
 
                 <div className="flex items-center gap-2">
@@ -338,6 +347,82 @@ function SettingsInner() {
           )}
         </div>
       </section>
+
+      {/* Connected Services (user_service providers) */}
+      {userServiceProviders.length > 0 && (
+        <section className="rounded-xl border border-surface-border bg-surface-light p-6">
+          <h2 className="text-lg font-semibold text-text-main">Connected Services</h2>
+          <p className="mt-1 text-sm text-text-muted">
+            Connect third-party services so agents can act on your behalf.
+          </p>
+
+          <div className="mt-4 space-y-3">
+            {userServiceProviders.map((p) => {
+              const cred = getCredentialForProvider(p.id)
+              return (
+                <div
+                  key={p.id}
+                  className="flex items-center justify-between rounded-lg border border-surface-border p-4"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-semibold text-text-main">{p.name}</span>
+                      {cred ? (
+                        <span
+                          className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-bold uppercase ${
+                            cred.status === "active"
+                              ? "bg-success/10 text-success"
+                              : cred.status === "expired"
+                                ? "bg-warning/10 text-warning"
+                                : "bg-danger/10 text-danger"
+                          }`}
+                        >
+                          {cred.status === "active" ? "Connected" : cred.status}
+                        </span>
+                      ) : (
+                        <span className="inline-block rounded-full bg-secondary px-2 py-0.5 text-[10px] font-bold uppercase text-text-muted">
+                          Not Connected
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-text-muted">{p.description}</p>
+                    {cred?.lastUsedAt && (
+                      <p className="mt-0.5 text-xs text-text-muted">
+                        Last used: {new Date(cred.lastUsedAt).toLocaleString()}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    {cred ? (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setDisconnectConfirm({
+                            id: cred.id,
+                            label: credentialLabel(cred, providers),
+                          })
+                        }
+                        className="rounded-lg px-3 py-1.5 text-xs font-medium text-danger hover:bg-danger/10 transition-colors"
+                      >
+                        Disconnect
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => connectOAuth(p.id)}
+                        className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-content hover:bg-primary/90 transition-colors"
+                      >
+                        Connect
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </section>
+      )}
 
       {/* Channels */}
       <ChannelConfigSection />


### PR DESCRIPTION
## Summary

Closes #452

- **Fix missing auth middleware on redirect callback**: `/auth/connect/callback/:provider` was missing `preHandler: [requireAuth]`, so the session cookie was never parsed and `request.principal` was always `undefined` — the callback always redirected to login, making the redirect-based OAuth flow uncompletable.
- **Add Antigravity project discovery to redirect flow**: Call `discoverAntigravityProject()` after token exchange in the redirect callback (matching what the code-paste flow already does), storing the GCP project ID as `accountId`.
- **Dashboard: add Connected Services section**: User service providers (Google Workspace, GitHub, Slack) now appear in their own section with Connect/Disconnect buttons. LLM provider cards now show `accountId` (GCP project) and `lastUsedAt` timestamp.

## Test plan

- [x] New test file `auth-connect-callback.test.ts` (6 tests):
  - Redirect callback calls `discoverAntigravityProject` for google-antigravity and passes `accountId`
  - Redirect callback does NOT call project discovery for other providers (google-workspace)
  - Returns 401 without session cookie
  - Redirects with error on invalid state, unconfigured provider, exchange failure
- [x] Lint clean (`eslint` on changed files)
- [x] Typecheck — no new errors (pre-existing `@cortex/shared/*` errors only)
- [x] Full test suite — 85 passed, 14 failed (all pre-existing `@cortex/shared/*` import failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)