### PR TITLE
fix: add quarantine release banner to chat tab

### DIFF
--- a/packages/dashboard/src/components/agents/chat-panel.tsx
+++ b/packages/dashboard/src/components/agents/chat-panel.tsx
@@ -2,6 +2,7 @@
 
 import { forwardRef, useCallback, useEffect, useRef, useState } from "react"
 
+import { QuarantineBanner } from "@/components/agents/quarantine-banner"
 import { EmptyState } from "@/components/layout/empty-state"
 import { useToast } from "@/components/layout/toast"
 import { useApiQuery } from "@/hooks/use-api"
@@ -114,6 +115,8 @@ export function ChatPanel({ agentId }: ChatPanelProps): React.JSX.Element {
         </div>
       </div>
 
+      {/* Quarantine banner */}
+      <QuarantineBanner agentId={agentId} />
       {/* Delete error banner */}
       {deleteError && (
         <div className="flex items-center justify-between border-b border-red-200 bg-red-50 px-4 py-2 dark:border-red-800 dark:bg-red-900/20">

--- a/packages/dashboard/src/components/agents/quarantine-banner.tsx
+++ b/packages/dashboard/src/components/agents/quarantine-banner.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { useCallback, useState } from "react"
+
+import { useApiQuery } from "@/hooks/use-api"
+import { getAgent, releaseAgent } from "@/lib/api-client"
+
+// ---------------------------------------------------------------------------
+// QuarantineBanner — shows a prominent warning when agent is quarantined
+// with a Release button that calls releaseAgent and resets circuit breaker.
+// ---------------------------------------------------------------------------
+
+interface QuarantineBannerProps {
+  agentId: string
+}
+
+export function QuarantineBanner({ agentId }: QuarantineBannerProps): React.JSX.Element | null {
+  const { data: agent, refetch } = useApiQuery(() => getAgent(agentId), [agentId])
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [released, setReleased] = useState(false)
+
+  const handleRelease = useCallback(async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await releaseAgent(agentId, true)
+      setReleased(true)
+      void refetch()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to release agent")
+    } finally {
+      setBusy(false)
+    }
+  }, [agentId, refetch])
+
+  // Hide banner if not quarantined or if just released
+  if (!agent || agent.status !== "QUARANTINED" || released) {
+    return null
+  }
+
+  return (
+    <div className="flex items-center justify-between border-b border-red-200 bg-red-50 px-4 py-3 dark:border-red-800 dark:bg-red-900/20">
+      <div className="flex items-center gap-2">
+        <span className="material-symbols-outlined text-lg text-red-500 dark:text-red-400">
+          shield
+        </span>
+        <div>
+          <span className="text-sm font-semibold text-red-700 dark:text-red-300">
+            Agent Quarantined
+          </span>
+          <p className="text-xs text-red-600 dark:text-red-400">
+            This agent has been quarantined and cannot process messages. Release it to resume
+            operation.
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        {error && <span className="text-xs text-red-500">{error}</span>}
+        <button
+          type="button"
+          onClick={() => void handleRelease()}
+          disabled={busy}
+          className="flex shrink-0 items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+        >
+          <span className="material-symbols-outlined text-sm">lock_open</span>
+          {busy ? "Releasing..." : "Release"}
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Add a `QuarantineBanner` component that allows users to release quarantined agents directly from the chat tab, without needing to navigate to the Operations page.

## Changes

### New: `quarantine-banner.tsx`
- Fetches agent status via `useApiQuery(() => getAgent(agentId))`
- Renders a prominent red warning banner when `agent.status === "QUARANTINED"`
- Provides a **Release** button that calls `releaseAgent(agentId, true)` to unquarantine the agent and reset the circuit breaker
- Banner auto-hides after successful release (via local `released` state)
- Shows inline error feedback if release fails

### Modified: `chat-panel.tsx`
- Import and mount `<QuarantineBanner>` above the chat area, below the toolbar
- Banner appears contextually only when the agent is quarantined

## Testing
- `pnpm lint` — 0 errors (only pre-existing warnings)
- `pnpm test` — all 1831 tests pass
- `pnpm build` — builds successfully

Closes #533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quarantine banner: A new status indicator has been added to the agent chat panel. When an agent is quarantined, a banner displays the quarantine status with a Release button, allowing users to restore the agent's operation with a single click.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->