### PR TITLE
fix(#551): add requireAuth middleware to feedback routes

### DIFF
--- a/packages/control-plane/src/__tests__/feedback-routes.test.ts
+++ b/packages/control-plane/src/__tests__/feedback-routes.test.ts
@@ -1,0 +1,226 @@
+import Fastify, { type FastifyInstance } from "fastify"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { FeedbackService } from "../feedback/service.js"
+import { hashApiKey } from "../middleware/api-keys.js"
+import type { AuthConfig } from "../middleware/types.js"
+import { feedbackRoutes } from "../routes/feedback.js"
+
+// ---------------------------------------------------------------------------
+// Test keys & auth config
+// ---------------------------------------------------------------------------
+
+const OPERATOR_KEY = "sk-operator-feedback-test"
+
+const authConfig: AuthConfig = {
+  apiKeys: [
+    {
+      keyHash: hashApiKey(OPERATOR_KEY),
+      userId: "user-operator",
+      roles: ["operator"],
+      label: "Operator Key",
+    },
+  ],
+  requireAuth: true,
+}
+
+// ---------------------------------------------------------------------------
+// Mock FeedbackService
+// ---------------------------------------------------------------------------
+
+function createMockFeedbackService() {
+  return {
+    listFeedback: vi.fn().mockResolvedValue([]),
+    createFeedback: vi.fn().mockResolvedValue({ id: "fb-1", summary: "test" }),
+    getFeedback: vi.fn().mockResolvedValue({ id: "fb-1", summary: "test" }),
+    updateRemediation: vi.fn().mockResolvedValue({ id: "fb-1", status: "resolved" }),
+    getActions: vi.fn().mockResolvedValue([]),
+    addAction: vi.fn().mockResolvedValue({ id: "action-1", actionType: "note" }),
+  } as unknown as FeedbackService
+}
+
+// ---------------------------------------------------------------------------
+// Tests — auth required
+// ---------------------------------------------------------------------------
+
+describe("Feedback routes with auth", () => {
+  let app: FastifyInstance
+  let mockService: ReturnType<typeof createMockFeedbackService>
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false })
+    mockService = createMockFeedbackService()
+
+    await app.register(
+      feedbackRoutes({
+        feedbackService: mockService as unknown as FeedbackService,
+        authConfig,
+      }),
+    )
+    await app.ready()
+  })
+
+  afterEach(async () => {
+    await app.close()
+    vi.restoreAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // GET /api/feedback
+  // -------------------------------------------------------------------------
+  describe("GET /api/feedback", () => {
+    it("returns 401 without auth", async () => {
+      const res = await app.inject({ method: "GET", url: "/api/feedback" })
+      expect(res.statusCode).toBe(401)
+    })
+
+    it("returns 200 with valid auth", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/feedback",
+        headers: { authorization: `Bearer ${OPERATOR_KEY}` },
+      })
+      expect(res.statusCode).toBe(200)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // POST /api/feedback
+  // -------------------------------------------------------------------------
+  describe("POST /api/feedback", () => {
+    const body = {
+      source: "agent",
+      category: "error",
+      severity: "medium",
+      summary: "test feedback",
+    }
+
+    it("returns 401 without auth", async () => {
+      const res = await app.inject({ method: "POST", url: "/api/feedback", payload: body })
+      expect(res.statusCode).toBe(401)
+    })
+
+    it("returns 201 with valid auth", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/feedback",
+        headers: { authorization: `Bearer ${OPERATOR_KEY}` },
+        payload: body,
+      })
+      expect(res.statusCode).toBe(201)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // GET /api/feedback/:id
+  // -------------------------------------------------------------------------
+  describe("GET /api/feedback/:id", () => {
+    it("returns 401 without auth", async () => {
+      const res = await app.inject({ method: "GET", url: "/api/feedback/fb-1" })
+      expect(res.statusCode).toBe(401)
+    })
+
+    it("returns 200 with valid auth", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/feedback/fb-1",
+        headers: { authorization: `Bearer ${OPERATOR_KEY}` },
+      })
+      expect(res.statusCode).toBe(200)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // PATCH /api/feedback/:id
+  // -------------------------------------------------------------------------
+  describe("PATCH /api/feedback/:id", () => {
+    it("returns 401 without auth", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/feedback/fb-1",
+        payload: { status: "resolved" },
+      })
+      expect(res.statusCode).toBe(401)
+    })
+
+    it("returns 200 with valid auth", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/api/feedback/fb-1",
+        headers: { authorization: `Bearer ${OPERATOR_KEY}` },
+        payload: { status: "resolved" },
+      })
+      expect(res.statusCode).toBe(200)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // POST /api/feedback/:id/actions
+  // -------------------------------------------------------------------------
+  describe("POST /api/feedback/:id/actions", () => {
+    it("returns 401 without auth", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/feedback/fb-1/actions",
+        payload: { actionType: "note", description: "test" },
+      })
+      expect(res.statusCode).toBe(401)
+    })
+
+    it("returns 201 with valid auth", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/feedback/fb-1/actions",
+        headers: { authorization: `Bearer ${OPERATOR_KEY}` },
+        payload: { actionType: "note", description: "test" },
+      })
+      expect(res.statusCode).toBe(201)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests — dev mode (no auth)
+// ---------------------------------------------------------------------------
+
+describe("Feedback routes in dev mode (no auth)", () => {
+  const devConfig: AuthConfig = {
+    apiKeys: [],
+    requireAuth: false,
+  }
+
+  let app: FastifyInstance
+  let mockService: ReturnType<typeof createMockFeedbackService>
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false })
+    mockService = createMockFeedbackService()
+
+    await app.register(
+      feedbackRoutes({
+        feedbackService: mockService as unknown as FeedbackService,
+        authConfig: devConfig,
+      }),
+    )
+    await app.ready()
+  })
+
+  afterEach(async () => {
+    await app.close()
+    vi.restoreAllMocks()
+  })
+
+  it("allows GET /api/feedback without auth in dev mode", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/feedback" })
+    expect(res.statusCode).toBe(200)
+  })
+
+  it("allows POST /api/feedback without auth in dev mode", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/feedback",
+      payload: { source: "agent", category: "error", severity: "medium", summary: "test" },
+    })
+    expect(res.statusCode).toBe(201)
+  })
+})

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -210,7 +210,7 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
 
   // Register approval routes (always available)
   await app.register(approvalRoutes({ approvalService, sseManager, authConfig, sessionService }))
-  await app.register(feedbackRoutes({ feedbackService }))
+  await app.register(feedbackRoutes({ feedbackService, authConfig, sessionService }))
 
   // Register agent CRUD + job routes
   await app.register(

--- a/packages/control-plane/src/routes/feedback.ts
+++ b/packages/control-plane/src/routes/feedback.ts
@@ -9,7 +9,14 @@ import type {
 } from "@cortex/shared"
 import type { FastifyInstance } from "fastify"
 
+import type { SessionService } from "../auth/session-service.js"
 import type { FeedbackService } from "../feedback/service.js"
+import {
+  type AuthMiddlewareOptions,
+  createRequireAuth,
+  type PreHandler,
+} from "../middleware/auth.js"
+import type { AuthConfig } from "../middleware/types.js"
 
 interface CreateFeedbackBody {
   runId?: string
@@ -47,31 +54,49 @@ interface AddActionBody {
 
 export interface FeedbackRouteDeps {
   feedbackService: FeedbackService
+  authConfig: AuthConfig
+  sessionService?: SessionService
 }
 
 export function feedbackRoutes(deps: FeedbackRouteDeps) {
-  const { feedbackService } = deps
+  const { feedbackService, authConfig, sessionService } = deps
+
+  const authOpts: AuthMiddlewareOptions = { config: authConfig, sessionService }
+  const requireAuth: PreHandler = createRequireAuth(authOpts)
 
   return function register(app: FastifyInstance): void {
-    app.get<{ Querystring: ListFeedbackQuery }>("/api/feedback", async (request, reply) => {
-      const items = await feedbackService.listFeedback(request.query)
-      return reply.status(200).send({ feedback: items })
-    })
+    app.get<{ Querystring: ListFeedbackQuery }>(
+      "/api/feedback",
+      { preHandler: [requireAuth] },
+      async (request, reply) => {
+        const items = await feedbackService.listFeedback(request.query)
+        return reply.status(200).send({ feedback: items })
+      },
+    )
 
-    app.post<{ Body: CreateFeedbackBody }>("/api/feedback", async (request, reply) => {
-      const created = await feedbackService.createFeedback(request.body)
-      return reply.status(201).send(created)
-    })
+    app.post<{ Body: CreateFeedbackBody }>(
+      "/api/feedback",
+      { preHandler: [requireAuth] },
+      async (request, reply) => {
+        const created = await feedbackService.createFeedback(request.body)
+        return reply.status(201).send(created)
+      },
+    )
 
-    app.get<{ Params: { id: string } }>("/api/feedback/:id", async (request, reply) => {
-      const item = await feedbackService.getFeedback(request.params.id)
-      if (!item) return reply.status(404).send({ error: "not_found" })
-      const actions = await feedbackService.getActions(request.params.id)
-      return reply.status(200).send({ ...item, actions })
-    })
+    app.get<{ Params: { id: string } }>(
+      "/api/feedback/:id",
+      { preHandler: [requireAuth] },
+      async (request, reply) => {
+        const item = await feedbackService.getFeedback(request.params.id)
+        if (!item) return reply.status(404).send({ error: "not_found" })
+        const actions = await feedbackService.getActions(request.params.id)
+        return reply.status(200).send({ ...item, actions })
+      },
+    )
 
     app.patch<{ Params: { id: string }; Body: UpdateFeedbackBody }>(
       "/api/feedback/:id",
+      { preHandler: [requireAuth] },
       async (request, reply) => {
         const resolvedAt =
           request.body.resolvedAt === undefined
@@ -93,6 +118,7 @@ export function feedbackRoutes(deps: FeedbackRouteDeps) {
 
     app.post<{ Params: { id: string }; Body: AddActionBody }>(
       "/api/feedback/:id/actions",
+      { preHandler: [requireAuth] },
       async (request, reply) => {
         const parent = await feedbackService.getFeedback(request.params.id)
         if (!parent) return reply.status(404).send({ error: "not_found" })


### PR DESCRIPTION
## Summary
- Add `requireAuth` preHandler to all five `/api/feedback/*` endpoints (GET list, POST create, GET by id, PATCH update, POST actions)
- Pass `authConfig` and `sessionService` through `FeedbackRouteDeps` and app.ts registration
- Add 12 tests covering 401 rejection without auth and success with valid auth for all endpoints, plus dev-mode passthrough

Closes #551

## Test plan
- [x] `npx vitest run src/__tests__/feedback-routes.test.ts` — 12 tests pass
- [x] Lint clean (no new errors)
- [x] Typecheck passes (pre-existing errors in unrelated files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feedback API endpoints now require authentication across all operations: listing feedback, creating entries, retrieving records, updating feedback, and triggering actions.

* **Tests**
  * Comprehensive test suite added for Feedback API routes with coverage for authenticated access, development mode access, and authentication validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->