### PR TITLE
fix(#583): rewrite Antigravity /v1/messages to Vertex AI rawPredict

### DIFF
--- a/packages/control-plane/src/__tests__/http-llm.test.ts
+++ b/packages/control-plane/src/__tests__/http-llm.test.ts
@@ -1290,7 +1290,7 @@ describe("HttpLlmBackend — 401 token refresh retry", () => {
 // ---------------------------------------------------------------------------
 
 describe("HttpLlmBackend — credential provider routing", () => {
-  it("routes google-antigravity to Anthropic SDK with Vertex AI base URL and authToken", async () => {
+  it("routes google-antigravity to Vertex AI client with path rewriting and authToken", async () => {
     const backend = new HttpLlmBackend()
     await backend.start({ provider: "anthropic", apiKey: "global-key" })
 
@@ -1309,11 +1309,18 @@ describe("HttpLlmBackend — credential provider routing", () => {
     const handle = await backend.executeTask(task)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    const client = (handle as any).client as { baseURL: string; authToken: string | null }
-    expect(client.baseURL).toBe(
-      "https://us-east5-aiplatform.googleapis.com/v1/projects/my-gcp-project-123/locations/us-east5/publishers/anthropic",
-    )
+    const client = (handle as any).client as {
+      baseURL: string
+      authToken: string | null
+      vertexProjectId: string
+      vertexRegion: string
+    }
+    // Vertex AI base URL does NOT include the project path — path rewriting
+    // appends /projects/{project}/locations/{region}/publishers/anthropic/models/{model}:rawPredict
+    expect(client.baseURL).toBe("https://us-east5-aiplatform.googleapis.com/v1")
     expect(client.authToken).toBe("gcp-oauth-token")
+    expect(client.vertexProjectId).toBe("my-gcp-project-123")
+    expect(client.vertexRegion).toBe("us-east5")
 
     await handle.cancel("test")
   })
@@ -1393,11 +1400,14 @@ describe("HttpLlmBackend — credential provider routing", () => {
     const handle = await backend.executeTask(task)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    const client = (handle as any).client as { baseURL: string; authToken: string | null }
-    // Without accountId, uses the default project in the Vertex AI URL
-    expect(client.baseURL).toBe(
-      "https://us-east5-aiplatform.googleapis.com/v1/projects/anthropic-cortex-default/locations/us-east5/publishers/anthropic",
-    )
+    const client = (handle as any).client as {
+      baseURL: string
+      authToken: string | null
+      vertexProjectId: string
+    }
+    // Without accountId, Vertex client stores default project internally
+    expect(client.baseURL).toBe("https://us-east5-aiplatform.googleapis.com/v1")
+    expect(client.vertexProjectId).toBe("anthropic-cortex-default")
     expect(client.authToken).toBe("gcp-oauth-token")
 
     await handle.cancel("test")
@@ -1464,5 +1474,52 @@ describe("HttpLlmBackend — credential provider routing", () => {
         process.env.ANTIGRAVITY_BASE_URL = originalEnv
       }
     }
+  })
+
+  it("rewrites /v1/messages path to Vertex AI rawPredict format", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "global-key" })
+
+    const task = makeTask({
+      constraints: {
+        ...makeTask().constraints,
+        llmCredential: {
+          provider: "google-antigravity",
+          token: "gcp-oauth-token",
+          credentialId: "cred-gcp-rewrite",
+          accountId: "my-project-42",
+        },
+      },
+    })
+
+    const handle = await backend.executeTask(task)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    const client = (handle as any).client as unknown as {
+      baseURL: string
+      buildRequest(opts: Record<string, unknown>): Promise<{ url: string }>
+    }
+    // Verify the base URL no longer embeds the project path — path rewriting
+    // in buildRequest produces the correct Vertex AI endpoint at call time.
+    expect(client.baseURL).toBe("https://us-east5-aiplatform.googleapis.com/v1")
+
+    // Verify buildRequest rewrites the path correctly
+    const reqOpts = await client.buildRequest({
+      path: "/v1/messages",
+      method: "post",
+      body: {
+        model: "claude-sonnet-4-5-20250929",
+        stream: true,
+        messages: [{ role: "user", content: "test" }],
+      },
+    })
+
+    const reqUrl = reqOpts.url
+    expect(reqUrl).toContain("/projects/my-project-42/locations/us-east5/publishers/anthropic")
+    expect(reqUrl).toContain("/models/claude-sonnet-4-5-20250929:streamRawPredict")
+    // Must NOT contain the old double-/v1 pattern
+    expect(reqUrl).not.toContain("/publishers/anthropic/v1/messages")
+
+    await handle.cancel("test")
   })
 })

--- a/packages/control-plane/src/backends/http-llm.ts
+++ b/packages/control-plane/src/backends/http-llm.ts
@@ -211,23 +211,48 @@ export class HttpLlmBackend implements ExecutionBackend {
         // Google Antigravity routes through Vertex AI with Bearer auth.
         // cloudcode-pa.googleapis.com is only for quota queries, NOT message routing.
         const isAntigravity = cred.provider === "google-antigravity"
-        let clientBaseUrl = baseUrl
-        if (isAntigravity) {
-          clientBaseUrl = resolveAntigravityBaseUrl(cred.baseUrl, cred.accountId)
-        }
         // OAuth tokens (Anthropic OAuth, Google Antigravity) use Bearer auth;
         // API keys use the x-api-key header.
         const useBearer = cred.credentialType === "oauth" || isAntigravity
-        const client = new Anthropic({
-          ...(useBearer ? { authToken: cred.token, apiKey: null } : { apiKey: cred.token }),
-          ...(clientBaseUrl ? { baseURL: clientBaseUrl } : {}),
-        })
+
+        let client: Anthropic
+        let clientBaseUrl = baseUrl
+        let antigravityInfo: { projectId: string; region: string } | undefined
+
+        if (isAntigravity) {
+          const routing = resolveAntigravityRouting(cred.baseUrl, cred.accountId)
+          clientBaseUrl = routing.baseUrl
+          if (routing.type === "vertex") {
+            // Native Vertex AI — needs path rewriting from /v1/messages
+            // to /models/{model}:streamRawPredict
+            antigravityInfo = { projectId: routing.projectId, region: routing.region }
+            client = new AntigravityAnthropicClient({
+              authToken: cred.token,
+              projectId: routing.projectId,
+              region: routing.region,
+            })
+          } else {
+            // Custom proxy that accepts standard Anthropic API format
+            client = new Anthropic({
+              authToken: cred.token,
+              apiKey: null as unknown as string,
+              baseURL: routing.baseUrl,
+            })
+          }
+        } else {
+          client = new Anthropic({
+            ...(useBearer ? { authToken: cred.token, apiKey: null } : { apiKey: cred.token }),
+            ...(clientBaseUrl ? { baseURL: clientBaseUrl } : {}),
+          })
+        }
+
         return Promise.resolve(
           new AnthropicHandle(task, client, model, startTime, registry, {
             tokenRefresher,
             credentialId: cred.credentialId,
             baseUrl: clientBaseUrl,
             useAuthToken: useBearer,
+            antigravity: antigravityInfo,
           }),
         )
       }
@@ -322,6 +347,8 @@ interface RefreshOpts {
   baseUrl?: string
   /** When true, use Bearer auth (`authToken`) instead of `apiKey` for the Anthropic SDK. */
   useAuthToken?: boolean
+  /** Vertex AI project/region for Antigravity clients (requires path rewriting). */
+  antigravity?: { projectId: string; region: string }
 }
 
 /** Returns true if the error is a 401 authentication error from an LLM SDK. */
@@ -360,25 +387,105 @@ function mapCredentialProvider(provider: string): LlmProvider {
 }
 
 /**
- * Resolve the correct base URL for Google Antigravity message routing.
+ * Resolve Antigravity routing config.
  *
  * Priority:
- *   1. Explicit `baseUrl` on the credential ref (set by provider config)
- *   2. `ANTIGRAVITY_BASE_URL` env var (full URL override)
- *   3. Constructed Vertex AI URL from accountId + region
+ *   1. Explicit `baseUrl` on the credential ref (set by provider config) — assumed
+ *      to be a custom proxy that accepts standard Anthropic API format.
+ *   2. `ANTIGRAVITY_BASE_URL` env var — same assumption.
+ *   3. Native Vertex AI endpoint — requires path rewriting from /v1/messages to
+ *      /models/{model}:streamRawPredict (the standard Anthropic SDK path is not
+ *      a valid Vertex AI endpoint).
  *
- * The cloudcode-pa.googleapis.com domain is NOT used here — it serves
- * only internal quota/project-discovery endpoints, not /v1/messages.
+ * Returns either:
+ *   - `{ type: "proxy", baseUrl }` for cases 1/2 (custom proxy, no rewrite needed)
+ *   - `{ type: "vertex", baseUrl, projectId, region }` for case 3 (needs rewrite)
  */
-function resolveAntigravityBaseUrl(credBaseUrl?: string | null, accountId?: string | null): string {
-  if (credBaseUrl) return credBaseUrl
+type AntigravityRouting =
+  | { type: "proxy"; baseUrl: string }
+  | { type: "vertex"; baseUrl: string; projectId: string; region: string }
+
+function resolveAntigravityRouting(
+  credBaseUrl?: string | null,
+  accountId?: string | null,
+): AntigravityRouting {
+  if (credBaseUrl) return { type: "proxy", baseUrl: credBaseUrl }
 
   const envUrl = process.env.ANTIGRAVITY_BASE_URL
-  if (envUrl) return envUrl
+  if (envUrl) return { type: "proxy", baseUrl: envUrl }
 
   const region = process.env.ANTIGRAVITY_REGION ?? "us-east5"
-  const project = accountId ?? process.env.ANTIGRAVITY_PROJECT ?? "anthropic-cortex-default"
-  return `https://${region}-aiplatform.googleapis.com/v1/projects/${project}/locations/${region}/publishers/anthropic`
+  const projectId = accountId ?? process.env.ANTIGRAVITY_PROJECT ?? "anthropic-cortex-default"
+  return {
+    type: "vertex",
+    baseUrl: `https://${region}-aiplatform.googleapis.com/v1`,
+    projectId,
+    region,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Antigravity Vertex AI client
+// ---------------------------------------------------------------------------
+
+/**
+ * Anthropic SDK client that rewrites /v1/messages paths to the Vertex AI
+ * rawPredict endpoint format.
+ *
+ * Google Vertex AI does not serve a /v1/messages endpoint. The official
+ * @anthropic-ai/vertex-sdk rewrites the path to:
+ *   /projects/{project}/locations/{region}/publishers/anthropic/models/{model}:{specifier}
+ *
+ * This class replicates that behaviour so we can use the standard Anthropic SDK
+ * (with our own OAuth token management) against Vertex AI.
+ */
+const VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16"
+const VERTEX_MESSAGE_ENDPOINTS = new Set(["/v1/messages", "/v1/messages?beta=true"])
+
+interface AntigravityClientOpts {
+  authToken: string
+  projectId: string
+  region: string
+}
+
+class AntigravityAnthropicClient extends Anthropic {
+  private readonly vertexProjectId: string
+  private readonly vertexRegion: string
+
+  constructor(opts: AntigravityClientOpts) {
+    super({
+      authToken: opts.authToken,
+      apiKey: null as unknown as string,
+      baseURL: `https://${opts.region}-aiplatform.googleapis.com/v1`,
+    })
+    this.vertexProjectId = opts.projectId
+    this.vertexRegion = opts.region
+  }
+
+  /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any */
+  override async buildRequest(options: any): Promise<any> {
+    // Inject Vertex anthropic_version into the body (required by Vertex AI)
+    if (
+      typeof options.body === "object" &&
+      options.body !== null &&
+      !options.body.anthropic_version
+    ) {
+      options.body.anthropic_version = VERTEX_ANTHROPIC_VERSION
+    }
+
+    // Rewrite /v1/messages → Vertex AI rawPredict / streamRawPredict
+    if (VERTEX_MESSAGE_ENDPOINTS.has(options.path as string) && options.method === "post") {
+      const body = options.body as Record<string, unknown>
+      const model = body.model as string
+      body.model = undefined
+      const stream = (body.stream as boolean) ?? false
+      const specifier = stream ? "streamRawPredict" : "rawPredict"
+      options.path = `/projects/${this.vertexProjectId}/locations/${this.vertexRegion}/publishers/anthropic/models/${model}:${specifier}`
+    }
+
+    return super.buildRequest(options)
+  }
+  /* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any */
 }
 
 function toOpenAITools(defs: ToolDefinition[]): OpenAI.ChatCompletionTool[] {
@@ -409,6 +516,7 @@ class AnthropicHandle implements ExecutionHandle {
   private readonly credentialId?: string
   private readonly baseUrl?: string
   private readonly useAuthToken: boolean
+  private readonly antigravity?: { projectId: string; region: string }
 
   constructor(
     private readonly task: ExecutionTask,
@@ -426,6 +534,7 @@ class AnthropicHandle implements ExecutionHandle {
     this.credentialId = refreshOpts?.credentialId
     this.baseUrl = refreshOpts?.baseUrl
     this.useAuthToken = refreshOpts?.useAuthToken ?? false
+    this.antigravity = refreshOpts?.antigravity
   }
 
   async *events(): AsyncIterable<OutputEvent> {
@@ -551,12 +660,18 @@ class AnthropicHandle implements ExecutionHandle {
             lastRetryTurn = turn
             const newToken = await this.tokenRefresher(this.credentialId)
             if (newToken) {
-              this.client = new Anthropic({
-                ...(this.useAuthToken
-                  ? { authToken: newToken, apiKey: null }
-                  : { apiKey: newToken }),
-                ...(this.baseUrl ? { baseURL: this.baseUrl } : {}),
-              })
+              this.client = this.antigravity
+                ? new AntigravityAnthropicClient({
+                    authToken: newToken,
+                    projectId: this.antigravity.projectId,
+                    region: this.antigravity.region,
+                  })
+                : new Anthropic({
+                    ...(this.useAuthToken
+                      ? { authToken: newToken, apiKey: null }
+                      : { apiKey: newToken }),
+                    ...(this.baseUrl ? { baseURL: this.baseUrl } : {}),
+                  })
               turn-- // retry this turn
               continue
             }


### PR DESCRIPTION
## Summary
- The Anthropic SDK appends `/v1/messages` to the base URL, but Google Vertex AI does not serve that path — it expects `.../models/{model}:streamRawPredict`. The old base URL (`https://{region}-aiplatform.googleapis.com/v1/projects/{project}/.../publishers/anthropic`) combined with the SDK's `/v1/messages` produced a double-`/v1` path that Google returned 404 for.
- Introduce `AntigravityAnthropicClient` that overrides `buildRequest()` to rewrite `/v1/messages` → `/projects/{project}/locations/{region}/publishers/anthropic/models/{model}:rawPredict` (matching `@anthropic-ai/vertex-sdk` behaviour).
- Custom proxy URLs via `cred.baseUrl` or `ANTIGRAVITY_BASE_URL` env var bypass path rewriting, preserving backward compatibility.

Closes #583

## Test plan
- [x] Existing 38 http-llm tests pass (updated 2 tests for new base URL format)
- [x] New test verifies `buildRequest()` rewrites `/v1/messages` to the correct Vertex AI `streamRawPredict` endpoint with project/region/model
- [x] Full suite: 1896 passed, 0 failed
- [x] Typecheck clean, lint clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for Google Antigravity routing to enable Anthropic model requests through Vertex AI infrastructure
* Implemented automatic endpoint rewriting and region-aware configuration for Vertex AI deployments  
* Enhanced per-job credential management with Vertex AI project ID and region support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->