### PR TITLE
fix(#532): route Antigravity messages through Vertex AI

### DIFF
--- a/packages/control-plane/src/__tests__/http-llm.test.ts
+++ b/packages/control-plane/src/__tests__/http-llm.test.ts
@@ -1290,7 +1290,7 @@ describe("HttpLlmBackend — 401 token refresh retry", () => {
 // ---------------------------------------------------------------------------
 
 describe("HttpLlmBackend — credential provider routing", () => {
-  it("routes google-antigravity to Anthropic SDK with CloudCode PA base URL and authToken", async () => {
+  it("routes google-antigravity to Anthropic SDK with Vertex AI base URL and authToken", async () => {
     const backend = new HttpLlmBackend()
     await backend.start({ provider: "anthropic", apiKey: "global-key" })
 
@@ -1310,7 +1310,9 @@ describe("HttpLlmBackend — credential provider routing", () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     const client = (handle as any).client as { baseURL: string; authToken: string | null }
-    expect(client.baseURL).toBe("https://cloudcode-pa.googleapis.com")
+    expect(client.baseURL).toBe(
+      "https://us-east5-aiplatform.googleapis.com/v1/projects/my-gcp-project-123/locations/us-east5/publishers/anthropic",
+    )
     expect(client.authToken).toBe("gcp-oauth-token")
 
     await handle.cancel("test")
@@ -1372,7 +1374,7 @@ describe("HttpLlmBackend — credential provider routing", () => {
     await handle.cancel("test")
   })
 
-  it("uses CloudCode PA base URL even when accountId is missing", async () => {
+  it("falls back to default project when accountId is missing", async () => {
     const backend = new HttpLlmBackend()
     await backend.start({ provider: "anthropic", apiKey: "global-key" })
 
@@ -1383,7 +1385,7 @@ describe("HttpLlmBackend — credential provider routing", () => {
           provider: "google-antigravity",
           token: "gcp-oauth-token",
           credentialId: "cred-gcp-no-account",
-          // accountId omitted — not needed for cloudcode-pa
+          // accountId omitted — falls back to default project
         },
       },
     })
@@ -1392,10 +1394,75 @@ describe("HttpLlmBackend — credential provider routing", () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     const client = (handle as any).client as { baseURL: string; authToken: string | null }
-    // CloudCode PA proxy does not require accountId in the URL
-    expect(client.baseURL).toBe("https://cloudcode-pa.googleapis.com")
+    // Without accountId, uses the default project in the Vertex AI URL
+    expect(client.baseURL).toBe(
+      "https://us-east5-aiplatform.googleapis.com/v1/projects/anthropic-cortex-default/locations/us-east5/publishers/anthropic",
+    )
     expect(client.authToken).toBe("gcp-oauth-token")
 
     await handle.cancel("test")
+  })
+
+  it("uses credential baseUrl when provided (provider config override)", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "global-key" })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        llmCredential: {
+          provider: "google-antigravity",
+          token: "gcp-oauth-token",
+          credentialId: "cred-gcp-custom",
+          accountId: "my-project",
+          baseUrl: "https://custom-proxy.example.com/v1",
+        },
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    const client = (handle as any).client as { baseURL: string; authToken: string | null }
+    expect(client.baseURL).toBe("https://custom-proxy.example.com/v1")
+    expect(client.authToken).toBe("gcp-oauth-token")
+
+    await handle.cancel("test")
+  })
+
+  it("uses ANTIGRAVITY_BASE_URL env var when set", async () => {
+    const originalEnv = process.env.ANTIGRAVITY_BASE_URL
+    process.env.ANTIGRAVITY_BASE_URL = "https://env-override.example.com/anthropic"
+
+    try {
+      const backend = new HttpLlmBackend()
+      await backend.start({ provider: "anthropic", apiKey: "global-key" })
+
+      const task = makeTask({
+        constraints: {
+          ...makeTask().constraints,
+          llmCredential: {
+            provider: "google-antigravity",
+            token: "gcp-oauth-token",
+            credentialId: "cred-gcp-env",
+            accountId: "my-project",
+          },
+        },
+      })
+
+      const handle = await backend.executeTask(task)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      const client = (handle as any).client as { baseURL: string }
+      expect(client.baseURL).toBe("https://env-override.example.com/anthropic")
+
+      await handle.cancel("test")
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.ANTIGRAVITY_BASE_URL
+      } else {
+        process.env.ANTIGRAVITY_BASE_URL = originalEnv
+      }
+    }
   })
 })

--- a/packages/control-plane/src/backends/http-llm.ts
+++ b/packages/control-plane/src/backends/http-llm.ts
@@ -208,11 +208,12 @@ export class HttpLlmBackend implements ExecutionBackend {
     if (cred) {
       const credProvider = mapCredentialProvider(cred.provider)
       if (credProvider === "anthropic") {
-        // Google Antigravity routes through the CloudCode PA proxy with Bearer auth
+        // Google Antigravity routes through Vertex AI with Bearer auth.
+        // cloudcode-pa.googleapis.com is only for quota queries, NOT message routing.
         const isAntigravity = cred.provider === "google-antigravity"
         let clientBaseUrl = baseUrl
         if (isAntigravity) {
-          clientBaseUrl = "https://cloudcode-pa.googleapis.com"
+          clientBaseUrl = resolveAntigravityBaseUrl(cred.baseUrl, cred.accountId)
         }
         const client = new Anthropic({
           ...(isAntigravity ? { authToken: cred.token, apiKey: null } : { apiKey: cred.token }),
@@ -353,6 +354,28 @@ function toAnthropicTools(defs: ToolDefinition[]): Anthropic.Tool[] {
 function mapCredentialProvider(provider: string): LlmProvider {
   if (provider === "anthropic" || provider === "google-antigravity") return "anthropic"
   return "openai"
+}
+
+/**
+ * Resolve the correct base URL for Google Antigravity message routing.
+ *
+ * Priority:
+ *   1. Explicit `baseUrl` on the credential ref (set by provider config)
+ *   2. `ANTIGRAVITY_BASE_URL` env var (full URL override)
+ *   3. Constructed Vertex AI URL from accountId + region
+ *
+ * The cloudcode-pa.googleapis.com domain is NOT used here — it serves
+ * only internal quota/project-discovery endpoints, not /v1/messages.
+ */
+function resolveAntigravityBaseUrl(credBaseUrl?: string | null, accountId?: string | null): string {
+  if (credBaseUrl) return credBaseUrl
+
+  const envUrl = process.env.ANTIGRAVITY_BASE_URL
+  if (envUrl) return envUrl
+
+  const region = process.env.ANTIGRAVITY_REGION ?? "us-east5"
+  const project = accountId ?? process.env.ANTIGRAVITY_PROJECT ?? "anthropic-cortex-default"
+  return `https://${region}-aiplatform.googleapis.com/v1/projects/${project}/locations/${region}/publishers/anthropic`
 }
 
 function toOpenAITools(defs: ToolDefinition[]): OpenAI.ChatCompletionTool[] {

--- a/packages/shared/src/backends/types.ts
+++ b/packages/shared/src/backends/types.ts
@@ -95,6 +95,11 @@ export interface LlmCredentialRef {
   credentialId: string
   /** Provider account ID (e.g. GCP project ID for google-antigravity). */
   accountId?: string | null
+  /**
+   * Provider-specific base URL for the LLM API.
+   * When set, overrides any URL the backend would derive from the provider.
+   */
+  baseUrl?: string | null
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Removed hardcoded `cloudcode-pa.googleapis.com`** base URL for Antigravity message routing — that domain only serves quota/project-discovery endpoints, not `/v1/messages`
- **Added `resolveAntigravityBaseUrl()`** helper that constructs the correct Vertex AI URL from the credential's `accountId` (GCP project ID) and configurable region
- **Added `baseUrl` field to `LlmCredentialRef`** for provider config abstraction — credentials can now carry an explicit base URL override
- **Env var support**: `ANTIGRAVITY_BASE_URL` (full override), `ANTIGRAVITY_REGION` (default: `us-east5`), `ANTIGRAVITY_PROJECT` (fallback project)

Closes #532

## Test plan
- [x] Existing Antigravity routing test updated to expect Vertex AI URL
- [x] New test: falls back to default project when `accountId` is missing
- [x] New test: uses `credential.baseUrl` when provider config supplies it
- [x] New test: uses `ANTIGRAVITY_BASE_URL` env var override
- [x] All 1833 tests pass, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now specify custom base URLs for LLM credential configurations, enabling flexibility in API endpoint routing
  * Added environment variable support to override credential base URL settings globally
  * Extended per-task credential options to support custom endpoint configurations for enhanced control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->