### PR TITLE
fix(#582): use Bearer auth for Anthropic OAuth credentials

### DIFF
--- a/packages/control-plane/src/__tests__/credential-injection.test.ts
+++ b/packages/control-plane/src/__tests__/credential-injection.test.ts
@@ -190,6 +190,75 @@ describe("LLM credential injection", () => {
     await handle.cancel("test")
   })
 
+  it("uses Bearer auth (authToken) for Anthropic OAuth credentials", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "global-key" })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        llmCredential: {
+          provider: "anthropic",
+          token: "oauth-access-token",
+          credentialId: "cred-oauth",
+          credentialType: "oauth",
+        },
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const useAuthToken = (handle as any).useAuthToken
+    expect(useAuthToken).toBe(true)
+    await handle.cancel("test")
+  })
+
+  it("uses x-api-key (apiKey) for Anthropic api_key credentials", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "global-key" })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        llmCredential: {
+          provider: "anthropic",
+          token: "sk-ant-api-key",
+          credentialId: "cred-apikey",
+          credentialType: "api_key",
+        },
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const useAuthToken = (handle as any).useAuthToken
+    expect(useAuthToken).toBe(false)
+    await handle.cancel("test")
+  })
+
+  it("uses Bearer auth for google-antigravity even without credentialType", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "global-key" })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        llmCredential: {
+          provider: "google-antigravity",
+          token: "goog-oauth-token",
+          credentialId: "cred-goog-2",
+          // No credentialType — Antigravity always uses Bearer
+        },
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const useAuthToken = (handle as any).useAuthToken
+    expect(useAuthToken).toBe(true)
+    await handle.cancel("test")
+  })
+
   it("falls back to global client when no llmCredential is set", async () => {
     const backend = new HttpLlmBackend()
     await backend.start({ provider: "anthropic", apiKey: "global-key" })

--- a/packages/control-plane/src/backends/http-llm.ts
+++ b/packages/control-plane/src/backends/http-llm.ts
@@ -215,8 +215,11 @@ export class HttpLlmBackend implements ExecutionBackend {
         if (isAntigravity) {
           clientBaseUrl = resolveAntigravityBaseUrl(cred.baseUrl, cred.accountId)
         }
+        // OAuth tokens (Anthropic OAuth, Google Antigravity) use Bearer auth;
+        // API keys use the x-api-key header.
+        const useBearer = cred.credentialType === "oauth" || isAntigravity
         const client = new Anthropic({
-          ...(isAntigravity ? { authToken: cred.token, apiKey: null } : { apiKey: cred.token }),
+          ...(useBearer ? { authToken: cred.token, apiKey: null } : { apiKey: cred.token }),
           ...(clientBaseUrl ? { baseURL: clientBaseUrl } : {}),
         })
         return Promise.resolve(
@@ -224,7 +227,7 @@ export class HttpLlmBackend implements ExecutionBackend {
             tokenRefresher,
             credentialId: cred.credentialId,
             baseUrl: clientBaseUrl,
-            useAuthToken: !!isAntigravity,
+            useAuthToken: useBearer,
           }),
         )
       }

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -381,6 +381,7 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
               .select([
                 "provider_credential.user_account_id",
                 "provider_credential.provider",
+                "provider_credential.credential_type",
                 "provider_credential.credential_class",
                 "provider_credential.account_id",
               ])
@@ -406,6 +407,7 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                   token: result.token,
                   credentialId: result.credentialId,
                   accountId: binding.account_id,
+                  credentialType: binding.credential_type as "oauth" | "api_key",
                 }
 
                 // Build a token refresher for transparent 401 retry.

--- a/packages/shared/src/backends/types.ts
+++ b/packages/shared/src/backends/types.ts
@@ -100,6 +100,12 @@ export interface LlmCredentialRef {
    * When set, overrides any URL the backend would derive from the provider.
    */
   baseUrl?: string | null
+  /**
+   * Credential type determines how the token is sent to the LLM provider.
+   * OAuth tokens use Bearer auth; API keys use provider-specific headers
+   * (e.g. x-api-key for Anthropic).
+   */
+  credentialType?: "oauth" | "api_key"
 }
 
 /**


### PR DESCRIPTION
## Summary
- Anthropic OAuth access tokens were sent via `x-api-key` header instead of `Authorization: Bearer`, causing 401 "invalid x-api-key" errors when the Claude SWE agent made chat requests
- Added `credentialType` field to `LlmCredentialRef` to distinguish OAuth tokens from API keys
- Propagated `credential_type` from the credential binding query in `agent-execute.ts`
- Updated `http-llm.ts` to use Bearer auth (`authToken`) for all OAuth credentials targeting the Anthropic SDK (not just google-antigravity)

Closes #582

## Test plan
- [x] 3 new tests: Anthropic OAuth uses Bearer, Anthropic API key uses x-api-key, Antigravity uses Bearer without credentialType
- [x] All 1895 existing tests pass
- [x] Lint clean (0 errors)
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced credential handling for LLM providers to properly distinguish between OAuth tokens and API keys, ensuring correct authentication method is used for each credential type.

* **Tests**
  * Added test coverage for credential injection scenarios with different authentication methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->