### PR TITLE
fix(#511): add real-time auto-refresh to operations pages

### DIFF
--- a/packages/dashboard/src/__tests__/operations-auto-refresh.test.ts
+++ b/packages/dashboard/src/__tests__/operations-auto-refresh.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for operations page auto-refresh behavior (issue #511).
+ *
+ * The pages use a canonical SSE-triggered refetch pattern:
+ *   1. Track event count with a ref
+ *   2. When events.length > prevCount, refetch() and update ref
+ *
+ * We test this pattern directly (without React rendering) since the
+ * hooks are thin wrappers tested elsewhere.
+ */
+
+import { describe, expect, it, vi } from "vitest"
+
+import type { ApprovalEventPayload } from "@/hooks/use-approval-stream"
+
+// ---------------------------------------------------------------------------
+// SSE-triggered refetch pattern (mirrors page implementation)
+// ---------------------------------------------------------------------------
+
+/**
+ * Simulates the useEffect pattern used by both operations pages:
+ *   if (events.length > prevCount) { prevCount = events.length; refetch() }
+ */
+function simulateRefetchOnEvents(eventCounts: number[], refetch: () => void): void {
+  let prevCount = 0
+  for (const count of eventCounts) {
+    if (count > prevCount) {
+      prevCount = count
+      refetch()
+    }
+  }
+}
+
+describe("SSE-triggered auto-refresh pattern", () => {
+  it("refetches when new events arrive", () => {
+    const refetch = vi.fn()
+    // Simulate: mount with 0 events, then 1, then 2, then 3 arrive
+    simulateRefetchOnEvents([0, 1, 2, 3], refetch)
+    expect(refetch).toHaveBeenCalledTimes(3)
+  })
+
+  it("does not refetch when event count stays the same", () => {
+    const refetch = vi.fn()
+    // Simulate: same count across multiple renders
+    simulateRefetchOnEvents([0, 0, 0], refetch)
+    expect(refetch).toHaveBeenCalledTimes(0)
+  })
+
+  it("does not refetch on initial mount with zero events", () => {
+    const refetch = vi.fn()
+    simulateRefetchOnEvents([0], refetch)
+    expect(refetch).toHaveBeenCalledTimes(0)
+  })
+
+  it("handles burst of events (count jumps)", () => {
+    const refetch = vi.fn()
+    // Simulate: 0 events, then suddenly 5
+    simulateRefetchOnEvents([0, 5], refetch)
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("refetches again after a quiet period then new events", () => {
+    const refetch = vi.fn()
+    // 0 -> 3 (refetch), 3 -> 3 (no-op), 3 -> 5 (refetch)
+    simulateRefetchOnEvents([0, 3, 3, 3, 5], refetch)
+    expect(refetch).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Approval toast logic (mirrors page implementation)
+// ---------------------------------------------------------------------------
+
+function simulateApprovalToasts(
+  events: ApprovalEventPayload[],
+  agentId?: string,
+): { warnings: string[]; infos: string[] } {
+  const warnings: string[] = []
+  const infos: string[] = []
+
+  let prevCount = 0
+  // Simulate a single "render" with all events
+  if (events.length > prevCount) {
+    const newEvents = events.slice(prevCount)
+    prevCount = events.length
+    for (const evt of newEvents) {
+      if (evt.type === "created") {
+        // Fleet page shows all; agent page filters by agent_id
+        if (!agentId || evt.data.agent_id === agentId) {
+          warnings.push(`Approval required: ${evt.data.action_summary}`)
+        }
+      } else if (evt.type === "decided") {
+        if (!agentId) {
+          // fleet page doesn't toast on decisions
+        } else {
+          infos.push(`Approval ${evt.data.decision.toLowerCase()}`)
+        }
+      }
+    }
+  }
+
+  return { warnings, infos }
+}
+
+describe("Approval notification toasts", () => {
+  it("shows warning toast for new approval (fleet page)", () => {
+    const events: ApprovalEventPayload[] = [
+      {
+        type: "created",
+        data: {
+          approval_request_id: "apr-1",
+          job_id: "job-1",
+          agent_id: "agt-1",
+          action_summary: "Delete user records",
+          action_type: "destructive",
+          expires_at: "2026-03-10T00:00:00Z",
+          timestamp: "2026-03-09T12:00:00Z",
+        },
+      },
+    ]
+    const result = simulateApprovalToasts(events)
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings[0]).toBe("Approval required: Delete user records")
+  })
+
+  it("shows toast only for matching agent on agent page", () => {
+    const events: ApprovalEventPayload[] = [
+      {
+        type: "created",
+        data: {
+          approval_request_id: "apr-1",
+          job_id: "job-1",
+          agent_id: "agt-1",
+          action_summary: "Delete records",
+          action_type: "destructive",
+          expires_at: "2026-03-10T00:00:00Z",
+          timestamp: "2026-03-09T12:00:00Z",
+        },
+      },
+      {
+        type: "created",
+        data: {
+          approval_request_id: "apr-2",
+          job_id: "job-2",
+          agent_id: "agt-2",
+          action_summary: "Send email",
+          action_type: "external",
+          expires_at: "2026-03-10T00:00:00Z",
+          timestamp: "2026-03-09T12:01:00Z",
+        },
+      },
+    ]
+
+    const result = simulateApprovalToasts(events, "agt-1")
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings[0]).toBe("Approval required: Delete records")
+  })
+
+  it("shows info toast for decided approvals on agent page", () => {
+    const events: ApprovalEventPayload[] = [
+      {
+        type: "decided",
+        data: {
+          approval_request_id: "apr-1",
+          job_id: "job-1",
+          decision: "APPROVED",
+          decided_by: "admin",
+          timestamp: "2026-03-09T12:05:00Z",
+        },
+      },
+    ]
+    const result = simulateApprovalToasts(events, "agt-1")
+    expect(result.infos).toHaveLength(1)
+    expect(result.infos[0]).toBe("Approval approved")
+  })
+
+  it("no toasts when no events arrive", () => {
+    const result = simulateApprovalToasts([])
+    expect(result.warnings).toHaveLength(0)
+    expect(result.infos).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fleet stats derivation (mirrors operations page)
+// ---------------------------------------------------------------------------
+
+interface AgentSummaryLike {
+  lifecycle_state?: string
+  status?: string
+}
+
+function deriveFleetStats(agents: AgentSummaryLike[]) {
+  let executing = 0
+  let ready = 0
+  let quarantined = 0
+  let other = 0
+  for (const a of agents) {
+    const s = a.lifecycle_state
+    if (s === "EXECUTING") executing++
+    else if (s === "READY") ready++
+    else if (a.status === "ARCHIVED" || a.status === "DISABLED") quarantined++
+    else other++
+  }
+  return { total: agents.length, executing, ready, quarantined, other }
+}
+
+describe("Fleet stats update on agent list refetch", () => {
+  it("reflects executing count change after refetch", () => {
+    const before = deriveFleetStats([{ lifecycle_state: "READY" }, { lifecycle_state: "READY" }])
+    expect(before.executing).toBe(0)
+    expect(before.ready).toBe(2)
+
+    // After refetch, one agent switched to EXECUTING
+    const after = deriveFleetStats([{ lifecycle_state: "EXECUTING" }, { lifecycle_state: "READY" }])
+    expect(after.executing).toBe(1)
+    expect(after.ready).toBe(1)
+  })
+
+  it("reflects quarantine after agent status change", () => {
+    const before = deriveFleetStats([{ lifecycle_state: "READY" }])
+    expect(before.quarantined).toBe(0)
+
+    const after = deriveFleetStats([{ status: "ARCHIVED" }])
+    expect(after.quarantined).toBe(1)
+    expect(after.ready).toBe(0)
+  })
+})

--- a/packages/dashboard/src/app/agents/[agentId]/operations/page.tsx
+++ b/packages/dashboard/src/app/agents/[agentId]/operations/page.tsx
@@ -1,14 +1,16 @@
 "use client"
 
-import { use, useMemo } from "react"
+import { use, useEffect, useMemo, useRef } from "react"
 
 import { ActivityStream } from "@/components/activity-stream"
 import { AgentControlPanel } from "@/components/agent-control-panel"
 import { CostSummary } from "@/components/cost-summary"
 import { PageHeader } from "@/components/layout/page-header"
 import { Skeleton } from "@/components/layout/skeleton"
+import { useToast } from "@/components/layout/toast"
 import { useActivityStream } from "@/hooks/use-activity-stream"
 import { useApiQuery } from "@/hooks/use-api"
+import { useApprovalStream } from "@/hooks/use-approval-stream"
 import { type AgentEvent, getAgent, getAgentCost, getAgentEvents } from "@/lib/api-client"
 import { relativeTime } from "@/lib/format"
 
@@ -63,6 +65,36 @@ export default function AgentOperationsPage({ params }: Props): React.JSX.Elemen
   const { events: liveEvents, connected } = useActivityStream({
     agentIds: agentId,
   })
+
+  // Approval SSE stream — surface notifications without reload
+  const { events: approvalEvents } = useApprovalStream()
+  const { addToast } = useToast()
+
+  // Auto-refresh agent detail when new activity events arrive
+  const prevActivityCount = useRef(0)
+  useEffect(() => {
+    if (liveEvents.length > prevActivityCount.current) {
+      prevActivityCount.current = liveEvents.length
+      void refetch()
+    }
+  }, [liveEvents.length, refetch])
+
+  // Toast for approval events related to this agent
+  const prevApprovalCount = useRef(0)
+  useEffect(() => {
+    if (approvalEvents.length > prevApprovalCount.current) {
+      const newEvents = approvalEvents.slice(prevApprovalCount.current)
+      prevApprovalCount.current = approvalEvents.length
+      for (const evt of newEvents) {
+        if (evt.type === "created" && evt.data.agent_id === agentId) {
+          addToast(`Approval required: ${evt.data.action_summary}`, "warning")
+        } else if (evt.type === "decided" && evt.data.job_id) {
+          addToast(`Approval ${evt.data.decision.toLowerCase()}`, "info")
+        }
+      }
+      void refetch()
+    }
+  }, [approvalEvents.length, approvalEvents, agentId, addToast, refetch])
 
   // Merge REST events + live SSE events for display
   const activityEvents = useMemo(() => {

--- a/packages/dashboard/src/app/operations/page.tsx
+++ b/packages/dashboard/src/app/operations/page.tsx
@@ -1,14 +1,16 @@
 "use client"
 
 import Link from "next/link"
-import { useMemo } from "react"
+import { useEffect, useMemo, useRef } from "react"
 
 import { ActivityStream } from "@/components/activity-stream"
 import { EmptyState } from "@/components/layout/empty-state"
 import { PageHeader } from "@/components/layout/page-header"
 import { Skeleton } from "@/components/layout/skeleton"
+import { useToast } from "@/components/layout/toast"
 import { useActivityStream } from "@/hooks/use-activity-stream"
 import { useApiQuery } from "@/hooks/use-api"
+import { useApprovalStream } from "@/hooks/use-approval-stream"
 import type { AgentSummary } from "@/lib/api-client"
 import { listAgents } from "@/lib/api-client"
 
@@ -58,10 +60,36 @@ function AgentOverviewCard({ agent }: { agent: AgentSummary }): React.JSX.Elemen
 // ---------------------------------------------------------------------------
 
 export default function OperationsPage(): React.JSX.Element {
-  const { data: agentData, isLoading: agentsLoading } = useApiQuery(() => listAgents(), [])
+  const { data: agentData, isLoading: agentsLoading, refetch } = useApiQuery(() => listAgents(), [])
   const agents = agentData?.agents ?? []
 
   const { events, connected } = useActivityStream()
+  const { events: approvalEvents } = useApprovalStream()
+  const { addToast } = useToast()
+
+  // Auto-refresh agent list when new activity events arrive
+  const prevActivityCount = useRef(0)
+  useEffect(() => {
+    if (events.length > prevActivityCount.current) {
+      prevActivityCount.current = events.length
+      void refetch()
+    }
+  }, [events.length, refetch])
+
+  // Toast for approval events
+  const prevApprovalCount = useRef(0)
+  useEffect(() => {
+    if (approvalEvents.length > prevApprovalCount.current) {
+      const newEvents = approvalEvents.slice(prevApprovalCount.current)
+      prevApprovalCount.current = approvalEvents.length
+      for (const evt of newEvents) {
+        if (evt.type === "created") {
+          addToast(`Approval required: ${evt.data.action_summary}`, "warning")
+        }
+      }
+      void refetch()
+    }
+  }, [approvalEvents.length, approvalEvents, addToast, refetch])
 
   // Build agentId -> name map for activity stream
   const agentNames = useMemo(() => {


### PR DESCRIPTION
## Summary
- Wire SSE activity stream events to trigger `refetch()` on agent data in both fleet operations (`/operations`) and agent operations (`/agents/:id/operations`) pages, using the established pattern from `use-jobs-page.ts`
- Add `useApprovalStream` to both pages so approval notifications (created/decided) surface as toasts without manual reload
- Agent status badges, fleet stats, and current job info now update within seconds of state changes

Fixes #511

## Test plan
- [x] 11 new tests in `operations-auto-refresh.test.ts` covering:
  - SSE-triggered refetch pattern (fires on new events, skips duplicates, handles bursts)
  - Approval toast logic (fleet-wide vs agent-filtered, created vs decided events)
  - Fleet stats derivation updates after refetch
- [x] All 588 dashboard tests pass
- [x] All 1757 control-plane tests pass
- [x] ESLint clean on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operations dashboard now auto-refreshes when activity events occur.
  * Approval events trigger real-time toast notifications with action summaries and decisions.
  * Live activity stream integration ensures UI stays current without manual reloads.

* **Tests**
  * Added comprehensive test suite for operations dashboard covering auto-refresh patterns, approval notifications, and fleet statistics derivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->