### PR TITLE
fix(#546): emit binding_updated audit event in PUT tool-bindings route

### DIFF
--- a/packages/control-plane/src/__tests__/agent-tool-binding-routes.test.ts
+++ b/packages/control-plane/src/__tests__/agent-tool-binding-routes.test.ts
@@ -414,6 +414,20 @@ describe("PUT /agents/:agentId/tool-bindings/:bindingId", () => {
     expect(res.statusCode).toBe(404)
   })
 
+  it("writes audit log on successful update", async () => {
+    const updated = makeBinding({ approval_policy: "always_approve" })
+    const { app, auditInsertValues } = await buildTestApp({ updatedBinding: updated })
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/agents/${AGENT_ID}/tool-bindings/${BINDING_ID}`,
+      payload: { approvalPolicy: "always_approve" },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(auditInsertValues).toHaveBeenCalled()
+  })
+
   it("returns 400 when no fields provided", async () => {
     const { app } = await buildTestApp()
 

--- a/packages/control-plane/src/routes/agent-tool-bindings.ts
+++ b/packages/control-plane/src/routes/agent-tool-bindings.ts
@@ -387,6 +387,18 @@ export function agentToolBindingRoutes(deps: AgentToolBindingRouteDeps) {
           return reply.status(404).send({ error: "not_found", message: "Binding not found" })
         }
 
+        // Audit log
+        await db
+          .insertInto("capability_audit_log")
+          .values({
+            agent_id: agentId,
+            tool_ref: updated.tool_ref,
+            event_type: "binding_updated",
+            actor_user_id: principal.userId,
+            details: { binding_id: bindingId, changed_fields: Object.keys(updates) },
+          })
+          .execute()
+
         return reply.status(200).send({
           id: updated.id,
           agentId: updated.agent_id,


### PR DESCRIPTION
## Summary
- The `PUT /agents/:agentId/tool-bindings/:bindingId` route was the only binding mutation that did **not** write to `capability_audit_log` (CREATE, DELETE, and bulk-create all did)
- Adds a `binding_updated` audit event after successful update, capturing `binding_id` and `changed_fields` in details
- Adds test asserting audit log is written on update

Closes #546

## Test plan
- [x] New test: "writes audit log on successful update" verifies `auditInsertValues` is called
- [x] All 21 route tests pass
- [x] Full suite: 1868 passed, 1 skipped
- [x] Lint + typecheck clean (pre-existing errors in unrelated files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit logging now captures changes made to tool bindings, including binding ID and modified fields.

* **Tests**
  * Added test case to verify audit log entries are created on successful tool binding updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->