### PR TITLE
cleanup(#557): drop unused effective_capabilities column

### DIFF
--- a/packages/control-plane/docs/gap-audit-534.md
+++ b/packages/control-plane/docs/gap-audit-534.md
@@ -156,12 +156,11 @@ Features that exist but do not work correctly.
 - **Severity**: MEDIUM
 - **Fix**: Emit audit events on tool binding changes, or remove table + route.
 
-### 4.6 Agent Config Column Unused
+### 4.6 ~~Agent Config Column Unused~~ effective_capabilities Column Unused
 
-- **DB column**: `agent.config` (JSONB)
-- **Status**: Written during agent creation but **never read** — `effective_capabilities` used instead.
+- **DB column**: `agent.effective_capabilities` (JSONB) — added in migration 018 but never read or written by application code.
+- **Status**: **RESOLVED** — column dropped in migration 034 (#557). Note: original audit incorrectly identified `agent.config` as unused; `config` is actively read for webhook tool definitions.
 - **Severity**: LOW
-- **Fix**: Remove column or use it as the source of truth for agent configuration.
 
 ### 4.7 Effective Tools Placeholder
 

--- a/packages/control-plane/migrations/034_drop_effective_capabilities.down.sql
+++ b/packages/control-plane/migrations/034_drop_effective_capabilities.down.sql
@@ -1,0 +1,2 @@
+-- 034 down: Re-add effective_capabilities JSONB column to agent table.
+ALTER TABLE agent ADD COLUMN effective_capabilities JSONB;

--- a/packages/control-plane/migrations/034_drop_effective_capabilities.up.sql
+++ b/packages/control-plane/migrations/034_drop_effective_capabilities.up.sql
@@ -1,0 +1,4 @@
+-- 034: Drop unused effective_capabilities JSONB column from agent table.
+-- Added in 018 as a computed-cache column but never read or written
+-- by application code. Closes #557.
+ALTER TABLE agent DROP COLUMN IF EXISTS effective_capabilities;

--- a/packages/control-plane/src/__tests__/migrations.test.ts
+++ b/packages/control-plane/src/__tests__/migrations.test.ts
@@ -289,16 +289,7 @@ describe("PostgreSQL migrations", () => {
         "conditional",
       ])
 
-      // effective_capabilities column on agent
-      const colResult = await client.query<{ exists: boolean }>(
-        `SELECT EXISTS (
-          SELECT 1 FROM information_schema.columns
-          WHERE table_name = 'agent'
-            AND column_name = 'effective_capabilities'
-            AND data_type = 'jsonb'
-        )`,
-      )
-      expect(colResult.rows[0]?.exists).toBe(true)
+      // effective_capabilities column removed in migration 034
 
       // Deprecation comment on mcp_server.agent_scope
       const commentResult = await client.query<{ description: string | null }>(
@@ -756,6 +747,22 @@ describe("PostgreSQL migrations", () => {
 
       // Clean up
       await client.query("DELETE FROM agent WHERE id = $1", [agent2Id])
+    } finally {
+      client.release()
+    }
+  })
+
+  it("migration 034: drops effective_capabilities column from agent", async () => {
+    const client = await pool.connect()
+    try {
+      const colResult = await client.query<{ exists: boolean }>(
+        `SELECT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = 'agent'
+            AND column_name = 'effective_capabilities'
+        )`,
+      )
+      expect(colResult.rows[0]?.exists).toBe(false)
     } finally {
       client.release()
     }

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -92,11 +92,6 @@ export interface AgentTable {
     Record<string, unknown> | undefined,
     Record<string, unknown>
   >
-  effective_capabilities: ColumnType<
-    Record<string, unknown> | null,
-    Record<string, unknown> | null | undefined,
-    Record<string, unknown> | null
-  >
   auth_model: ColumnType<AgentAuthModel, AgentAuthModel | undefined, AgentAuthModel>
   status: ColumnType<AgentStatus, AgentStatus | undefined, AgentStatus>
   health_reset_at: ColumnType<Date | null, Date | null | undefined, Date | null>


### PR DESCRIPTION
## Summary

- Adds migration **034** to drop the `effective_capabilities` JSONB column from the `agent` table — it was added in migration 018 as a computed cache but never read or written by application code.
- Removes the column from the Kysely `AgentTable` type in `db/types.ts`.
- Updates the migration 018 test (column no longer exists after 034) and adds a dedicated 034 test.
- Corrects the gap audit doc (`docs/gap-audit-534.md` §4.6): the original audit misidentified `agent.config` as unused, but it is actively read for webhook tool definitions.

Closes #557

## Test plan

- [x] All 1890 unit tests pass (116 files)
- [x] Lint clean on changed files
- [x] Pre-existing typecheck/build errors only (unrelated `sync-service.ts`)
- [ ] CI migration tests validate column is dropped and rollback re-adds it

🤖 Generated with [Claude Code](https://claude.com/claude-code)