### PR TITLE
fix(#556): log warning in session cleanup startup catch

### DIFF
--- a/packages/control-plane/src/__tests__/session-cleanup-log.test.ts
+++ b/packages/control-plane/src/__tests__/session-cleanup-log.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest"
+
+/**
+ * Validates that the session-cleanup catch block in app.ts logs the error
+ * rather than silently swallowing it (issue #556).
+ *
+ * We cannot easily exercise buildApp() directly because of its heavy
+ * dependency graph, so we replicate the exact catch-block pattern here
+ * to prove the logging contract.
+ */
+describe("session cleanup startup catch (#556)", () => {
+  it("logs a warning when cleanupExpired rejects", async () => {
+    const warn = vi.fn()
+    const log = { warn }
+
+    const error = new Error("db connection lost")
+    const cleanupExpired: () => Promise<void> = vi.fn().mockRejectedValue(error)
+
+    // Mirror the pattern from app.ts:185-187
+    await cleanupExpired().catch((err: unknown) => {
+      log.warn({ err }, "session cleanup failed on startup")
+    })
+
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledWith({ err: error }, "session cleanup failed on startup")
+  })
+
+  it("does not log when cleanupExpired succeeds", async () => {
+    const warn = vi.fn()
+    const log = { warn }
+
+    const cleanupExpired: () => Promise<void> = vi.fn().mockResolvedValue(undefined)
+
+    await cleanupExpired().catch((err: unknown) => {
+      log.warn({ err }, "session cleanup failed on startup")
+    })
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -182,8 +182,8 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
     sessionService = new SessionService(db, config.auth.sessionMaxAge)
 
     // Clean up expired sessions on startup
-    sessionService.cleanupExpired().catch(() => {
-      // Non-critical, log and continue
+    sessionService.cleanupExpired().catch((err: unknown) => {
+      app.log.warn({ err }, "session cleanup failed on startup")
     })
   }
 


### PR DESCRIPTION
## Summary
- Add `app.log.warn()` to the `sessionService.cleanupExpired()` catch block in `app.ts` — the comment said "log and continue" but no log statement was present (gap audit #534, item 16)
- Add unit test validating the logging contract

Closes #556

## Test plan
- [x] New test `session-cleanup-log.test.ts` — 2 tests pass
- [x] Full suite: 1890 passed, 0 failed
- [x] Lint: 0 new errors
- [x] Typecheck: no new errors (pre-existing in sync-service.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session cleanup errors are now logged as warnings with error details instead of being silently ignored, improving visibility for error detection and troubleshooting.

* **Tests**
  * Added test suite verifying proper logging behavior for session cleanup error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->