### PR TITLE
fix(#554): propagate chat job error details

### DIFF
--- a/packages/control-plane/src/__tests__/chat-session-crud.test.ts
+++ b/packages/control-plane/src/__tests__/chat-session-crud.test.ts
@@ -726,3 +726,101 @@ describe("Dashboard reflects session state changes", () => {
     expect(enqueueJob).toHaveBeenCalledWith("job-async-1")
   })
 })
+
+// ---------------------------------------------------------------------------
+// Sync wait: error detail propagation (#554)
+// ---------------------------------------------------------------------------
+
+describe("Sync wait propagates job error details (#554)", () => {
+  it("returns error message from job error column on FAILED job", async () => {
+    const jobError = { category: "LLM_ERROR", message: "Rate limit exceeded" }
+
+    // Make watchJobCompletion invoke the callback immediately with FAILED status
+    mockWatchJobCompletion.mockImplementation(
+      (_db: unknown, _jobId: string, cb: (result: unknown, status: string) => Promise<void>) => {
+        void cb(null, "FAILED")
+      },
+    )
+
+    // Build db where job-table selectFrom returns the error column
+    const { db: baseDb } = mockDb({ job: { id: "job-fail-1" } })
+    const { db: fallbackDb } = mockDb({ job: { id: "job-fail-1" } })
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const baseSelectFrom = vi.mocked(baseDb.selectFrom)
+    baseSelectFrom.mockImplementation((table: string) => {
+      if (table === "job") {
+        const executeTakeFirst = vi.fn().mockResolvedValue({ error: jobError })
+        const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+        whereFn.mockReturnValue({ where: whereFn, executeTakeFirst })
+        const select = vi.fn().mockReturnValue({ where: whereFn, executeTakeFirst })
+        return { select } as never
+      }
+      return (fallbackDb.selectFrom as ReturnType<typeof vi.fn>)(table) as never
+    })
+    const db = baseDb
+
+    mockMapJobErrorToUserMessage.mockReturnValue("Rate limit exceeded")
+    const enqueueJob = vi.fn().mockResolvedValue(undefined)
+    const app = await buildApp(db, enqueueJob)
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/chat?wait=true&timeout=5000`,
+      payload: { text: "Fail test" },
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    expect(body.status).toBe("FAILED")
+    expect(body.error).toBeDefined()
+    expect(body.error.message).toBe("Rate limit exceeded")
+    expect(body.error.code).toBe("job_failed")
+  })
+
+  it("returns fallback error message when error column fetch fails", async () => {
+    // Make watchJobCompletion invoke the callback immediately with FAILED status
+    mockWatchJobCompletion.mockImplementation(
+      (_db: unknown, _jobId: string, cb: (result: unknown, status: string) => Promise<void>) => {
+        void cb(null, "FAILED")
+      },
+    )
+
+    // Build db where job-table selectFrom rejects (simulates connection failure)
+    const { db: baseDb } = mockDb({ job: { id: "job-fail-2" } })
+    const { db: fallbackDb } = mockDb({ job: { id: "job-fail-2" } })
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const baseSelectFrom = vi.mocked(baseDb.selectFrom)
+    baseSelectFrom.mockImplementation((table: string) => {
+      if (table === "job") {
+        const executeTakeFirst = vi.fn().mockRejectedValue(new Error("connection lost"))
+        const whereFn: ReturnType<typeof vi.fn> = vi.fn()
+        whereFn.mockReturnValue({ where: whereFn, executeTakeFirst })
+        const select = vi.fn().mockReturnValue({ where: whereFn, executeTakeFirst })
+        return { select } as never
+      }
+      return (fallbackDb.selectFrom as ReturnType<typeof vi.fn>)(table) as never
+    })
+    const db = baseDb
+
+    mockMapJobErrorToUserMessage.mockReturnValue(
+      "Job failed but error details could not be retrieved.",
+    )
+    const enqueueJob = vi.fn().mockResolvedValue(undefined)
+    const app = await buildApp(db, enqueueJob)
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/chat?wait=true&timeout=5000`,
+      payload: { text: "Fail test 2" },
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const body = res.json()
+    expect(body.status).toBe("FAILED")
+    expect(body.error).toBeDefined()
+    expect(body.error.message).toBe("Job failed but error details could not be retrieved.")
+    expect(body.error.code).toBe("job_failed")
+  })
+})

--- a/packages/control-plane/src/routes/chat.ts
+++ b/packages/control-plane/src/routes/chat.ts
@@ -242,7 +242,7 @@ export function chatRoutes(deps: ChatRouteDeps) {
         }
 
         // Synchronous wait: poll for completion and return the response inline
-        const result = await waitForJob(db, job.id, timeout)
+        const result = await waitForJob(db, job.id, timeout, request.log)
 
         if (!result) {
           return reply.status(202).send({
@@ -498,6 +498,7 @@ function waitForJob(
   db: Kysely<Database>,
   jobId: string,
   timeoutMs: number,
+  log: { warn: (obj: Record<string, unknown>, msg: string) => void },
 ): Promise<WaitForJobResult | null> {
   return new Promise((resolve) => {
     const deadline = Date.now() + timeoutMs
@@ -522,11 +523,12 @@ function waitForJob(
                 error: (row?.error as Record<string, unknown>) ?? null,
               })
             })
-            .catch(() => {
+            .catch((fetchErr: unknown) => {
+              log.warn({ err: fetchErr, jobId }, "Failed to fetch error column for completed job")
               resolve({
                 status,
                 result: (_result as Record<string, unknown>) ?? {},
-                error: null,
+                error: { message: "Job failed but error details could not be retrieved." },
               })
             })
         }


### PR DESCRIPTION
## Summary
- **Bug**: `waitForJob` in `src/routes/chat.ts` had a `.catch()` that swallowed DB fetch errors and resolved with `error: null`, so users saw "failed" with no message
- **Fix**: Log the fetch failure via `request.log.warn` and resolve with a fallback error object (`{ message: "Job failed but error details could not be retrieved." }`) instead of `null`
- Added `log` parameter to `waitForJob` for structured logging of the fetch failure

## Test plan
- [x] New test: sync-wait returns error message from job error column on FAILED job
- [x] New test: sync-wait returns fallback error when error column fetch fails
- [x] All 1888 existing tests pass
- [x] Lint clean on changed files
- [ ] CI passes

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for failed background jobs with detailed error messages and fallback messaging when error retrieval fails.
  * Enhanced logging for job monitoring and error scenarios.

* **Tests**
  * Added test coverage for job failure error propagation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->