### PR TITLE
cleanup(#552): remove unused approval notification stubs

### DIFF
--- a/packages/control-plane/src/__tests__/approval-auth-routes.test.ts
+++ b/packages/control-plane/src/__tests__/approval-auth-routes.test.ts
@@ -79,7 +79,6 @@ function createMockApprovalService() {
     }),
     getAuditTrail: vi.fn().mockResolvedValue([]),
     getPendingForJob: vi.fn().mockResolvedValue([]),
-    recordNotification: vi.fn().mockResolvedValue(undefined),
     expireStaleRequests: vi.fn().mockResolvedValue(0),
   } as unknown as ApprovalService
 }

--- a/packages/control-plane/src/approval/service.ts
+++ b/packages/control-plane/src/approval/service.ts
@@ -14,7 +14,6 @@
 import {
   type ApprovalAuditEventType,
   type ApprovalDecisionResult,
-  type ApprovalNotificationRecord,
   type ApprovalStatus,
   type CreateApprovalRequest,
   MAX_APPROVAL_TTL_SECONDS,
@@ -352,52 +351,6 @@ export class ApprovalService {
     }
 
     return expiredRequests.length
-  }
-
-  async recordNotification(
-    approvalRequestId: string,
-    notification: ApprovalNotificationRecord,
-  ): Promise<void> {
-    const request = await this.db
-      .selectFrom("approval_request")
-      .select(["id", "job_id", "notification_channels"])
-      .where("id", "=", approvalRequestId)
-      .executeTakeFirst()
-
-    if (!request) return
-
-    const channels = Array.isArray(request.notification_channels)
-      ? [...request.notification_channels, notification]
-      : [notification]
-
-    await this.db
-      .updateTable("approval_request")
-      .set({ notification_channels: channels as Record<string, unknown>[] })
-      .where("id", "=", approvalRequestId)
-      .execute()
-
-    await this.writeAuditLog({
-      approvalRequestId,
-      jobId: request.job_id,
-      eventType: "notification_sent",
-      details: {
-        channel_type: notification.channel_type,
-        channel_user_id: notification.channel_user_id,
-        chat_id: notification.chat_id,
-        message_id: notification.message_id,
-      },
-    })
-  }
-
-  async shouldNotify(approvalRequestId: string): Promise<boolean> {
-    const req = await this.db
-      .selectFrom("approval_request")
-      .select(["risk_level"])
-      .where("id", "=", approvalRequestId)
-      .executeTakeFirst()
-    if (!req) return false
-    if (req.risk_level === "P3") return false
-    return true
   }
 
   async getRequest(approvalRequestId: string): Promise<ApprovalRequest | undefined> {


### PR DESCRIPTION
## Summary
- Remove dead `recordNotification()` and `shouldNotify()` methods from `ApprovalService` (never called in production code)
- Remove corresponding mock in `approval-auth-routes.test.ts`
- Retain `notification_channels` DB column and shared `ApprovalNotificationRecord` type for future use

Closes #552

## Test plan
- [x] All 52 existing approval tests pass (approval-service + approval-auth-routes)
- [x] Lint clean on changed files
- [x] Typecheck shows only pre-existing unrelated errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)