### PR TITLE
fix(#500): route google-antigravity credentials through Vertex AI proxy

### DIFF
--- a/packages/control-plane/src/__tests__/agent-execute-credential-wiring.test.ts
+++ b/packages/control-plane/src/__tests__/agent-execute-credential-wiring.test.ts
@@ -211,6 +211,7 @@ describe("agent-execute credential wiring (#444)", () => {
         user_account_id: "user-owner-1",
         provider: "google-antigravity",
         credential_class: "llm_provider",
+        account_id: "my-gcp-project",
       },
     })
     const { registry, executeTaskSpy } = makeMockRegistry()
@@ -238,6 +239,7 @@ describe("agent-execute credential wiring (#444)", () => {
       provider: "google-antigravity",
       token: "resolved-oauth-token",
       credentialId: "cred-abc",
+      accountId: "my-gcp-project",
     })
   })
 

--- a/packages/control-plane/src/__tests__/http-llm.test.ts
+++ b/packages/control-plane/src/__tests__/http-llm.test.ts
@@ -1284,3 +1284,119 @@ describe("HttpLlmBackend — 401 token refresh retry", () => {
     expect(callCount).toBe(2)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Credential routing: google-antigravity vs anthropic vs openai
+// ---------------------------------------------------------------------------
+
+describe("HttpLlmBackend — credential provider routing", () => {
+  it("routes google-antigravity to Anthropic SDK with Vertex base URL and authToken", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "global-key" })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        llmCredential: {
+          provider: "google-antigravity",
+          token: "gcp-oauth-token",
+          credentialId: "cred-gcp",
+          accountId: "my-gcp-project-123",
+        },
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    const client = (handle as any).client as { baseURL: string; authToken: string | null }
+    expect(client.baseURL).toBe(
+      "https://us-central1-aiplatform.googleapis.com/v1/projects/my-gcp-project-123/locations/us-central1/publishers/anthropic",
+    )
+    expect(client.authToken).toBe("gcp-oauth-token")
+
+    await handle.cancel("test")
+  })
+
+  it("routes plain anthropic credential with apiKey and default base URL", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "global-key" })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        llmCredential: {
+          provider: "anthropic",
+          token: "anthropic-api-key",
+          credentialId: "cred-anthropic",
+        },
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    const client = (handle as any).client as {
+      baseURL: string
+      authToken: string | null
+      apiKey: string
+    }
+    // Default Anthropic base URL (no custom override)
+    expect(client.baseURL).toContain("api.anthropic.com")
+    expect(client.apiKey).toBe("anthropic-api-key")
+    expect(client.authToken).toBeNull()
+
+    await handle.cancel("test")
+  })
+
+  it("routes openai-codex credential to OpenAI SDK", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "global-key" })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        llmCredential: {
+          provider: "openai-codex",
+          token: "openai-api-key",
+          credentialId: "cred-openai",
+        },
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+
+    // OpenAI handles have a different client type — verify it's not an AnthropicHandle
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    const client = (handle as any).client as { apiKey: string }
+    expect(client.apiKey).toBe("openai-api-key")
+
+    await handle.cancel("test")
+  })
+
+  it("does not set Vertex base URL when accountId is missing", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "global-key" })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        llmCredential: {
+          provider: "google-antigravity",
+          token: "gcp-oauth-token",
+          credentialId: "cred-gcp-no-account",
+          // accountId omitted
+        },
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    const client = (handle as any).client as { baseURL: string; authToken: string | null }
+    // Without accountId, should fall back to default Anthropic base URL
+    expect(client.baseURL).toContain("api.anthropic.com")
+
+    await handle.cancel("test")
+  })
+})

--- a/packages/control-plane/src/backends/http-llm.ts
+++ b/packages/control-plane/src/backends/http-llm.ts
@@ -208,15 +208,22 @@ export class HttpLlmBackend implements ExecutionBackend {
     if (cred) {
       const credProvider = mapCredentialProvider(cred.provider)
       if (credProvider === "anthropic") {
+        // Google Antigravity routes through a GCP Vertex endpoint with Bearer auth
+        const isAntigravity = cred.provider === "google-antigravity" && cred.accountId
+        let clientBaseUrl = baseUrl
+        if (isAntigravity) {
+          clientBaseUrl = `https://us-central1-aiplatform.googleapis.com/v1/projects/${cred.accountId}/locations/us-central1/publishers/anthropic`
+        }
         const client = new Anthropic({
-          apiKey: cred.token,
-          ...(baseUrl ? { baseURL: baseUrl } : {}),
+          ...(isAntigravity ? { authToken: cred.token, apiKey: null } : { apiKey: cred.token }),
+          ...(clientBaseUrl ? { baseURL: clientBaseUrl } : {}),
         })
         return Promise.resolve(
           new AnthropicHandle(task, client, model, startTime, registry, {
             tokenRefresher,
             credentialId: cred.credentialId,
-            baseUrl,
+            baseUrl: clientBaseUrl,
+            useAuthToken: !!isAntigravity,
           }),
         )
       }
@@ -309,6 +316,8 @@ interface RefreshOpts {
   tokenRefresher?: TokenRefresher
   credentialId?: string
   baseUrl?: string
+  /** When true, use Bearer auth (`authToken`) instead of `apiKey` for the Anthropic SDK. */
+  useAuthToken?: boolean
 }
 
 /** Returns true if the error is a 401 authentication error from an LLM SDK. */
@@ -373,6 +382,7 @@ class AnthropicHandle implements ExecutionHandle {
   private readonly tokenRefresher?: TokenRefresher
   private readonly credentialId?: string
   private readonly baseUrl?: string
+  private readonly useAuthToken: boolean
 
   constructor(
     private readonly task: ExecutionTask,
@@ -389,6 +399,7 @@ class AnthropicHandle implements ExecutionHandle {
     this.tokenRefresher = refreshOpts?.tokenRefresher
     this.credentialId = refreshOpts?.credentialId
     this.baseUrl = refreshOpts?.baseUrl
+    this.useAuthToken = refreshOpts?.useAuthToken ?? false
   }
 
   async *events(): AsyncIterable<OutputEvent> {
@@ -515,7 +526,9 @@ class AnthropicHandle implements ExecutionHandle {
             const newToken = await this.tokenRefresher(this.credentialId)
             if (newToken) {
               this.client = new Anthropic({
-                apiKey: newToken,
+                ...(this.useAuthToken
+                  ? { authToken: newToken, apiKey: null }
+                  : { apiKey: newToken }),
                 ...(this.baseUrl ? { baseURL: this.baseUrl } : {}),
               })
               turn-- // retry this turn

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -377,6 +377,7 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                 "provider_credential.user_account_id",
                 "provider_credential.provider",
                 "provider_credential.credential_class",
+                "provider_credential.account_id",
               ])
               .where("agent_credential_binding.agent_id", "=", agent.id)
               .where("provider_credential.credential_class", "=", "llm_provider")
@@ -393,6 +394,7 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                   provider: binding.provider,
                   token: result.token,
                   credentialId: result.credentialId,
+                  accountId: binding.account_id,
                 }
 
                 // Build a token refresher for transparent 401 retry.

--- a/packages/shared/src/backends/types.ts
+++ b/packages/shared/src/backends/types.ts
@@ -93,6 +93,8 @@ export interface LlmCredentialRef {
   token: string
   /** Credential ID for audit trail. */
   credentialId: string
+  /** Provider account ID (e.g. GCP project ID for google-antigravity). */
+  accountId?: string | null
 }
 
 /**


### PR DESCRIPTION
## Problem
Agents bound to google-antigravity credentials got 401 from Anthropic API — the OAuth token was sent as `apiKey` to `api.anthropic.com` instead of as a Bearer token to the Vertex AI Antigravity proxy.

## Root Cause
1. Credential resolution (`agent-execute.ts`) didn't select `account_id` from `provider_credential`
2. `http-llm.ts` didn't construct the Antigravity base URL or use Bearer auth for google-antigravity

## Fix
- Added `accountId` to `LlmCredentialRef` type (`@cortex/shared`)
- Step 4b query now selects `account_id` and passes it through
- When `cred.provider === 'google-antigravity'` with an `accountId`, constructs Vertex AI proxy URL and uses `authToken` (Bearer) instead of `apiKey`
- Token refresh also uses Bearer auth when `useAuthToken` is set

## Tests (4 new)
- google-antigravity with accountId → Vertex URL + authToken
- plain anthropic → default api.anthropic.com + apiKey
- openai-codex → OpenAI SDK
- google-antigravity without accountId → fallback behavior

1738/1738 tests pass. Lint + build clean.

Closes #500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Vertex AI endpoint integration with enhanced credential routing across cloud AI providers (Google, Anthropic, OpenAI).

* **Improvements**
  * Enhanced token refresh mechanism to support Bearer token authentication for cloud-backed credentials.
  * Improved credential resolution to properly propagate account information for multi-account scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->