### PR TITLE
fix(#500): use cloudcode-pa proxy for google-antigravity (not Vertex AI)

### DIFF
--- a/packages/control-plane/src/__tests__/http-llm.test.ts
+++ b/packages/control-plane/src/__tests__/http-llm.test.ts
@@ -1290,7 +1290,7 @@ describe("HttpLlmBackend — 401 token refresh retry", () => {
 // ---------------------------------------------------------------------------
 
 describe("HttpLlmBackend — credential provider routing", () => {
-  it("routes google-antigravity to Anthropic SDK with Vertex base URL and authToken", async () => {
+  it("routes google-antigravity to Anthropic SDK with CloudCode PA base URL and authToken", async () => {
     const backend = new HttpLlmBackend()
     await backend.start({ provider: "anthropic", apiKey: "global-key" })
 
@@ -1310,9 +1310,7 @@ describe("HttpLlmBackend — credential provider routing", () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     const client = (handle as any).client as { baseURL: string; authToken: string | null }
-    expect(client.baseURL).toBe(
-      "https://us-central1-aiplatform.googleapis.com/v1/projects/my-gcp-project-123/locations/us-central1/publishers/anthropic",
-    )
+    expect(client.baseURL).toBe("https://cloudcode-pa.googleapis.com")
     expect(client.authToken).toBe("gcp-oauth-token")
 
     await handle.cancel("test")
@@ -1374,7 +1372,7 @@ describe("HttpLlmBackend — credential provider routing", () => {
     await handle.cancel("test")
   })
 
-  it("does not set Vertex base URL when accountId is missing", async () => {
+  it("uses CloudCode PA base URL even when accountId is missing", async () => {
     const backend = new HttpLlmBackend()
     await backend.start({ provider: "anthropic", apiKey: "global-key" })
 
@@ -1385,7 +1383,7 @@ describe("HttpLlmBackend — credential provider routing", () => {
           provider: "google-antigravity",
           token: "gcp-oauth-token",
           credentialId: "cred-gcp-no-account",
-          // accountId omitted
+          // accountId omitted — not needed for cloudcode-pa
         },
       },
     })
@@ -1394,8 +1392,9 @@ describe("HttpLlmBackend — credential provider routing", () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     const client = (handle as any).client as { baseURL: string; authToken: string | null }
-    // Without accountId, should fall back to default Anthropic base URL
-    expect(client.baseURL).toContain("api.anthropic.com")
+    // CloudCode PA proxy does not require accountId in the URL
+    expect(client.baseURL).toBe("https://cloudcode-pa.googleapis.com")
+    expect(client.authToken).toBe("gcp-oauth-token")
 
     await handle.cancel("test")
   })

--- a/packages/control-plane/src/backends/http-llm.ts
+++ b/packages/control-plane/src/backends/http-llm.ts
@@ -208,11 +208,11 @@ export class HttpLlmBackend implements ExecutionBackend {
     if (cred) {
       const credProvider = mapCredentialProvider(cred.provider)
       if (credProvider === "anthropic") {
-        // Google Antigravity routes through a GCP Vertex endpoint with Bearer auth
-        const isAntigravity = cred.provider === "google-antigravity" && cred.accountId
+        // Google Antigravity routes through the CloudCode PA proxy with Bearer auth
+        const isAntigravity = cred.provider === "google-antigravity"
         let clientBaseUrl = baseUrl
         if (isAntigravity) {
-          clientBaseUrl = `https://us-central1-aiplatform.googleapis.com/v1/projects/${cred.accountId}/locations/us-central1/publishers/anthropic`
+          clientBaseUrl = "https://cloudcode-pa.googleapis.com"
         }
         const client = new Anthropic({
           ...(isAntigravity ? { authToken: cred.token, apiKey: null } : { apiKey: cred.token }),


### PR DESCRIPTION
## Problem
PR #503 used the wrong base URL for Google Antigravity. The Vertex AI endpoint (`aiplatform.googleapis.com`) returns 404 because the Anthropic SDK appends `/v1/messages`, creating a bad path (`/v1/projects/.../publishers/anthropic/v1/messages`).

## Fix
Changed base URL to `https://cloudcode-pa.googleapis.com` — the actual Google CloudCode PA proxy that Antigravity uses. The SDK sends to `cloudcode-pa.googleapis.com/v1/messages` which is correct.

Simplified the check: no `accountId` needed for cloudcode-pa. Bearer auth preserved.

## Tests
2 tests updated with correct URL. 1738/1738 pass.

Closes #500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced credential routing for multiple LLM providers with improved account ID tracking throughout credential flows.
  * Added token refresh mechanism for Bearer authentication in credential handling.

* **Tests**
  * Added comprehensive test coverage validating credential routing logic across different provider types and authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->