### PR TITLE
fix(#543): add browser screenshot/event persistence

### DIFF
--- a/packages/control-plane/migrations/033_browser_observation.down.sql
+++ b/packages/control-plane/migrations/033_browser_observation.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS browser_event;
+DROP TABLE IF EXISTS browser_screenshot;
+DROP TYPE IF EXISTS browser_event_severity;
+DROP TYPE IF EXISTS browser_event_type;

--- a/packages/control-plane/migrations/033_browser_observation.up.sql
+++ b/packages/control-plane/migrations/033_browser_observation.up.sql
@@ -1,0 +1,34 @@
+-- Browser observation persistence: screenshots + events
+-- Closes #543
+
+CREATE TYPE browser_event_type AS ENUM (
+  'GET', 'CLICK', 'CONSOLE', 'SNAPSHOT', 'NAVIGATE', 'ERROR'
+);
+
+CREATE TYPE browser_event_severity AS ENUM ('info', 'warn', 'error');
+
+CREATE TABLE browser_screenshot (
+  id              UUID              PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id        UUID              NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
+  thumbnail_url   TEXT              NOT NULL,
+  full_url        TEXT              NOT NULL,
+  width           INT               NOT NULL,
+  height          INT               NOT NULL,
+  created_at      TIMESTAMPTZ       NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_browser_screenshot_agent ON browser_screenshot (agent_id, created_at DESC);
+
+CREATE TABLE browser_event (
+  id              UUID                    PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id        UUID                    NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
+  type            browser_event_type      NOT NULL,
+  url             TEXT,
+  selector        TEXT,
+  message         TEXT,
+  duration_ms     INT,
+  severity        browser_event_severity  NOT NULL DEFAULT 'info',
+  created_at      TIMESTAMPTZ             NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_browser_event_agent ON browser_event (agent_id, created_at DESC);

--- a/packages/control-plane/src/__tests__/dashboard-routes.test.ts
+++ b/packages/control-plane/src/__tests__/dashboard-routes.test.ts
@@ -7,6 +7,8 @@ import { dashboardRoutes } from "../routes/dashboard.js"
 
 const JOB_UUID = "00000000-0000-4000-8000-000000000001"
 const AGENT_UUID = "00000000-0000-4000-8000-000000000002"
+const SCREENSHOT_UUID = "00000000-0000-4000-8000-000000000010"
+const EVENT_UUID = "00000000-0000-4000-8000-000000000011"
 
 function makeJob(overrides: Record<string, unknown> = {}) {
   return {
@@ -45,8 +47,14 @@ function makeJob(overrides: Record<string, unknown> = {}) {
 function mockDb(
   jobOverrides: Record<string, unknown> = {},
   agentEventRows: Record<string, unknown>[] = [],
+  opts: {
+    screenshotRows?: Record<string, unknown>[]
+    browserEventRows?: Record<string, unknown>[]
+  } = {},
 ) {
   const jobs = [makeJob(jobOverrides)]
+  const screenshotRows = opts.screenshotRows ?? []
+  const browserEventRows = opts.browserEventRows ?? []
   const memoryRows = [
     {
       id: "mem-1",
@@ -106,6 +114,8 @@ function mockDb(
       if (table === "agent_event") return selectChain(agentEventRows)
       if (table === "memory_extract_message") return selectChain(memoryRows)
       if (table === "approval_request") return selectChain([{ count: 0 }])
+      if (table === "browser_screenshot") return selectChain(screenshotRows)
+      if (table === "browser_event") return selectChain(browserEventRows)
       return selectChain([])
     }),
     updateTable: vi.fn().mockImplementation((table: string) => {
@@ -118,9 +128,13 @@ function mockDb(
 async function buildTestApp(
   jobOverrides: Record<string, unknown> = {},
   agentEventRows: Record<string, unknown>[] = [],
+  opts: {
+    screenshotRows?: Record<string, unknown>[]
+    browserEventRows?: Record<string, unknown>[]
+  } = {},
 ) {
   const app = Fastify({ logger: false })
-  const db = mockDb(jobOverrides, agentEventRows)
+  const db = mockDb(jobOverrides, agentEventRows, opts)
 
   await app.register(
     dashboardRoutes({
@@ -408,6 +422,99 @@ describe("dashboard routes", () => {
       error: "not_found",
       message: "Content item not found",
     })
+  })
+
+  it("returns persisted screenshots from database", async () => {
+    const { app } = await buildTestApp({}, [], {
+      screenshotRows: [
+        {
+          id: SCREENSHOT_UUID,
+          agent_id: AGENT_UUID,
+          thumbnail_url: "/thumbs/shot1.jpg",
+          full_url: "/shots/shot1.png",
+          width: 1920,
+          height: 1080,
+          created_at: new Date("2026-03-10T12:00:00.000Z"),
+        },
+      ],
+    })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_UUID}/browser/screenshots`,
+    })
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.screenshots).toHaveLength(1)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.screenshots[0]).toMatchObject({
+      id: SCREENSHOT_UUID,
+      agentId: AGENT_UUID,
+      thumbnailUrl: "/thumbs/shot1.jpg",
+      fullUrl: "/shots/shot1.png",
+      dimensions: { width: 1920, height: 1080 },
+    })
+  })
+
+  it("returns persisted browser events from database", async () => {
+    const { app } = await buildTestApp({}, [], {
+      browserEventRows: [
+        {
+          id: EVENT_UUID,
+          agent_id: AGENT_UUID,
+          type: "NAVIGATE",
+          url: "https://example.com",
+          selector: null,
+          message: null,
+          duration_ms: 120,
+          severity: "info",
+          created_at: new Date("2026-03-10T12:01:00.000Z"),
+        },
+      ],
+    })
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_UUID}/browser/events`,
+    })
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.events).toHaveLength(1)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.events[0]).toMatchObject({
+      id: EVENT_UUID,
+      type: "NAVIGATE",
+      url: "https://example.com",
+      durationMs: 120,
+      severity: "info",
+    })
+    // null fields should be omitted
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.events[0].selector).toBeUndefined()
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.events[0].message).toBeUndefined()
+  })
+
+  it("returns empty arrays when no browser data exists", async () => {
+    const { app } = await buildTestApp()
+
+    const screenshots = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_UUID}/browser/screenshots`,
+    })
+    expect(screenshots.statusCode).toBe(200)
+    expect(screenshots.json()).toEqual({ screenshots: [] })
+
+    const events = await app.inject({
+      method: "GET",
+      url: `/agents/${AGENT_UUID}/browser/events`,
+    })
+    expect(events.statusCode).toBe(200)
+    expect(events.json()).toEqual({ events: [] })
   })
 
   it("returns 501 for memory sync stub", async () => {

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -932,6 +932,53 @@ export type NewContentItem = Insertable<ContentItemTable>
 export type ContentItemUpdate = Updateable<ContentItemTable>
 
 // ---------------------------------------------------------------------------
+// Table: browser_screenshot
+// ---------------------------------------------------------------------------
+export type BrowserScreenshotEventType =
+  | "GET"
+  | "CLICK"
+  | "CONSOLE"
+  | "SNAPSHOT"
+  | "NAVIGATE"
+  | "ERROR"
+export type BrowserEventSeverity = "info" | "warn" | "error"
+
+export interface BrowserScreenshotTable {
+  id: Generated<string>
+  agent_id: string
+  thumbnail_url: string
+  full_url: string
+  width: number
+  height: number
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
+export type BrowserScreenshot = Selectable<BrowserScreenshotTable>
+export type NewBrowserScreenshot = Insertable<BrowserScreenshotTable>
+
+// ---------------------------------------------------------------------------
+// Table: browser_event
+// ---------------------------------------------------------------------------
+export interface BrowserEventTable {
+  id: Generated<string>
+  agent_id: string
+  type: ColumnType<
+    BrowserScreenshotEventType,
+    BrowserScreenshotEventType,
+    BrowserScreenshotEventType
+  >
+  url: string | null
+  selector: string | null
+  message: string | null
+  duration_ms: number | null
+  severity: ColumnType<BrowserEventSeverity, BrowserEventSeverity | undefined, BrowserEventSeverity>
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
+export type BrowserEvent = Selectable<BrowserEventTable>
+export type NewBrowserEvent = Insertable<BrowserEventTable>
+
+// ---------------------------------------------------------------------------
 // Database interface — register all tables here.
 // ---------------------------------------------------------------------------
 export interface Database {
@@ -968,4 +1015,6 @@ export interface Database {
   channel_allowlist: ChannelAllowlistTable
   channel_allowlist_audit: ChannelAllowlistAuditTable
   content_item: ContentItemTable
+  browser_screenshot: BrowserScreenshotTable
+  browser_event: BrowserEventTable
 }

--- a/packages/control-plane/src/routes/dashboard.ts
+++ b/packages/control-plane/src/routes/dashboard.ts
@@ -803,15 +803,58 @@ export function dashboardRoutes(deps: DashboardRouteDeps) {
 
     app.get<{ Params: AgentParams; Querystring: BrowserScreenshotsQuery }>(
       "/agents/:agentId/browser/screenshots",
-      async (_request, reply) => {
-        return reply.send({ screenshots: [] })
+      async (request, reply) => {
+        const { agentId } = request.params
+        const limit = Math.min(Number(request.query.limit) || 50, 200)
+
+        const rows = await db
+          .selectFrom("browser_screenshot")
+          .selectAll()
+          .where("agent_id", "=", agentId)
+          .orderBy("created_at", "desc")
+          .limit(limit)
+          .execute()
+
+        const screenshots = rows.map((r) => ({
+          id: r.id,
+          agentId: r.agent_id,
+          timestamp: new Date(r.created_at).toISOString(),
+          thumbnailUrl: r.thumbnail_url,
+          fullUrl: r.full_url,
+          dimensions: { width: r.width, height: r.height },
+        }))
+
+        return reply.send({ screenshots })
       },
     )
 
     app.get<{ Params: AgentParams; Querystring: BrowserEventsQuery }>(
       "/agents/:agentId/browser/events",
-      async (_request, reply) => {
-        return reply.send({ events: [] })
+      async (request, reply) => {
+        const { agentId } = request.params
+        const limit = Math.min(Number(request.query.limit) || 50, 200)
+        const typeFilter = request.query.types?.split(",").filter(Boolean)
+
+        let query = db.selectFrom("browser_event").selectAll().where("agent_id", "=", agentId)
+
+        if (typeFilter && typeFilter.length > 0) {
+          query = query.where("type", "in", typeFilter as never)
+        }
+
+        const rows = await query.orderBy("created_at", "desc").limit(limit).execute()
+
+        const events = rows.map((r) => ({
+          id: r.id,
+          type: r.type,
+          timestamp: new Date(r.created_at).toISOString(),
+          ...(r.url != null && { url: r.url }),
+          ...(r.selector != null && { selector: r.selector }),
+          ...(r.message != null && { message: r.message }),
+          ...(r.duration_ms != null && { durationMs: r.duration_ms }),
+          ...(r.severity != null && { severity: r.severity }),
+        }))
+
+        return reply.send({ events })
       },
     )
 


### PR DESCRIPTION
## Summary
- **Migration 033**: Creates `browser_screenshot` and `browser_event` tables with indexes on `(agent_id, created_at DESC)`
- **DB types**: Adds `BrowserScreenshotTable`, `BrowserEventTable`, and registers them in the `Database` interface
- **Route handlers**: Wires `GET /agents/:agentId/browser/screenshots` and `GET /agents/:agentId/browser/events` to query the new tables with pagination (`limit`) and optional type filtering
- **Tests**: 3 new test cases covering populated screenshots, populated events with null-field omission, and empty-state fallback

Closes #543

## Test plan
- [x] `npx vitest run` — 111 files, 1857 tests pass
- [x] `npx eslint` — no new errors
- [x] `npm run typecheck` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser observation capabilities to store and retrieve browser activity for monitored agents, including screenshots and event logs capturing interactions (navigation, clicks, console messages) with metadata such as URLs, selectors, duration, and severity classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->