### PR TITLE
fix(#487): add QUARANTINED to AgentStatusSchema with tests + session delete error UX (#486)

### DIFF
--- a/packages/dashboard/src/__tests__/schemas.test.ts
+++ b/packages/dashboard/src/__tests__/schemas.test.ts
@@ -79,6 +79,25 @@ describe("AgentSummarySchema", () => {
     expect(() => AgentSummarySchema.parse({ ...validAgent, lifecycle_state: "RUNNING" })).toThrow()
   })
 
+  it("accepts all valid statuses including QUARANTINED", () => {
+    for (const status of ["ACTIVE", "DISABLED", "ARCHIVED", "QUARANTINED"]) {
+      expect(AgentSummarySchema.parse({ ...validAgent, status }).status).toBe(status)
+    }
+  })
+
+  it("parses a full agent response with QUARANTINED status", () => {
+    const quarantinedAgent = {
+      ...validAgent,
+      status: "QUARANTINED",
+      description: "Agent flagged for review",
+      current_job_id: null,
+      updated_at: "2026-03-08T00:00:00Z",
+    }
+    const result = AgentSummarySchema.parse(quarantinedAgent)
+    expect(result.status).toBe("QUARANTINED")
+    expect(result.description).toBe("Agent flagged for review")
+  })
+
   it("rejects missing required fields", () => {
     expect(() => AgentSummarySchema.parse({ id: "a1" })).toThrow()
   })
@@ -110,6 +129,18 @@ describe("AgentDetailSchema", () => {
       skill_config: { tools: ["web"] },
     }
     expect(AgentDetailSchema.parse(detail)).toEqual(detail)
+  })
+
+  it("accepts QUARANTINED status (inherited from AgentSummarySchema)", () => {
+    const detail = {
+      ...validAgent,
+      status: "QUARANTINED",
+      checkpoint: { job_id: "job-1", saved_at: "2026-01-01T00:00:00Z", crc32: 12345 },
+      config: { quarantine_reason: "repeated failures" },
+    }
+    const result = AgentDetailSchema.parse(detail)
+    expect(result.status).toBe("QUARANTINED")
+    expect(result.config).toEqual({ quarantine_reason: "repeated failures" })
   })
 })
 

--- a/packages/dashboard/src/components/agents/chat-panel.tsx
+++ b/packages/dashboard/src/components/agents/chat-panel.tsx
@@ -24,6 +24,7 @@ interface ChatPanelProps {
 export function ChatPanel({ agentId }: ChatPanelProps): React.JSX.Element {
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
   const [showSessions, setShowSessions] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
 
   // Fetch sessions
   const {
@@ -61,11 +62,16 @@ export function ChatPanel({ agentId }: ChatPanelProps): React.JSX.Element {
 
   const handleDeleteSession = useCallback(
     async (sessionId: string) => {
-      await deleteSession(sessionId)
-      if (activeSessionId === sessionId) {
-        setActiveSessionId(null)
+      setDeleteError(null)
+      try {
+        await deleteSession(sessionId)
+        if (activeSessionId === sessionId) {
+          setActiveSessionId(null)
+        }
+        void refetchSessions()
+      } catch (err) {
+        setDeleteError(err instanceof Error ? err.message : "Failed to delete session")
       }
-      void refetchSessions()
     },
     [activeSessionId, refetchSessions],
   )
@@ -100,6 +106,19 @@ export function ChatPanel({ agentId }: ChatPanelProps): React.JSX.Element {
           </button>
         </div>
       </div>
+
+      {/* Delete error banner */}
+      {deleteError && (
+        <div className="flex items-center justify-between border-b border-red-200 bg-red-50 px-4 py-2 dark:border-red-800 dark:bg-red-900/20">
+          <span className="text-xs text-red-600 dark:text-red-400">{deleteError}</span>
+          <button
+            onClick={() => setDeleteError(null)}
+            className="ml-2 text-xs font-medium text-red-500 hover:text-red-700 dark:hover:text-red-300"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
 
       {/* Session list dropdown */}
       {showSessions && (

--- a/packages/dashboard/src/lib/schemas/agents.ts
+++ b/packages/dashboard/src/lib/schemas/agents.ts
@@ -2,7 +2,7 @@ import { z } from "zod"
 
 import { PaginationSchema } from "./common"
 
-export const AgentStatusSchema = z.enum(["ACTIVE", "DISABLED", "ARCHIVED"])
+export const AgentStatusSchema = z.enum(["ACTIVE", "DISABLED", "ARCHIVED", "QUARANTINED"])
 
 export const AgentLifecycleStateSchema = z.enum([
   "BOOTING",


### PR DESCRIPTION
## Changes

### 1. AgentStatusSchema — add QUARANTINED (#487)
`AgentStatusSchema` was `z.enum(["ACTIVE", "DISABLED", "ARCHIVED"])` — missing `QUARANTINED`. When the control-plane returned a quarantined agent, the dashboard Zod schema rejected it → "Unexpected API response" toast → entire agents page broken (0 agents shown), release button never rendered.

**Fix:** Added `"QUARANTINED"` to the enum.

### 2. Session delete error handling (#486)
`handleDeleteSession` in `chat-panel.tsx` had no error handling — `void asyncFn()` swallowed all errors silently.

**Fix:** Added `deleteError` state, try/catch with user-visible error banner and dismiss button. No more silent failures.

### 3. Tests
- `AgentSummarySchema` accepts all 4 statuses including QUARANTINED
- `AgentSummarySchema` parses full mock agent with QUARANTINED status
- `AgentDetailSchema` accepts QUARANTINED (inherited via `.extend()`)

Closes #487, closes #486, closes #485

## Verification
- `pnpm lint` ✅
- `pnpm build` ✅  
- `pnpm test` ✅ (dashboard + control-plane)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now support a QUARANTINED status alongside existing statuses
  * Delete session failures are now displayed with an error banner and dismiss button

* **Tests**
  * Expanded test coverage to validate QUARANTINED status handling in agent schemas

<!-- end of auto-generated comment: release notes by coderabbit.ai -->