### PR TITLE
fix(#510): add credential health visibility to settings page

### DIFF
--- a/packages/control-plane/src/__tests__/credential-routes.test.ts
+++ b/packages/control-plane/src/__tests__/credential-routes.test.ts
@@ -410,6 +410,115 @@ describe("GET /credentials?class=tool_specific", () => {
 })
 
 // ---------------------------------------------------------------------------
+// Tests: GET /credentials — health fields
+// ---------------------------------------------------------------------------
+
+describe("GET /credentials — credential health fields", () => {
+  it("returns health fields for an active credential", async () => {
+    const healthyCred = makeSummary({
+      provider: "openai",
+      credentialType: "api_key",
+      credentialClass: "llm_provider",
+      status: "active",
+      errorCount: 0,
+      lastError: null,
+      lastUsedAt: "2026-03-09T10:00:00.000Z",
+      tokenExpiresAt: null,
+      lastRefreshAt: null,
+    })
+
+    const { app } = await buildTestApp({
+      credentialServiceOverrides: {
+        listCredentials: vi.fn().mockResolvedValue([healthyCred]),
+      },
+    })
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/credentials",
+      headers: withSession(),
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.credentials).toHaveLength(1)
+    const cred = body.credentials[0]
+    expect(cred.status).toBe("active")
+    expect(cred.errorCount).toBe(0)
+    expect(cred.lastError).toBeNull()
+    expect(cred.lastUsedAt).toBe("2026-03-09T10:00:00.000Z")
+  })
+
+  it("returns health fields for an errored credential", async () => {
+    const erroredCred = makeSummary({
+      provider: "anthropic",
+      credentialType: "oauth",
+      credentialClass: "llm_provider",
+      status: "error",
+      errorCount: 3,
+      lastError: "token refresh failed: invalid_grant",
+      lastUsedAt: "2026-03-08T14:00:00.000Z",
+      tokenExpiresAt: "2026-03-08T12:00:00.000Z",
+      lastRefreshAt: "2026-03-08T11:30:00.000Z",
+    })
+
+    const { app } = await buildTestApp({
+      credentialServiceOverrides: {
+        listCredentials: vi.fn().mockResolvedValue([erroredCred]),
+      },
+    })
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/credentials",
+      headers: withSession(),
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.credentials).toHaveLength(1)
+    const cred = body.credentials[0]
+    expect(cred.status).toBe("error")
+    expect(cred.errorCount).toBe(3)
+    expect(cred.lastError).toBe("token refresh failed: invalid_grant")
+    expect(cred.tokenExpiresAt).toBe("2026-03-08T12:00:00.000Z")
+    expect(cred.lastRefreshAt).toBe("2026-03-08T11:30:00.000Z")
+  })
+
+  it("returns health fields for an OAuth credential with upcoming expiry", async () => {
+    const oauthCred = makeSummary({
+      provider: "google-antigravity",
+      credentialType: "oauth",
+      credentialClass: "llm_provider",
+      status: "active",
+      errorCount: 0,
+      lastError: null,
+      tokenExpiresAt: "2026-03-10T12:00:00.000Z",
+      lastRefreshAt: "2026-03-09T11:00:00.000Z",
+    })
+
+    const { app } = await buildTestApp({
+      credentialServiceOverrides: {
+        listCredentials: vi.fn().mockResolvedValue([oauthCred]),
+      },
+    })
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/credentials",
+      headers: withSession(),
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    const cred = body.credentials[0]
+    expect(cred.tokenExpiresAt).toBe("2026-03-10T12:00:00.000Z")
+    expect(cred.lastRefreshAt).toBe("2026-03-09T11:00:00.000Z")
+    expect(cred.errorCount).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Tests: DELETE /credentials/:id
 // ---------------------------------------------------------------------------
 

--- a/packages/dashboard/src/__tests__/credential-health.test.ts
+++ b/packages/dashboard/src/__tests__/credential-health.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest"
+
+import type { Credential } from "@/lib/api-client"
+import { errorSummary, refreshStatus, tokenExpiry } from "@/lib/credential-health"
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function makeCred(overrides: Partial<Credential> = {}): Credential {
+  return {
+    id: "cred-1",
+    provider: "openai",
+    credentialType: "api_key",
+    displayLabel: null,
+    maskedKey: "****1234",
+    status: "active",
+    lastUsedAt: null,
+    createdAt: "2026-03-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// tokenExpiry
+// ---------------------------------------------------------------------------
+
+describe("tokenExpiry", () => {
+  const now = new Date("2026-03-09T12:00:00.000Z")
+
+  it("returns null when tokenExpiresAt is absent", () => {
+    expect(tokenExpiry(makeCred(), now)).toBeNull()
+  })
+
+  it("returns null when tokenExpiresAt is null", () => {
+    expect(tokenExpiry(makeCred({ tokenExpiresAt: null }), now)).toBeNull()
+  })
+
+  it("returns danger when token is already expired", () => {
+    const cred = makeCred({ tokenExpiresAt: "2026-03-09T11:00:00.000Z" })
+    const result = tokenExpiry(cred, now)!
+    expect(result.severity).toBe("danger")
+    expect(result.label).toMatch(/^Expired/)
+    expect(result.label).toContain("1h")
+  })
+
+  it("returns warning when token expires within 24 hours", () => {
+    // Expires in 6 hours
+    const cred = makeCred({ tokenExpiresAt: "2026-03-09T18:00:00.000Z" })
+    const result = tokenExpiry(cred, now)!
+    expect(result.severity).toBe("warning")
+    expect(result.label).toMatch(/^Expires in/)
+    expect(result.label).toContain("6h")
+  })
+
+  it("returns ok when token expires in more than 24 hours", () => {
+    // Expires in 3 days
+    const cred = makeCred({ tokenExpiresAt: "2026-03-12T12:00:00.000Z" })
+    const result = tokenExpiry(cred, now)!
+    expect(result.severity).toBe("ok")
+    expect(result.label).toMatch(/^Expires in/)
+    expect(result.label).toContain("3d")
+  })
+
+  it("shows minutes for short durations", () => {
+    // Expires in 30 minutes
+    const cred = makeCred({ tokenExpiresAt: "2026-03-09T12:30:00.000Z" })
+    const result = tokenExpiry(cred, now)!
+    expect(result.severity).toBe("warning")
+    expect(result.label).toBe("Expires in 30m")
+  })
+
+  it("shows <1m for very short durations", () => {
+    // Expires in 30 seconds
+    const cred = makeCred({ tokenExpiresAt: "2026-03-09T12:00:30.000Z" })
+    const result = tokenExpiry(cred, now)!
+    expect(result.label).toBe("Expires in <1m")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// errorSummary
+// ---------------------------------------------------------------------------
+
+describe("errorSummary", () => {
+  it("returns null for active credential with no errors", () => {
+    expect(errorSummary(makeCred())).toBeNull()
+  })
+
+  it("returns null for active credential with errorCount 0", () => {
+    expect(errorSummary(makeCred({ errorCount: 0 }))).toBeNull()
+  })
+
+  it("returns error info for status=error with error details", () => {
+    const cred = makeCred({
+      status: "error",
+      errorCount: 3,
+      lastError: "token refresh failed: invalid_grant",
+    })
+    const result = errorSummary(cred)!
+    expect(result.label).toBe("3 consecutive failures")
+    expect(result.message).toBe("token refresh failed: invalid_grant")
+  })
+
+  it("returns singular form for 1 failure", () => {
+    const cred = makeCred({
+      status: "error",
+      errorCount: 1,
+      lastError: "timeout",
+    })
+    const result = errorSummary(cred)!
+    expect(result.label).toBe("1 consecutive failure")
+  })
+
+  it("returns status label when error/expired with no details", () => {
+    const cred = makeCred({ status: "expired", errorCount: 0 })
+    const result = errorSummary(cred)!
+    expect(result.label).toBe("Status: expired")
+  })
+
+  it("returns status label for revoked credentials", () => {
+    const cred = makeCred({ status: "revoked" })
+    const result = errorSummary(cred)!
+    expect(result.label).toBe("Status: revoked")
+  })
+
+  it("shows error info for active credential with nonzero errorCount", () => {
+    const cred = makeCred({
+      status: "active",
+      errorCount: 2,
+      lastError: "rate_limited",
+    })
+    const result = errorSummary(cred)!
+    expect(result.label).toBe("2 consecutive failures")
+    expect(result.message).toBe("rate_limited")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// refreshStatus
+// ---------------------------------------------------------------------------
+
+describe("refreshStatus", () => {
+  it("returns null when lastRefreshAt is absent", () => {
+    expect(refreshStatus(makeCred())).toBeNull()
+  })
+
+  it("returns null when lastRefreshAt is null", () => {
+    expect(refreshStatus(makeCred({ lastRefreshAt: null }))).toBeNull()
+  })
+
+  it("returns formatted refresh timestamp", () => {
+    const cred = makeCred({ lastRefreshAt: "2026-03-09T10:30:00.000Z" })
+    const result = refreshStatus(cred)!
+    expect(result).toMatch(/^Last refreshed:/)
+  })
+})

--- a/packages/dashboard/src/app/settings/page.tsx
+++ b/packages/dashboard/src/app/settings/page.tsx
@@ -15,11 +15,50 @@ import {
   type ProviderInfo,
   saveProviderApiKey,
 } from "@/lib/api-client"
+import { errorSummary, refreshStatus, tokenExpiry } from "@/lib/credential-health"
 
 /** Find a human-readable label for a credential (provider name or display label). */
 function credentialLabel(cred: Credential, providers: ProviderInfo[]): string {
   if (cred.displayLabel) return cred.displayLabel
   return providers.find((p) => p.id === cred.provider)?.name ?? cred.provider
+}
+
+/** Render credential health details (errors, token expiry, refresh status). */
+function CredentialHealthDetails({ cred }: { cred: Credential }) {
+  const err = errorSummary(cred)
+  const expiry = tokenExpiry(cred)
+  const refresh = refreshStatus(cred)
+
+  const hasDetails = err || expiry || refresh || cred.lastUsedAt
+  if (!hasDetails) return null
+
+  return (
+    <div className="mt-1.5 space-y-0.5 text-xs">
+      {cred.lastUsedAt && (
+        <p className="text-text-muted">Last used: {new Date(cred.lastUsedAt).toLocaleString()}</p>
+      )}
+      {expiry && (
+        <p
+          className={
+            expiry.severity === "danger"
+              ? "text-danger"
+              : expiry.severity === "warning"
+                ? "text-warning"
+                : "text-text-muted"
+          }
+        >
+          {expiry.label}
+        </p>
+      )}
+      {refresh && <p className="text-text-muted">{refresh}</p>}
+      {err && (
+        <div className="mt-1 rounded border border-danger/20 bg-danger/5 px-2 py-1">
+          <p className="font-medium text-danger">{err.label}</p>
+          {err.message && <p className="mt-0.5 text-text-muted">{err.message}</p>}
+        </div>
+      )}
+    </div>
+  )
 }
 
 /** Code-paste providers that use the init/exchange flow. */
@@ -289,11 +328,7 @@ function SettingsInner() {
                       Project: <span className="font-mono">{cred.accountId}</span>
                     </p>
                   )}
-                  {cred?.lastUsedAt && (
-                    <p className="mt-0.5 text-xs text-text-muted">
-                      Last used: {new Date(cred.lastUsedAt).toLocaleString()}
-                    </p>
-                  )}
+                  {cred && <CredentialHealthDetails cred={cred} />}
                   {p.models && p.models.length > 0 && (
                     <div className="mt-1.5 flex flex-wrap gap-1">
                       {p.models.map((m) => (
@@ -398,11 +433,7 @@ function SettingsInner() {
                       )}
                     </div>
                     <p className="text-xs text-text-muted">{p.description}</p>
-                    {cred?.lastUsedAt && (
-                      <p className="mt-0.5 text-xs text-text-muted">
-                        Last used: {new Date(cred.lastUsedAt).toLocaleString()}
-                      </p>
-                    )}
+                    {cred && <CredentialHealthDetails cred={cred} />}
                   </div>
 
                   <div className="flex items-center gap-2">

--- a/packages/dashboard/src/lib/credential-health.ts
+++ b/packages/dashboard/src/lib/credential-health.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure utility helpers for credential health display.
+ *
+ * These are extracted from the settings page so they can be unit-tested
+ * without React rendering.
+ */
+
+import type { Credential } from "./api-client"
+
+// ---------------------------------------------------------------------------
+// Token expiry helpers
+// ---------------------------------------------------------------------------
+
+export interface ExpiryInfo {
+  /** Human-readable label, e.g. "Expires in 2h 15m" or "Expired 3d ago" */
+  label: string
+  /** Severity for styling: "ok" (>24h), "warning" (<24h), "danger" (expired) */
+  severity: "ok" | "warning" | "danger"
+}
+
+/**
+ * Compute a human-readable expiry summary for an OAuth credential.
+ * Returns null for credentials without a tokenExpiresAt timestamp.
+ */
+export function tokenExpiry(cred: Credential, now: Date = new Date()): ExpiryInfo | null {
+  if (!cred.tokenExpiresAt) return null
+
+  const expiresAt = new Date(cred.tokenExpiresAt)
+  const diffMs = expiresAt.getTime() - now.getTime()
+
+  if (diffMs <= 0) {
+    // Already expired — show how long ago
+    const ago = formatDuration(Math.abs(diffMs))
+    return { label: `Expired ${ago} ago`, severity: "danger" }
+  }
+
+  const label = `Expires in ${formatDuration(diffMs)}`
+  const severity = diffMs < 24 * 60 * 60 * 1000 ? "warning" : "ok"
+  return { label, severity }
+}
+
+// ---------------------------------------------------------------------------
+// Error summary
+// ---------------------------------------------------------------------------
+
+export interface ErrorInfo {
+  /** Short summary, e.g. "3 consecutive failures" or the lastError message */
+  label: string
+  /** The raw error message, if any */
+  message: string | null
+}
+
+/**
+ * Build an error summary for display. Returns null when there is no error state.
+ */
+export function errorSummary(cred: Credential): ErrorInfo | null {
+  if (cred.status !== "error" && cred.status !== "expired" && cred.status !== "revoked") {
+    // Even for active credentials, show if there are recent errors
+    if (!cred.errorCount || cred.errorCount === 0) return null
+  }
+
+  const count = cred.errorCount ?? 0
+  const message = cred.lastError ?? null
+
+  if (count === 0 && !message) {
+    // Status is error/expired/revoked but no details available
+    return { label: `Status: ${cred.status}`, message: null }
+  }
+
+  const label =
+    count > 0 ? `${count} consecutive failure${count === 1 ? "" : "s"}` : (message ?? "Error")
+
+  return { label, message }
+}
+
+// ---------------------------------------------------------------------------
+// Refresh status
+// ---------------------------------------------------------------------------
+
+/**
+ * Format the last-refresh timestamp for display. Returns null when unavailable.
+ */
+export function refreshStatus(cred: Credential): string | null {
+  if (!cred.lastRefreshAt) return null
+  return `Last refreshed: ${new Date(cred.lastRefreshAt).toLocaleString()}`
+}
+
+// ---------------------------------------------------------------------------
+// Internal
+// ---------------------------------------------------------------------------
+
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.floor(ms / 60_000)
+  if (totalMinutes < 1) return "<1m"
+  if (totalMinutes < 60) return `${totalMinutes}m`
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  if (hours < 24) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+  const days = Math.floor(hours / 24)
+  const remainingHours = hours % 24
+  return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`
+}


### PR DESCRIPTION
## Summary
- Adds credential health details to the settings page so users can see token expiry countdowns, last error messages, error counts, and refresh status for each credential
- Extracts pure utility functions (`tokenExpiry`, `errorSummary`, `refreshStatus`) into `credential-health.ts` for testability
- Adds `CredentialHealthDetails` component used by both LLM provider and user service credential cards

Closes #510

## Test plan
- [x] 17 new dashboard unit tests for `tokenExpiry`, `errorSummary`, `refreshStatus` helpers
- [x] 3 new backend route tests verifying health fields in `GET /credentials` response
- [x] All 2308 existing tests pass (551 dashboard + 1757 control-plane)
- [x] Lint, typecheck, and build all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)