### PR TITLE
fix(#544): enforce access_level in channel auth guard

### DIFF
--- a/packages/control-plane/src/auth/__tests__/channel-auth-guard.test.ts
+++ b/packages/control-plane/src/auth/__tests__/channel-auth-guard.test.ts
@@ -521,6 +521,85 @@ describe("ChannelAuthGuard", () => {
   })
 
   // -----------------------------------------------------------------------
+  // authorize — access_level enforcement
+  // -----------------------------------------------------------------------
+  describe("authorize — access_level enforcement", () => {
+    it("denies write intent when grant has read-only access", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "allowlist" }),
+        grant: makeGrant({ access_level: "read" }),
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize({ ...baseParams, intent: "write" })
+
+      expect(decision.allowed).toBe(false)
+      expect(decision.reason).toBe("read_only")
+      expect(decision.accessLevel).toBe("read")
+      expect(decision.grantId).toBe(GRANT_ID)
+      expect(decision.replyToUser).toContain("read-only")
+    })
+
+    it("allows read intent when grant has read-only access", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "allowlist" }),
+        grant: makeGrant({ access_level: "read" }),
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize({ ...baseParams, intent: "read" })
+
+      expect(decision.allowed).toBe(true)
+      expect(decision.reason).toBe("granted")
+      expect(decision.accessLevel).toBe("read")
+    })
+
+    it("allows write intent when grant has write access", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "allowlist" }),
+        grant: makeGrant({ access_level: "write" }),
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      const decision = await guard.authorize({ ...baseParams, intent: "write" })
+
+      expect(decision.allowed).toBe(true)
+      expect(decision.reason).toBe("granted")
+      expect(decision.accessLevel).toBe("write")
+    })
+
+    it("defaults intent to write (backward compat)", async () => {
+      const { db } = buildMockDb({
+        agent: makeAgent({ auth_model: "allowlist" }),
+        grant: makeGrant({ access_level: "read" }),
+      })
+      const guard = new ChannelAuthGuard({
+        db,
+        pairingService: makePairingService(),
+        accessRequestService: makeAccessRequestService(),
+      })
+
+      // No intent specified — should default to "write" and deny read-only
+      const decision = await guard.authorize(baseParams)
+
+      expect(decision.allowed).toBe(false)
+      expect(decision.reason).toBe("read_only")
+    })
+  })
+
+  // -----------------------------------------------------------------------
   // authorize — revoked / expired grants
   // -----------------------------------------------------------------------
   describe("authorize — revoked grant", () => {

--- a/packages/control-plane/src/auth/channel-auth-guard.ts
+++ b/packages/control-plane/src/auth/channel-auth-guard.ts
@@ -16,6 +16,8 @@ export interface AuthorizeParams {
   chatId: string
   messageText?: string
   channelConfigId?: string
+  /** Whether the caller intends to read or write. Defaults to "write". */
+  intent?: "read" | "write"
 }
 
 export type AuthDecisionReason =
@@ -29,12 +31,14 @@ export type AuthDecisionReason =
   | "budget_exceeded"
   | "revoked"
   | "expired"
+  | "read_only"
 
 export interface AuthDecision {
   allowed: boolean
   userId: string
   grantId?: string
   reason: AuthDecisionReason
+  accessLevel?: "read" | "write"
   replyToUser?: string
 }
 
@@ -84,7 +88,15 @@ export class ChannelAuthGuard {
    * checks for an existing grant, and applies the appropriate policy.
    */
   async authorize(params: AuthorizeParams): Promise<AuthDecision> {
-    const { agentId, channelType, channelUserId, chatId, messageText, channelConfigId } = params
+    const {
+      agentId,
+      channelType,
+      channelUserId,
+      chatId,
+      messageText,
+      channelConfigId,
+      intent = "write",
+    } = params
 
     // 1. Resolve or create identity
     const { userAccountId, channelMappingId } = await this.resolveOrCreateIdentity(
@@ -156,12 +168,25 @@ export class ChannelAuthGuard {
         }
       }
 
-      // Valid grant exists — allowed
+      // Valid grant exists — check access_level vs intent
+      const grantLevel = grant.access_level ?? "write"
+      if (intent === "write" && grantLevel === "read") {
+        return {
+          allowed: false,
+          userId: userAccountId,
+          grantId: grant.id,
+          reason: "read_only",
+          accessLevel: "read",
+          replyToUser: "You have read-only access to this agent.",
+        }
+      }
+
       return {
         allowed: true,
         userId: userAccountId,
         grantId: grant.id,
         reason: "granted",
+        accessLevel: grantLevel,
       }
     }
 


### PR DESCRIPTION
## Summary
- **Bug**: `agent_user_grant.access_level` (read/write) was stored but never enforced — read-only users could send messages just like write users
- **Fix**: `authorize()` now checks the grant's `access_level` against a new `intent` parameter (defaults to `"write"`), denying write operations for read-only grants with reason `"read_only"`
- Added `accessLevel` field to `AuthDecision` so callers can inspect the resolved level
- 4 new tests covering read-only denial, read intent passthrough, write grant passthrough, and default-intent backward compat

## Test plan
- [x] 4 new unit tests in `channel-auth-guard.test.ts` (32 total, all passing)
- [x] Full suite: 1861 tests pass, 0 failures
- [x] Lint + typecheck clean on changed files

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added read-only access level enforcement for channel authorization, allowing fine-grained permission control between read and write operations.
  * Callers can now specify their intended access level, with automatic downgrade to read-only when appropriate.

* **Tests**
  * Added comprehensive test coverage for access level enforcement scenarios, including read/write validation and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->