### PR TITLE
fix(#505): add model dropdown selector to agent detail edit panel

### DIFF
--- a/packages/dashboard/src/__tests__/deploy-agent-modal.test.ts
+++ b/packages/dashboard/src/__tests__/deploy-agent-modal.test.ts
@@ -1,6 +1,15 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+
 import { describe, expect, it } from "vitest"
 
 import { AVAILABLE_MODELS } from "@/components/agents/deploy-agent-modal"
+
+const SRC_DIR = path.resolve(__dirname, "..")
+
+function readSrc(relative: string): string {
+  return readFileSync(path.join(SRC_DIR, relative), "utf-8")
+}
 
 // ---------------------------------------------------------------------------
 // AVAILABLE_MODELS constant
@@ -30,6 +39,12 @@ describe("AVAILABLE_MODELS", () => {
   it("includes the default fallback model (claude-sonnet-4-6)", () => {
     const ids = AVAILABLE_MODELS.map((m) => m.id)
     expect(ids).toContain("claude-sonnet-4-6")
+  })
+
+  it("includes anthropic and openai providers", () => {
+    const providers = new Set(AVAILABLE_MODELS.map((m) => m.provider))
+    expect(providers.has("anthropic")).toBe(true)
+    expect(providers.has("openai")).toBe(true)
   })
 })
 
@@ -68,5 +83,56 @@ describe("model_config construction", () => {
   it("trims whitespace from model and systemPrompt", () => {
     const cfg = buildModelConfig("  claude-opus-4-6  ", "  Hello  ")
     expect(cfg).toEqual({ model: "claude-opus-4-6", systemPrompt: "Hello" })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Static analysis: deploy modal structure
+// ---------------------------------------------------------------------------
+
+describe("Deploy modal structure", () => {
+  const content = readSrc("components/agents/deploy-agent-modal.tsx")
+
+  it("has a Model label", () => {
+    expect(content).toContain("Model")
+  })
+
+  it("has model state", () => {
+    expect(content).toContain('useState("")')
+    expect(content).toContain("setModel")
+  })
+
+  it("uses a select element for model selection", () => {
+    expect(content).toContain('data-testid="deploy-model-select"')
+  })
+
+  it("exports AVAILABLE_MODELS list", () => {
+    expect(content).toContain("AVAILABLE_MODELS")
+    expect(content).toContain("claude-sonnet-4-6")
+  })
+
+  it("includes model in model_config when building request body", () => {
+    expect(content).toContain("modelConfig.model = model.trim()")
+  })
+
+  it("includes systemPrompt in model_config when building request body", () => {
+    expect(content).toContain("modelConfig.systemPrompt = systemPrompt.trim()")
+  })
+
+  it("resets model on form reset", () => {
+    expect(content).toContain('setModel("")')
+  })
+
+  it("requires model for form submission", () => {
+    expect(content).toContain("!model.trim()")
+  })
+
+  it("has system prompt textarea", () => {
+    expect(content).toContain("System Prompt")
+    expect(content).toContain("setSystemPrompt")
+  })
+
+  it("shows credential warning when model is selected", () => {
+    expect(content).toContain("provider credential")
   })
 })

--- a/packages/dashboard/src/__tests__/model-config.test.ts
+++ b/packages/dashboard/src/__tests__/model-config.test.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 
 import { afterEach, describe, expect, it, vi } from "vitest"
 
+import { AVAILABLE_MODELS } from "@/components/agents/deploy-agent-modal"
 import { updateAgent } from "@/lib/api-client"
 
 // ---------------------------------------------------------------------------
@@ -54,8 +55,24 @@ describe("ModelConfigPanel in agent detail page", () => {
     expect(content).toContain('data-testid="model-config-edit-btn"')
   })
 
-  it("has model input field when editing", () => {
+  it("uses a select dropdown for model selection when editing", () => {
+    expect(content).toContain('data-testid="model-config-model-select"')
+    expect(content).toContain("<select")
+  })
+
+  it("includes AVAILABLE_MODELS options in dropdown", () => {
+    expect(content).toContain("AVAILABLE_MODELS.map")
+    expect(content).toContain("import { AVAILABLE_MODELS }")
+  })
+
+  it("offers a Custom option in the model dropdown", () => {
+    expect(content).toContain("Custom...")
+    expect(content).toContain("CUSTOM_MODEL_VALUE")
+  })
+
+  it("shows custom text input when Custom is selected", () => {
     expect(content).toContain('data-testid="model-config-model-input"')
+    expect(content).toContain("model === CUSTOM_MODEL_VALUE")
   })
 
   it("has system prompt textarea when editing", () => {
@@ -83,13 +100,29 @@ describe("ModelConfigPanel in agent detail page", () => {
   it("calls updateAgent with model_config on save", () => {
     expect(content).toContain("updateAgent(agent.id, { model_config:")
   })
+
+  it("resolves custom model value before saving", () => {
+    expect(content).toContain("resolvedModel")
+    // Ensures __custom__ sentinel is never sent to the API
+    expect(content).toContain("model === CUSTOM_MODEL_VALUE ? customModel.trim() : model.trim()")
+  })
+
+  it("displays model label for known models in view mode", () => {
+    expect(content).toContain("modelLabel")
+    expect(content).toContain("AVAILABLE_MODELS.find")
+  })
+
+  it("pre-selects Custom when current model is not in AVAILABLE_MODELS", () => {
+    expect(content).toContain("isKnownModel")
+    expect(content).toContain("AVAILABLE_MODELS.some")
+  })
 })
 
 // ---------------------------------------------------------------------------
-// Static analysis: deploy modal includes model input
+// Static analysis: deploy modal includes model selector
 // ---------------------------------------------------------------------------
 
-describe("Deploy modal model input", () => {
+describe("Deploy modal model selector", () => {
   const content = readSrc("components/agents/deploy-agent-modal.tsx")
 
   it("has a Model label", () => {
@@ -128,6 +161,158 @@ describe("Deploy modal model input", () => {
 })
 
 // ---------------------------------------------------------------------------
+// AVAILABLE_MODELS constant validation
+// ---------------------------------------------------------------------------
+
+describe("AVAILABLE_MODELS", () => {
+  it("contains at least one model", () => {
+    expect(AVAILABLE_MODELS.length).toBeGreaterThan(0)
+  })
+
+  it("every entry has id, label, and provider", () => {
+    for (const m of AVAILABLE_MODELS) {
+      expect(typeof m.id).toBe("string")
+      expect(m.id.length).toBeGreaterThan(0)
+      expect(typeof m.label).toBe("string")
+      expect(m.label.length).toBeGreaterThan(0)
+      expect(typeof m.provider).toBe("string")
+      expect(m.provider.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("has unique model ids", () => {
+    const ids = AVAILABLE_MODELS.map((m) => m.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it("includes the default fallback model (claude-sonnet-4-6)", () => {
+    const ids = AVAILABLE_MODELS.map((m) => m.id)
+    expect(ids).toContain("claude-sonnet-4-6")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// model_config construction (mirrors deploy-agent-modal handleSubmit logic)
+// ---------------------------------------------------------------------------
+
+describe("model_config construction", () => {
+  function buildModelConfig(
+    model: string,
+    systemPrompt: string,
+  ): Record<string, unknown> | undefined {
+    const cfg: Record<string, unknown> = {}
+    if (model.trim()) cfg.model = model.trim()
+    if (systemPrompt.trim()) cfg.systemPrompt = systemPrompt.trim()
+    return Object.keys(cfg).length > 0 ? cfg : undefined
+  }
+
+  it("includes model when selected", () => {
+    const cfg = buildModelConfig("claude-sonnet-4-6", "")
+    expect(cfg).toEqual({ model: "claude-sonnet-4-6" })
+  })
+
+  it("includes both model and systemPrompt", () => {
+    const cfg = buildModelConfig("gpt-4o", "You are a helpful assistant")
+    expect(cfg).toEqual({
+      model: "gpt-4o",
+      systemPrompt: "You are a helpful assistant",
+    })
+  })
+
+  it("returns undefined when both are empty", () => {
+    expect(buildModelConfig("", "")).toBeUndefined()
+  })
+
+  it("trims whitespace from model and systemPrompt", () => {
+    const cfg = buildModelConfig("  claude-opus-4-6  ", "  Hello  ")
+    expect(cfg).toEqual({ model: "claude-opus-4-6", systemPrompt: "Hello" })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// model_config edit save logic (mirrors ModelConfigPanel handleSave)
+// ---------------------------------------------------------------------------
+
+describe("model_config edit save logic", () => {
+  function buildSaveConfig(
+    existing: Record<string, unknown>,
+    resolvedModel: string,
+    systemPrompt: string,
+  ): Record<string, unknown> {
+    const newConfig: Record<string, unknown> = { ...existing }
+    if (resolvedModel) {
+      newConfig.model = resolvedModel
+    } else {
+      delete newConfig.model
+    }
+    if (systemPrompt.trim()) {
+      newConfig.systemPrompt = systemPrompt.trim()
+    } else {
+      delete newConfig.systemPrompt
+    }
+    return newConfig
+  }
+
+  it("updates model while preserving other fields", () => {
+    const existing = { model: "old-model", max_tokens: 4096, provider: "anthropic" }
+    const result = buildSaveConfig(existing, "claude-opus-4-6", "")
+    expect(result).toEqual({ model: "claude-opus-4-6", max_tokens: 4096, provider: "anthropic" })
+  })
+
+  it("removes model when empty", () => {
+    const existing = { model: "old-model", max_tokens: 4096 }
+    const result = buildSaveConfig(existing, "", "")
+    expect(result).toEqual({ max_tokens: 4096 })
+  })
+
+  it("sets systemPrompt while preserving model", () => {
+    const existing = { model: "claude-sonnet-4-6" }
+    const result = buildSaveConfig(existing, "claude-sonnet-4-6", "Be helpful")
+    expect(result).toEqual({ model: "claude-sonnet-4-6", systemPrompt: "Be helpful" })
+  })
+
+  it("removes systemPrompt when empty", () => {
+    const existing = { model: "gpt-4o", systemPrompt: "old prompt" }
+    const result = buildSaveConfig(existing, "gpt-4o", "")
+    expect(result).toEqual({ model: "gpt-4o" })
+  })
+
+  it("handles custom model id correctly", () => {
+    const existing = {}
+    const result = buildSaveConfig(existing, "custom-model-v2", "Custom prompt")
+    expect(result).toEqual({ model: "custom-model-v2", systemPrompt: "Custom prompt" })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Custom model resolution logic (mirrors CUSTOM_MODEL_VALUE sentinel)
+// ---------------------------------------------------------------------------
+
+describe("custom model resolution", () => {
+  const CUSTOM_MODEL_VALUE = "__custom__"
+
+  function resolveModel(model: string, customModel: string): string {
+    return model === CUSTOM_MODEL_VALUE ? customModel.trim() : model.trim()
+  }
+
+  it("returns selected model when not custom", () => {
+    expect(resolveModel("claude-sonnet-4-6", "")).toBe("claude-sonnet-4-6")
+  })
+
+  it("returns custom model when custom sentinel is selected", () => {
+    expect(resolveModel(CUSTOM_MODEL_VALUE, "my-custom-model")).toBe("my-custom-model")
+  })
+
+  it("trims whitespace from custom model", () => {
+    expect(resolveModel(CUSTOM_MODEL_VALUE, "  spaced-model  ")).toBe("spaced-model")
+  })
+
+  it("returns empty string when custom is selected but no value entered", () => {
+    expect(resolveModel(CUSTOM_MODEL_VALUE, "")).toBe("")
+  })
+})
+
+// ---------------------------------------------------------------------------
 // API client: updateAgent sends model_config
 // ---------------------------------------------------------------------------
 
@@ -156,6 +341,21 @@ describe("updateAgent with model_config", () => {
     const mc = body.model_config as Record<string, unknown>
     expect(mc.model).toBe("claude-opus-4-6-thinking")
     expect(mc.systemPrompt).toBe("Be helpful")
+  })
+
+  it("sends model_config with only model (no systemPrompt)", async () => {
+    mockFetchResponse({})
+
+    await updateAgent("agt-456", {
+      model_config: { model: "gpt-4o" },
+    })
+
+    const fetchMock = vi.mocked(globalThis.fetch)
+    const [, init] = fetchMock.mock.calls[0]!
+    const body = JSON.parse(init?.body as string) as Record<string, unknown>
+    const mc = body.model_config as Record<string, unknown>
+    expect(mc.model).toBe("gpt-4o")
+    expect(mc.systemPrompt).toBeUndefined()
   })
 
   it("handles API error on update", async () => {

--- a/packages/dashboard/src/app/agents/[agentId]/page.tsx
+++ b/packages/dashboard/src/app/agents/[agentId]/page.tsx
@@ -8,6 +8,7 @@ import { AgentJobsTab } from "@/components/agents/agent-jobs-tab"
 import { ChannelBindingTab } from "@/components/agents/channel-binding-tab"
 import { ChatPanel } from "@/components/agents/chat-panel"
 import { CredentialBindingPanel } from "@/components/agents/credential-binding"
+import { AVAILABLE_MODELS } from "@/components/agents/deploy-agent-modal"
 import { type LifecycleStep, LifecycleTimeline } from "@/components/agents/lifecycle-timeline"
 import { ResourceSparklines } from "@/components/agents/resource-sparklines"
 import { SteerInput } from "@/components/agents/steer-input"
@@ -430,6 +431,8 @@ function LoadingSkeleton(): React.JSX.Element {
   )
 }
 
+const CUSTOM_MODEL_VALUE = "__custom__"
+
 function ModelConfigPanel({
   agent,
   onSave,
@@ -443,23 +446,34 @@ function ModelConfigPanel({
 
   const [editing, setEditing] = useState(false)
   const [model, setModel] = useState(currentModel)
+  const [customModel, setCustomModel] = useState("")
   const [systemPrompt, setSystemPrompt] = useState(currentPrompt)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
 
+  const isKnownModel = AVAILABLE_MODELS.some((m) => m.id === currentModel)
+
   const handleEdit = useCallback(() => {
-    setModel(currentModel)
+    if (isKnownModel || !currentModel) {
+      setModel(currentModel)
+      setCustomModel("")
+    } else {
+      setModel(CUSTOM_MODEL_VALUE)
+      setCustomModel(currentModel)
+    }
     setSystemPrompt(currentPrompt)
     setError(null)
     setSuccess(false)
     setEditing(true)
-  }, [currentModel, currentPrompt])
+  }, [currentModel, currentPrompt, isKnownModel])
 
   const handleCancel = useCallback(() => {
     setEditing(false)
     setError(null)
   }, [])
+
+  const resolvedModel = model === CUSTOM_MODEL_VALUE ? customModel.trim() : model.trim()
 
   const handleSave = useCallback(async () => {
     setSaving(true)
@@ -467,8 +481,8 @@ function ModelConfigPanel({
     setSuccess(false)
     try {
       const newConfig: Record<string, unknown> = { ...modelConfig }
-      if (model.trim()) {
-        newConfig.model = model.trim()
+      if (resolvedModel) {
+        newConfig.model = resolvedModel
       } else {
         delete newConfig.model
       }
@@ -487,7 +501,17 @@ function ModelConfigPanel({
     } finally {
       setSaving(false)
     }
-  }, [agent.id, model, systemPrompt, modelConfig, onSave])
+  }, [agent.id, resolvedModel, systemPrompt, modelConfig, onSave])
+
+  const handleModelSelect = useCallback((value: string) => {
+    setModel(value)
+    if (value !== CUSTOM_MODEL_VALUE) {
+      setCustomModel("")
+    }
+  }, [])
+
+  // Find the display label for the current model
+  const modelLabel = AVAILABLE_MODELS.find((m) => m.id === currentModel)?.label
 
   return (
     <div
@@ -524,15 +548,36 @@ function ModelConfigPanel({
         <div className="space-y-3">
           <div>
             <label className="mb-1 block text-xs font-medium text-slate-500">Model</label>
-            <input
-              type="text"
+            <select
               value={model}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setModel(e.target.value)}
-              placeholder="e.g. claude-opus-4-6-thinking"
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                handleModelSelect(e.target.value)
+              }
               disabled={saving}
-              data-testid="model-config-model-input"
-              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:ring-1 focus:ring-primary dark:border-slate-600 dark:bg-slate-800 dark:text-white"
-            />
+              data-testid="model-config-model-select"
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary dark:border-slate-600 dark:bg-slate-800 dark:text-white"
+            >
+              <option value="">Select a model...</option>
+              {AVAILABLE_MODELS.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.label}
+                </option>
+              ))}
+              <option value={CUSTOM_MODEL_VALUE}>Custom...</option>
+            </select>
+            {model === CUSTOM_MODEL_VALUE && (
+              <input
+                type="text"
+                value={customModel}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setCustomModel(e.target.value)
+                }
+                placeholder="e.g. claude-opus-4-6-thinking"
+                disabled={saving}
+                data-testid="model-config-model-input"
+                className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:ring-1 focus:ring-primary dark:border-slate-600 dark:bg-slate-800 dark:text-white"
+              />
+            )}
           </div>
           <div>
             <label className="mb-1 block text-xs font-medium text-slate-500">System Prompt</label>
@@ -580,7 +625,11 @@ function ModelConfigPanel({
               data-testid="model-config-model-value"
               className="text-right font-mono text-xs text-slate-700 dark:text-slate-300"
             >
-              {currentModel || "Not set"}
+              {currentModel
+                ? modelLabel
+                  ? `${modelLabel} (${currentModel})`
+                  : currentModel
+                : "Not set"}
             </span>
           </div>
           <div className="flex items-start justify-between gap-2">


### PR DESCRIPTION
## Summary
- Upgraded `ModelConfigPanel` in agent detail page from a plain text input to a dropdown selector using the shared `AVAILABLE_MODELS` list from the deploy modal
- Added a "Custom..." option that reveals a text input for arbitrary model IDs (e.g. `claude-opus-4-6-thinking`)
- Known models now display with their human-readable label in view mode (e.g. "Claude Opus 4.6 (claude-opus-4-6)")
- When editing an agent with a non-standard model, the dropdown auto-selects "Custom..." and pre-fills the text input
- Enhanced test coverage: 65 tests across model config edit logic, custom model resolution, save behavior, and API integration

Closes #505

## Test plan
- [x] All 623 dashboard tests pass (65 model-config + deploy-modal tests)
- [x] All 1757 control-plane tests pass
- [x] Typecheck clean
- [x] Lint clean (only pre-existing warnings in unrelated files)
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model selection now uses a dropdown menu with predefined options and a custom model entry option
  * Added label display for available models alongside selection

* **Tests**
  * Expanded test coverage for model configuration and deploy modal structure validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->