### PR TITLE
cleanup(#555): add debug logging to silent K8s cleanup catches

### DIFF
--- a/packages/control-plane/src/__tests__/agent-deployer.test.ts
+++ b/packages/control-plane/src/__tests__/agent-deployer.test.ts
@@ -528,13 +528,20 @@ describe("AgentDeployer", () => {
       )
     })
 
-    it("ignores errors for already-deleted resources", async () => {
+    it("ignores errors for already-deleted resources and logs at debug level", async () => {
+      const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {})
+
       mockCoreApi.deleteNamespacedPod.mockRejectedValue(new Error("not found"))
       mockRbacApi.deleteNamespacedRoleBinding.mockRejectedValue(new Error("not found"))
       mockRbacApi.deleteNamespacedRole.mockRejectedValue(new Error("not found"))
       mockCoreApi.deleteNamespacedServiceAccount.mockRejectedValue(new Error("not found"))
 
       await expect(deployer.deleteAgent("devops-01")).resolves.toBeUndefined()
+
+      expect(debugSpy).toHaveBeenCalledTimes(4)
+      expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining("Pod"), expect.any(Error))
+
+      debugSpy.mockRestore()
     })
   })
 

--- a/packages/control-plane/src/__tests__/mcp-k8s-deployer.test.ts
+++ b/packages/control-plane/src/__tests__/mcp-k8s-deployer.test.ts
@@ -375,15 +375,21 @@ describe("McpServerDeployer", () => {
     )
   })
 
-  it("teardown() ignores delete errors (best-effort)", async () => {
+  it("teardown() ignores delete errors and logs at debug level", async () => {
     resetMocks()
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {})
+
     mockAppsApi.deleteNamespacedDeployment.mockRejectedValue(new Error("not found"))
     mockCoreApi.deleteNamespacedService.mockRejectedValue(new Error("not found"))
     mockCoreApi.deleteNamespacedServiceAccount.mockRejectedValue(new Error("not found"))
 
     const deployer = new McpServerDeployer()
-    // Should not throw
     await expect(deployer.teardown("github")).resolves.toBeUndefined()
+
+    expect(debugSpy).toHaveBeenCalledTimes(3)
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining("Deployment"), expect.any(Error))
+
+    debugSpy.mockRestore()
   })
 
   it("waitForReady() resolves when deployment is ready", async () => {

--- a/packages/control-plane/src/k8s/agent-deployer.ts
+++ b/packages/control-plane/src/k8s/agent-deployer.ts
@@ -353,19 +353,23 @@ export class AgentDeployer {
   async deleteAgent(agentName: string, namespace?: string): Promise<void> {
     const ns = namespace ?? this.defaultNamespace
 
+    const name = `agent-${agentName}`
+    const ignoreDeletionError = (resource: string) => (err: unknown) => {
+      console.debug(
+        `[agent-deployer] ignoring cleanup error for ${resource} '${name}' in '${ns}':`,
+        err,
+      )
+    }
+
     const deletions = [
-      this.coreApi
-        .deleteNamespacedPod({ name: `agent-${agentName}`, namespace: ns })
-        .catch(() => {}),
+      this.coreApi.deleteNamespacedPod({ name, namespace: ns }).catch(ignoreDeletionError("Pod")),
       this.rbacApi
-        .deleteNamespacedRoleBinding({ name: `agent-${agentName}`, namespace: ns })
-        .catch(() => {}),
-      this.rbacApi
-        .deleteNamespacedRole({ name: `agent-${agentName}`, namespace: ns })
-        .catch(() => {}),
+        .deleteNamespacedRoleBinding({ name, namespace: ns })
+        .catch(ignoreDeletionError("RoleBinding")),
+      this.rbacApi.deleteNamespacedRole({ name, namespace: ns }).catch(ignoreDeletionError("Role")),
       this.coreApi
-        .deleteNamespacedServiceAccount({ name: `agent-${agentName}`, namespace: ns })
-        .catch(() => {}),
+        .deleteNamespacedServiceAccount({ name, namespace: ns })
+        .catch(ignoreDeletionError("ServiceAccount")),
     ]
 
     await Promise.all(deletions)

--- a/packages/control-plane/src/mcp/k8s-deployer.ts
+++ b/packages/control-plane/src/mcp/k8s-deployer.ts
@@ -271,10 +271,23 @@ export class McpServerDeployer {
     const ns = namespace ?? this.defaultNamespace
     const name = `mcp-server-${slug}`
 
+    const ignoreDeletionError = (resource: string) => (err: unknown) => {
+      console.debug(
+        `[k8s-deployer] ignoring cleanup error for ${resource} '${name}' in '${ns}':`,
+        err,
+      )
+    }
+
     await Promise.all([
-      this.appsApi.deleteNamespacedDeployment({ name, namespace: ns }).catch(() => {}),
-      this.coreApi.deleteNamespacedService({ name, namespace: ns }).catch(() => {}),
-      this.coreApi.deleteNamespacedServiceAccount({ name, namespace: ns }).catch(() => {}),
+      this.appsApi
+        .deleteNamespacedDeployment({ name, namespace: ns })
+        .catch(ignoreDeletionError("Deployment")),
+      this.coreApi
+        .deleteNamespacedService({ name, namespace: ns })
+        .catch(ignoreDeletionError("Service")),
+      this.coreApi
+        .deleteNamespacedServiceAccount({ name, namespace: ns })
+        .catch(ignoreDeletionError("ServiceAccount")),
     ])
   }
 


### PR DESCRIPTION
## Summary
- Replace empty `.catch(() => {})` handlers with `console.debug` calls in `agent-deployer.ts` (4 catches) and `mcp/k8s-deployer.ts` (3 catches)
- Failures during resource teardown are now traceable at debug level without changing behavior

## Test plan
- [x] Updated existing "ignores errors" tests to assert `console.debug` is called with resource type and error
- [x] 82 tests pass across both deployer test files
- [x] Lint clean, typecheck has only pre-existing unrelated errors

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)