### PR TITLE
fix(#558): validate toolName regex on credential rotate

### DIFF
--- a/packages/control-plane/src/__tests__/credential-routes.test.ts
+++ b/packages/control-plane/src/__tests__/credential-routes.test.ts
@@ -358,6 +358,39 @@ describe("PUT /credentials/:id/rotate", () => {
     const body = res.json()
     expect(body.message).toContain("8 characters")
   })
+
+  it("rejects invalid toolName", async () => {
+    const { app } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/credentials/${CRED_ID}/rotate`,
+      headers: withSession(),
+      payload: { apiKey: "BSA_new_key_1234", toolName: "INVALID!!!" },
+    })
+
+    expect(res.statusCode).toBe(400)
+    const body = res.json()
+    expect(body.message).toContain("toolName")
+  })
+
+  it("accepts valid toolName", async () => {
+    const { app, credentialService } = await buildTestApp()
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/credentials/${CRED_ID}/rotate`,
+      headers: withSession(),
+      payload: { apiKey: "BSA_new_key_1234", toolName: "my-tool-1" },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(credentialService.rotateToolSecret).toHaveBeenCalledWith(
+      "user-1",
+      CRED_ID,
+      "BSA_new_key_1234",
+    )
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/control-plane/src/routes/credentials.ts
+++ b/packages/control-plane/src/routes/credentials.ts
@@ -208,14 +208,14 @@ export function credentialRoutes(deps: CredentialRouteDeps) {
      */
     app.put<{
       Params: { id: string }
-      Body: { apiKey: string }
+      Body: { apiKey: string; toolName?: string }
     }>(
       "/credentials/:id/rotate",
       { preHandler: [requireAuth, requireAdmin] },
       async (
         request: FastifyRequest<{
           Params: { id: string }
-          Body: { apiKey: string }
+          Body: { apiKey: string; toolName?: string }
         }>,
         reply: FastifyReply,
       ) => {
@@ -225,7 +225,16 @@ export function credentialRoutes(deps: CredentialRouteDeps) {
           return
         }
 
-        const { apiKey } = request.body
+        const { apiKey, toolName } = request.body
+
+        if (toolName !== undefined && !TOOL_NAME_RE.test(toolName)) {
+          reply.status(400).send({
+            error: "bad_request",
+            message:
+              "toolName is required: 1-64 chars, lowercase alphanumeric + hyphens, must start with alphanumeric",
+          })
+          return
+        }
 
         if (!apiKey || apiKey.length < 8) {
           reply.status(400).send({


### PR DESCRIPTION
## Summary
- Adds `TOOL_NAME_RE` validation to `PUT /credentials/:id/rotate` when an optional `toolName` is provided in the request body
- Closes the validation gap where `POST /credentials/tool-secret` validated `toolName` but rotate did not (gap audit #534, item 18)
- Adds two tests: rejects invalid `toolName`, accepts valid `toolName`

Closes #558

## Test plan
- [x] `npx vitest run src/__tests__/credential-routes.test.ts` — 23 tests pass
- [x] ESLint clean on changed files
- [x] Typecheck: only pre-existing errors in unrelated `sync-service.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `toolName` field support when rotating credentials.

* **Tests**
  * Added validation tests for credential rotation endpoint to verify proper `toolName` handling and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->