### PR TITLE
feat(ui): explicit Channels ↔ Agent binding flow in dashboard

### DIFF
--- a/packages/control-plane/src/__tests__/agent-channel-service.test.ts
+++ b/packages/control-plane/src/__tests__/agent-channel-service.test.ts
@@ -204,6 +204,47 @@ describe("AgentChannelService", () => {
   })
 
   // ---------------------------------------------------------------------------
+  // Tests: listBindingsByChannelType
+  // ---------------------------------------------------------------------------
+
+  describe("listBindingsByChannelType", () => {
+    it("returns bindings with agent name and slug", async () => {
+      const rows = [
+        {
+          id: "b1",
+          agent_id: "a1",
+          agent_name: "My Agent",
+          agent_slug: "my-agent",
+          channel_type: "telegram",
+          chat_id: "12345",
+          is_default: false,
+          created_at: new Date(),
+        },
+      ]
+
+      const execute = vi.fn().mockResolvedValue(rows)
+      const orderBy = vi.fn().mockReturnValue({ execute })
+      const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+      whereFn.mockReturnValue({ where: whereFn, orderBy, execute })
+      const select = vi.fn().mockReturnValue({ where: whereFn, orderBy, execute })
+      const innerJoin = vi.fn().mockReturnValue({ select })
+
+      const db = {
+        selectFrom: vi.fn().mockReturnValue({ innerJoin }),
+      } as unknown as Kysely<Database>
+
+      const service = new AgentChannelService(db)
+      const result = await service.listBindingsByChannelType("telegram")
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.agent_name).toBe("My Agent")
+      expect(result[0]!.agent_slug).toBe("my-agent")
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(db.selectFrom).toHaveBeenCalledWith("agent_channel_binding")
+    })
+  })
+
+  // ---------------------------------------------------------------------------
   // Tests: setDefault
   // ---------------------------------------------------------------------------
 

--- a/packages/control-plane/src/__tests__/channel-config-routes.test.ts
+++ b/packages/control-plane/src/__tests__/channel-config-routes.test.ts
@@ -1,6 +1,7 @@
 import Fastify from "fastify"
 import { describe, expect, it, vi } from "vitest"
 
+import type { AgentChannelService } from "../channels/agent-channel-service.js"
 import type { ChannelConfigService } from "../channels/channel-config-service.js"
 import type { AuthConfig } from "../middleware/types.js"
 import { channelRoutes } from "../routes/channels.js"
@@ -59,13 +60,28 @@ function mockService(overrides: Partial<ChannelConfigService> = {}): ChannelConf
   } as unknown as ChannelConfigService
 }
 
-async function buildTestApp(serviceOverrides: Partial<ChannelConfigService> = {}) {
+function mockAgentChannelService(
+  overrides: Partial<AgentChannelService> = {},
+): AgentChannelService {
+  return {
+    listBindingsByChannelType: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  } as unknown as AgentChannelService
+}
+
+async function buildTestApp(
+  serviceOverrides: Partial<ChannelConfigService> = {},
+  agentChannelOverrides?: Partial<AgentChannelService>,
+) {
   const app = Fastify({ logger: false })
   const service = mockService(serviceOverrides)
+  const agentChannelService = agentChannelOverrides
+    ? mockAgentChannelService(agentChannelOverrides)
+    : undefined
 
-  await app.register(channelRoutes({ service, authConfig: DEV_AUTH_CONFIG }))
+  await app.register(channelRoutes({ service, agentChannelService, authConfig: DEV_AUTH_CONFIG }))
 
-  return { app, service }
+  return { app, service, agentChannelService }
 }
 
 // ---------------------------------------------------------------------------
@@ -365,5 +381,73 @@ describe("POST /channels/:id/verify", () => {
     const body = res.json()
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(body.error).toBe("upstream_error")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: GET /channels/:id/bindings — list agent bindings for a channel
+// ---------------------------------------------------------------------------
+
+describe("GET /channels/:id/bindings", () => {
+  it("returns bindings with agent info", async () => {
+    const bindings = [
+      {
+        id: "b1",
+        agent_id: "a1",
+        agent_name: "Agent Alpha",
+        agent_slug: "agent-alpha",
+        channel_type: "telegram",
+        chat_id: "12345",
+        is_default: false,
+        created_at: new Date().toISOString(),
+      },
+    ]
+    const { app, agentChannelService } = await buildTestApp(
+      { getById: vi.fn().mockResolvedValue(makeSummary()) },
+      { listBindingsByChannelType: vi.fn().mockResolvedValue(bindings) },
+    )
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/channels/cccccccc-1111-2222-3333-444444444444/bindings",
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.bindings).toHaveLength(1)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.bindings[0].agent_name).toBe("Agent Alpha")
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(agentChannelService!.listBindingsByChannelType).toHaveBeenCalledWith("telegram")
+  })
+
+  it("returns 404 when channel does not exist", async () => {
+    const { app } = await buildTestApp({ getById: vi.fn().mockResolvedValue(undefined) }, {})
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/channels/nonexistent/bindings",
+    })
+
+    expect(res.statusCode).toBe(404)
+  })
+
+  it("returns empty bindings when agentChannelService is not provided", async () => {
+    const { app } = await buildTestApp({
+      getById: vi.fn().mockResolvedValue(makeSummary()),
+    })
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/channels/cccccccc-1111-2222-3333-444444444444/bindings",
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.bindings).toEqual([])
   })
 })

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -251,6 +251,7 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
     await app.register(
       channelRoutes({
         service: channelConfigService,
+        agentChannelService,
         authConfig,
         sessionService,
         reloader: options.channelReloader,

--- a/packages/control-plane/src/channels/agent-channel-service.ts
+++ b/packages/control-plane/src/channels/agent-channel-service.ts
@@ -9,6 +9,18 @@ import type { Kysely } from "kysely"
 
 import type { AgentChannelBinding, Database } from "../db/types.js"
 
+/** Binding row enriched with the agent's name and slug. */
+export interface BindingWithAgent {
+  id: string
+  agent_id: string
+  agent_name: string
+  agent_slug: string
+  channel_type: string
+  chat_id: string
+  is_default: boolean
+  created_at: Date
+}
+
 export class AgentChannelService {
   constructor(private readonly db: Kysely<Database>) {}
 
@@ -88,6 +100,30 @@ export class AgentChannelService {
       .where("agent_id", "=", agentId)
       .orderBy("created_at", "desc")
       .execute()
+  }
+
+  /**
+   * List bindings for a channel type, enriched with agent name/slug.
+   */
+  async listBindingsByChannelType(channelType: string): Promise<BindingWithAgent[]> {
+    const rows = await this.db
+      .selectFrom("agent_channel_binding")
+      .innerJoin("agent", "agent.id", "agent_channel_binding.agent_id")
+      .select([
+        "agent_channel_binding.id",
+        "agent_channel_binding.agent_id",
+        "agent.name as agent_name",
+        "agent.slug as agent_slug",
+        "agent_channel_binding.channel_type",
+        "agent_channel_binding.chat_id",
+        "agent_channel_binding.is_default",
+        "agent_channel_binding.created_at",
+      ])
+      .where("agent_channel_binding.channel_type", "=", channelType)
+      .orderBy("agent_channel_binding.created_at", "desc")
+      .execute()
+
+    return rows as BindingWithAgent[]
   }
 
   /**

--- a/packages/control-plane/src/routes/channels.ts
+++ b/packages/control-plane/src/routes/channels.ts
@@ -12,6 +12,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
 
 import type { SessionService } from "../auth/session-service.js"
+import type { AgentChannelService } from "../channels/agent-channel-service.js"
 import type { ChannelConfigService } from "../channels/channel-config-service.js"
 import type { ChannelReloader } from "../channels/channel-reloader.js"
 import { fetchTelegramBotIdentity } from "../channels/telegram-identity.js"
@@ -56,13 +57,14 @@ const VALID_CHANNEL_TYPES = new Set<string>(["telegram", "discord", "whatsapp"])
 
 export interface ChannelRouteDeps {
   service: ChannelConfigService
+  agentChannelService?: AgentChannelService
   authConfig: AuthConfig
   sessionService?: SessionService
   reloader?: ChannelReloader
 }
 
 export function channelRoutes(deps: ChannelRouteDeps) {
-  const { service, authConfig, sessionService, reloader } = deps
+  const { service, agentChannelService, authConfig, sessionService, reloader } = deps
 
   const authOpts: AuthMiddlewareOptions = { config: authConfig, sessionService }
   const requireAuth: PreHandler = createRequireAuth(authOpts)
@@ -248,6 +250,36 @@ export function channelRoutes(deps: ChannelRouteDeps) {
 
         const channel = await service.update(request.params.id, { bot_metadata: botMetadata })
         return reply.status(200).send({ channel })
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // GET /channels/:id/bindings — List agent bindings for this channel
+    // -----------------------------------------------------------------
+    app.get<{ Params: ChannelIdParams }>(
+      "/channels/:id/bindings",
+      {
+        preHandler: [requireAuth, requireOperator],
+        schema: {
+          params: {
+            type: "object",
+            properties: { id: { type: "string" } },
+            required: ["id"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: ChannelIdParams }>, reply: FastifyReply) => {
+        const channel = await service.getById(request.params.id)
+        if (!channel) {
+          return reply.status(404).send({ error: "not_found", message: "Channel config not found" })
+        }
+
+        if (!agentChannelService) {
+          return reply.status(200).send({ bindings: [] })
+        }
+
+        const bindings = await agentChannelService.listBindingsByChannelType(channel.type)
+        return reply.status(200).send({ bindings })
       },
     )
 

--- a/packages/dashboard/src/app/agents/[agentId]/page.tsx
+++ b/packages/dashboard/src/app/agents/[agentId]/page.tsx
@@ -269,6 +269,7 @@ export default function AgentDetailPage({ params }: Props): React.JSX.Element {
           <SteerInput agentId={agentId} />
           <AgentConfigPanel agent={liveAgent} onSave={() => void refetch()} />
           <CredentialBindingPanel agentId={agentId} />
+          <ChannelBindingTab agentId={agentId} />
           <LifecycleDetails transitions={transitions} currentState={currentState} />
         </div>
 

--- a/packages/dashboard/src/components/settings/channel-config-section.tsx
+++ b/packages/dashboard/src/components/settings/channel-config-section.tsx
@@ -3,11 +3,17 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 
 import {
+  type AgentSummary,
   ApiError,
+  bindAgentChannel,
+  type BindingWithAgent,
   type ChannelConfigSummary,
   createChannelConfig,
   deleteChannelConfig,
+  listAgents,
+  listChannelBindings,
   listChannelConfigs,
+  unbindAgentChannel,
   updateChannelConfig,
 } from "@/lib/api-client"
 
@@ -50,8 +56,22 @@ export function ChannelConfigSection() {
     id: string
     name: string
     conflict?: string
+    boundAgents?: string[]
   } | null>(null)
   const [deleting, setDeleting] = useState(false)
+
+  // Expanded channel cards showing their bindings
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [channelBindings, setChannelBindings] = useState<Record<string, BindingWithAgent[]>>({})
+  const [loadingBindings, setLoadingBindings] = useState<string | null>(null)
+
+  // Bind-to-agent modal
+  const [bindTarget, setBindTarget] = useState<ChannelConfigSummary | null>(null)
+  const [agents, setAgents] = useState<AgentSummary[]>([])
+  const [loadingAgents, setLoadingAgents] = useState(false)
+  const [bindForm, setBindForm] = useState({ agentId: "", chatId: "", isDefault: false })
+  const [binding, setBinding] = useState(false)
+  const [bindError, setBindError] = useState<string | null>(null)
 
   const fetchChannels = useCallback(async () => {
     try {
@@ -67,6 +87,30 @@ export function ChannelConfigSection() {
   useEffect(() => {
     void fetchChannels()
   }, [fetchChannels])
+
+  const fetchBindingsForChannel = useCallback(async (channelId: string) => {
+    setLoadingBindings(channelId)
+    try {
+      const res = await listChannelBindings(channelId)
+      setChannelBindings((prev) => ({ ...prev, [channelId]: res.bindings ?? [] }))
+    } catch {
+      setChannelBindings((prev) => ({ ...prev, [channelId]: [] }))
+    } finally {
+      setLoadingBindings(null)
+    }
+  }, [])
+
+  const handleToggleExpand = useCallback(
+    (ch: ChannelConfigSummary) => {
+      if (expandedId === ch.id) {
+        setExpandedId(null)
+        return
+      }
+      setExpandedId(ch.id)
+      void fetchBindingsForChannel(ch.id)
+    },
+    [expandedId, fetchBindingsForChannel],
+  )
 
   const handleCreate = useCallback(async () => {
     setSaving(true)
@@ -106,14 +150,25 @@ export function ChannelConfigSection() {
       try {
         await deleteChannelConfig(id, force ? { force: true } : undefined)
         setDeleteConfirm(null)
+        if (expandedId === id) setExpandedId(null)
         void fetchChannels()
       } catch (err) {
         if (err instanceof ApiError && err.status === 409) {
           const ch = channels.find((c) => c.id === id)
+          // Fetch bound agents to display in the confirmation dialog
+          let boundAgents: string[] = []
+          try {
+            const res = await listChannelBindings(id)
+            const agentNames = [...new Set(res.bindings.map((b) => b.agent_name))]
+            boundAgents = agentNames
+          } catch {
+            // fall back to generic conflict message
+          }
           setDeleteConfirm({
             id,
             name: ch?.name ?? id,
             conflict: err.message,
+            boundAgents,
           })
         } else {
           setError(err instanceof Error ? err.message : "Failed to delete channel")
@@ -122,7 +177,54 @@ export function ChannelConfigSection() {
         setDeleting(false)
       }
     },
-    [fetchChannels, channels],
+    [fetchChannels, channels, expandedId],
+  )
+
+  const handleOpenBindModal = useCallback(async (ch: ChannelConfigSummary) => {
+    setBindTarget(ch)
+    setBindForm({ agentId: "", chatId: "", isDefault: false })
+    setBindError(null)
+    setLoadingAgents(true)
+    try {
+      const res = await listAgents({ status: "ACTIVE" })
+      setAgents(res.agents ?? [])
+    } catch {
+      setAgents([])
+    } finally {
+      setLoadingAgents(false)
+    }
+  }, [])
+
+  const handleBind = useCallback(async () => {
+    if (!bindTarget || !bindForm.agentId || !bindForm.chatId.trim()) return
+    setBinding(true)
+    setBindError(null)
+    try {
+      await bindAgentChannel(bindForm.agentId, bindTarget.type, bindForm.chatId.trim())
+      setBindTarget(null)
+      // Refresh bindings for the expanded channel
+      if (expandedId) {
+        void fetchBindingsForChannel(expandedId)
+      }
+    } catch (err) {
+      setBindError(err instanceof Error ? err.message : "Failed to bind channel")
+    } finally {
+      setBinding(false)
+    }
+  }, [bindTarget, bindForm, expandedId, fetchBindingsForChannel])
+
+  const handleUnbindFromChannel = useCallback(
+    async (b: BindingWithAgent) => {
+      try {
+        await unbindAgentChannel(b.agent_id, b.id)
+        if (expandedId) {
+          void fetchBindingsForChannel(expandedId)
+        }
+      } catch {
+        // silent
+      }
+    },
+    [expandedId, fetchBindingsForChannel],
   )
 
   const isDuplicate = useMemo(
@@ -171,49 +273,124 @@ export function ChannelConfigSection() {
 
       {/* Channel list */}
       <div className="mt-4 space-y-3">
-        {channels.map((ch) => (
-          <div
-            key={ch.id}
-            className="flex items-center justify-between rounded-lg border border-surface-border p-4"
-          >
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-semibold text-text-main">{ch.name}</span>
-                <span className="inline-block rounded-full bg-secondary px-2 py-0.5 text-[10px] font-bold uppercase text-text-muted">
-                  {ch.type}
-                </span>
-                <span
-                  className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-bold uppercase ${ch.enabled ? "bg-success/10 text-success" : "bg-secondary text-text-muted"}`}
+        {channels.map((ch) => {
+          const isExpanded = expandedId === ch.id
+          const bindings = channelBindings[ch.id] ?? []
+          const isLoadingThisBindings = loadingBindings === ch.id
+
+          return (
+            <div key={ch.id} className="rounded-lg border border-surface-border">
+              {/* Channel header row */}
+              <div className="flex items-center justify-between p-4">
+                <button
+                  type="button"
+                  onClick={() => handleToggleExpand(ch)}
+                  className="min-w-0 flex-1 text-left"
                 >
-                  {ch.enabled ? "Enabled" : "Disabled"}
-                </span>
+                  <div className="flex items-center gap-2">
+                    <span className="material-symbols-outlined text-sm text-text-muted">
+                      {isExpanded ? "expand_more" : "chevron_right"}
+                    </span>
+                    <span className="text-sm font-semibold text-text-main">{ch.name}</span>
+                    <span className="inline-block rounded-full bg-secondary px-2 py-0.5 text-[10px] font-bold uppercase text-text-muted">
+                      {ch.type}
+                    </span>
+                    <span
+                      className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-bold uppercase ${ch.enabled ? "bg-success/10 text-success" : "bg-secondary text-text-muted"}`}
+                    >
+                      {ch.enabled ? "Enabled" : "Disabled"}
+                    </span>
+                    {isExpanded && bindings.length > 0 && (
+                      <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-bold text-primary">
+                        {bindings.length} binding{bindings.length !== 1 ? "s" : ""}
+                      </span>
+                    )}
+                  </div>
+                  {ch.bot_metadata?.username && (
+                    <p className="mt-1 ml-6 text-xs text-text-muted">
+                      Bot: @{ch.bot_metadata.username}
+                      {ch.bot_metadata.display_name ? ` (${ch.bot_metadata.display_name})` : ""}
+                    </p>
+                  )}
+                </button>
+
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void handleOpenBindModal(ch)}
+                    className="rounded-lg px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
+                  >
+                    Bind to Agent
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleToggle(ch)}
+                    className="rounded-lg px-3 py-1.5 text-xs font-medium text-text-muted hover:bg-secondary transition-colors"
+                  >
+                    {ch.enabled ? "Disable" : "Enable"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setDeleteConfirm({ id: ch.id, name: ch.name })}
+                    className="rounded-lg px-3 py-1.5 text-xs font-medium text-danger hover:bg-danger/10 transition-colors"
+                  >
+                    Remove
+                  </button>
+                </div>
               </div>
-              {ch.bot_metadata?.username && (
-                <p className="mt-1 text-xs text-text-muted">
-                  Bot: @{ch.bot_metadata.username}
-                  {ch.bot_metadata.display_name ? ` (${ch.bot_metadata.display_name})` : ""}
-                </p>
+
+              {/* Expanded bindings panel */}
+              {isExpanded && (
+                <div className="border-t border-surface-border bg-surface-dark/30 px-4 py-3">
+                  {isLoadingThisBindings ? (
+                    <div className="flex justify-center py-3">
+                      <div className="size-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                    </div>
+                  ) : bindings.length === 0 ? (
+                    <p className="py-2 text-center text-xs text-text-muted">
+                      No agents bound to this channel type. Click &ldquo;Bind to Agent&rdquo; to
+                      create a binding.
+                    </p>
+                  ) : (
+                    <div className="space-y-2">
+                      <p className="text-[10px] font-bold uppercase tracking-wider text-text-muted">
+                        Agent Bindings
+                      </p>
+                      {bindings.map((b) => (
+                        <div
+                          key={b.id}
+                          className="flex items-center justify-between rounded-lg border border-surface-border bg-surface-light px-3 py-2"
+                        >
+                          <div className="flex items-center gap-2">
+                            <a
+                              href={`/agents/${b.agent_id}`}
+                              className="text-sm font-medium text-primary hover:underline"
+                            >
+                              {b.agent_name}
+                            </a>
+                            <span className="font-mono text-xs text-text-muted">{b.chat_id}</span>
+                            {b.is_default && (
+                              <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-bold uppercase text-primary">
+                                Default
+                              </span>
+                            )}
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => void handleUnbindFromChannel(b)}
+                            className="rounded-lg px-2 py-1 text-xs font-medium text-danger hover:bg-danger/10 transition-colors"
+                          >
+                            Unbind
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
               )}
             </div>
-
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => void handleToggle(ch)}
-                className="rounded-lg px-3 py-1.5 text-xs font-medium text-text-muted hover:bg-secondary transition-colors"
-              >
-                {ch.enabled ? "Disable" : "Enable"}
-              </button>
-              <button
-                type="button"
-                onClick={() => setDeleteConfirm({ id: ch.id, name: ch.name })}
-                className="rounded-lg px-3 py-1.5 text-xs font-medium text-danger hover:bg-danger/10 transition-colors"
-              >
-                Remove
-              </button>
-            </div>
-          </div>
-        ))}
+          )
+        })}
 
         {channels.length === 0 && (
           <p className="py-4 text-center text-sm text-text-muted">
@@ -230,8 +407,20 @@ export function ChannelConfigSection() {
             {deleteConfirm.conflict ? (
               <div className="mt-2">
                 <p className="text-sm text-text-muted">{deleteConfirm.conflict}</p>
+                {deleteConfirm.boundAgents && deleteConfirm.boundAgents.length > 0 && (
+                  <div className="mt-2 rounded-lg border border-surface-border bg-surface-dark p-2">
+                    <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-text-muted">
+                      Bound agents that will be detached:
+                    </p>
+                    {deleteConfirm.boundAgents.map((name) => (
+                      <p key={name} className="text-sm text-text-main">
+                        {name}
+                      </p>
+                    ))}
+                  </div>
+                )}
                 <p className="mt-2 text-sm text-text-muted">
-                  Force-remove to unbind agents and delete this channel?
+                  Force-remove to unbind all agents and delete this channel?
                 </p>
               </div>
             ) : (
@@ -350,6 +539,100 @@ export function ChannelConfigSection() {
                 className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-content hover:bg-primary/90 disabled:opacity-50 transition-colors"
               >
                 {saving ? "Saving..." : "Add Channel"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Bind to agent modal */}
+      {bindTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+          <div className="mx-4 w-full max-w-md rounded-xl border border-surface-border bg-surface-light p-6 shadow-xl">
+            <h3 className="text-lg font-semibold text-text-main">Bind to Agent</h3>
+            <p className="mt-1 text-xs text-text-muted">
+              Route messages from <strong>{bindTarget.name}</strong> ({bindTarget.type}) to an
+              agent.
+            </p>
+
+            {bindError && (
+              <div className="mt-3 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
+                {bindError}
+              </div>
+            )}
+
+            <div className="mt-4 space-y-3">
+              {/* Agent selector */}
+              <div>
+                <label className="mb-1 block text-xs font-medium text-text-muted">Agent</label>
+                {loadingAgents ? (
+                  <div className="flex justify-center py-3">
+                    <div className="size-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                  </div>
+                ) : agents.length === 0 ? (
+                  <p className="text-xs text-text-muted">No active agents available.</p>
+                ) : (
+                  <select
+                    value={bindForm.agentId}
+                    onChange={(e) => setBindForm({ ...bindForm, agentId: e.target.value })}
+                    className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  >
+                    <option value="">Select an agent...</option>
+                    {agents.map((a) => (
+                      <option key={a.id} value={a.id}>
+                        {a.name} ({a.slug})
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+
+              {/* Chat ID */}
+              <div>
+                <label className="mb-1 block text-xs font-medium text-text-muted">
+                  Chat ID
+                  {bindTarget.type === "telegram" && (
+                    <span className="ml-1 text-text-muted/70">(Telegram group/user ID)</span>
+                  )}
+                </label>
+                <input
+                  type="text"
+                  value={bindForm.chatId}
+                  onChange={(e) => setBindForm({ ...bindForm, chatId: e.target.value })}
+                  className="w-full rounded-lg border border-surface-border bg-surface-dark px-3 py-2 text-sm text-text-main placeholder:text-text-muted/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  placeholder="e.g., -1001234567890"
+                />
+              </div>
+
+              {/* Default checkbox */}
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={bindForm.isDefault}
+                  onChange={(e) => setBindForm({ ...bindForm, isDefault: e.target.checked })}
+                  className="size-4 rounded border-surface-border text-primary focus:ring-primary"
+                />
+                <span className="text-xs text-text-muted">
+                  Set as default binding for {bindTarget.type}
+                </span>
+              </label>
+            </div>
+
+            <div className="mt-6 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setBindTarget(null)}
+                className="rounded-lg px-4 py-2 text-sm text-text-muted hover:bg-secondary transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleBind()}
+                disabled={binding || !bindForm.agentId || !bindForm.chatId.trim()}
+                className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-content hover:bg-primary/90 disabled:opacity-50 transition-colors"
+              >
+                {binding ? "Binding..." : "Bind"}
               </button>
             </div>
           </div>

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -39,7 +39,10 @@ import {
   ChannelConfigListResponseSchema,
   ChannelConfigResponseSchema,
 } from "./schemas/channel-config"
-import { AgentChannelBindingListResponseSchema } from "./schemas/channels"
+import {
+  AgentChannelBindingListResponseSchema,
+  ChannelBindingsResponseSchema,
+} from "./schemas/channels"
 import { ContentListResponseSchema } from "./schemas/content"
 import {
   CredentialListResponseSchema,
@@ -823,7 +826,7 @@ export async function deleteCredential(id: string): Promise<unknown> {
 // Agent channel binding endpoint functions
 // ---------------------------------------------------------------------------
 
-export type { AgentChannelBinding } from "./schemas/channels"
+export type { AgentChannelBinding, BindingWithAgent } from "./schemas/channels"
 
 export async function listAgentChannels(agentId: string): Promise<{
   bindings: import("./schemas/channels").AgentChannelBinding[]
@@ -849,6 +852,14 @@ export async function unbindAgentChannel(agentId: string, bindingId: string): Pr
   return apiFetch(`/agents/${agentId}/channels/${bindingId}`, {
     method: "DELETE",
     schema: z.unknown(),
+  })
+}
+
+export async function listChannelBindings(channelId: string): Promise<{
+  bindings: import("./schemas/channels").BindingWithAgent[]
+}> {
+  return apiFetch(`/channels/${channelId}/bindings`, {
+    schema: ChannelBindingsResponseSchema,
   })
 }
 

--- a/packages/dashboard/src/lib/schemas/channels.ts
+++ b/packages/dashboard/src/lib/schemas/channels.ts
@@ -14,3 +14,20 @@ export const AgentChannelBindingListResponseSchema = z.object({
 })
 
 export type AgentChannelBinding = z.infer<typeof AgentChannelBindingSchema>
+
+export const BindingWithAgentSchema = z.object({
+  id: z.string(),
+  agent_id: z.string(),
+  agent_name: z.string(),
+  agent_slug: z.string(),
+  channel_type: z.string(),
+  chat_id: z.string(),
+  is_default: z.boolean(),
+  created_at: z.string(),
+})
+
+export const ChannelBindingsResponseSchema = z.object({
+  bindings: z.array(BindingWithAgentSchema),
+})
+
+export type BindingWithAgent = z.infer<typeof BindingWithAgentSchema>


### PR DESCRIPTION
## Summary
- **Channel-centric view**: Channels section now has expandable cards showing bound agents with agent name links, chat IDs, default badge, and unbind controls. "Bind to Agent" button opens a modal with agent picker, chat ID input, and default toggle.
- **Agent-centric view**: `ChannelBindingTab` now rendered on desktop layout (was mobile-only), giving parity between mobile and desktop.
- **Delete safety**: Force-remove confirmation now lists specific agent names that will be detached, not just a generic count.
- **Backend**: New `GET /channels/:id/bindings` endpoint returning bindings enriched with `agent_name` and `agent_slug` via a join query.

Closes #429

## Test plan
- [x] 1730 tests pass (103 files), including 4 new tests for `listBindingsByChannelType` and `GET /channels/:id/bindings`
- [x] Typecheck clean (control-plane + dashboard)
- [x] Lint clean (no new errors)
- [ ] Manual: Settings → Channels → expand a channel → verify bindings display
- [ ] Manual: Click "Bind to Agent" → select agent, enter chat ID → verify binding created
- [ ] Manual: Agent detail page → verify Channels panel on desktop left column
- [ ] Manual: Delete channel with bindings → confirm agent names listed in dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent binding visibility for channels—users can now view which agents are bound to each channel.
  * Introduced "Bind to Agent" functionality, allowing users to bind channels to agents with chat ID configuration.
  * Added "Unbind" action to remove channel-agent bindings.
  * Enhanced channel deletion flow to display bound agents when conflicts occur.

* **Tests**
  * Added comprehensive test coverage for agent channel binding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->