### PR TITLE
fix(#584): add model.request scope to OpenAI Codex OAuth

### DIFF
--- a/packages/control-plane/src/__tests__/oauth-providers.test.ts
+++ b/packages/control-plane/src/__tests__/oauth-providers.test.ts
@@ -55,6 +55,11 @@ describe("oauth-providers registry", () => {
     }
   })
 
+  it("openai-codex scopes include model.request for API access", () => {
+    const codex = getCodePasteProvider("openai-codex")!
+    expect(codex.scopes).toContain("model.request")
+  })
+
   it("anthropic is the only codePasteOnly provider", () => {
     const codePasteOnly = listCodePasteProviders().filter((p) => p.codePasteOnly)
     expect(codePasteOnly).toHaveLength(1)

--- a/packages/control-plane/src/__tests__/oauth-session.test.ts
+++ b/packages/control-plane/src/__tests__/oauth-session.test.ts
@@ -183,6 +183,19 @@ describe("buildAuthorizeUrl — user service providers", () => {
     expect(parsed.searchParams.get("user_scope")).toContain("users:read")
   })
 
+  it("builds OpenAI Codex OAuth URL with model.request scope", () => {
+    const url = buildAuthorizeUrl({
+      provider: "openai-codex",
+      config: mockConfig,
+      callbackUrl: "http://localhost:1455/auth/callback",
+      state: "test-state",
+    })
+
+    const parsed = new URL(url)
+    expect(parsed.searchParams.get("scope")).toContain("model.request")
+    expect(parsed.searchParams.get("scope")).toContain("offline_access")
+  })
+
   it("allows custom scopes to override defaults", () => {
     const url = buildAuthorizeUrl({
       provider: "google-workspace",

--- a/packages/control-plane/src/auth/oauth-providers.ts
+++ b/packages/control-plane/src/auth/oauth-providers.ts
@@ -72,7 +72,7 @@ export const CODE_PASTE_PROVIDERS: Record<string, CodePasteProviderConfig> = {
     redirectUri: "http://localhost:1455/auth/callback",
     authUrl: "https://auth.openai.com/oauth/authorize",
     tokenUrl: "https://auth.openai.com/oauth/token",
-    scopes: ["openid", "profile", "email", "offline_access"],
+    scopes: ["openid", "profile", "email", "offline_access", "model.request"],
     usePkce: true,
   },
 

--- a/packages/control-plane/src/auth/oauth-service.ts
+++ b/packages/control-plane/src/auth/oauth-service.ts
@@ -207,7 +207,10 @@ export function buildAuthorizeUrl(params: AuthorizeUrlParams): string {
       }
       break
     case "openai-codex":
-      url.searchParams.set("scope", scopes?.join(" ") ?? "openid profile email offline_access")
+      url.searchParams.set(
+        "scope",
+        scopes?.join(" ") ?? "openid profile email offline_access model.request",
+      )
       if (codeChallenge) {
         url.searchParams.set("code_challenge", codeChallenge)
         url.searchParams.set("code_challenge_method", "S256")


### PR DESCRIPTION
## Summary
- Add `model.request` to OpenAI Codex OAuth scopes in the code-paste provider registry (`oauth-providers.ts`)
- Add `model.request` to the `buildAuthorizeUrl` fallback scope for `openai-codex` (`oauth-service.ts`)
- Add tests verifying the scope is present in both code paths

Closes #584

## Context
The OpenAI Codex agent (Markov) was returning 401 with "Missing scopes: model.request" because the OAuth flow only requested OIDC scopes (`openid`, `profile`, `email`, `offline_access`) without the `model.request` scope required for inference API calls.

This is the third and final fix in the provider auth trilogy (#582 Anthropic OAuth → #585, #583 Antigravity routing → #591).

## Test plan
- [x] `oauth-providers.test.ts` — new test: openai-codex scopes include `model.request`
- [x] `oauth-session.test.ts` — new test: `buildAuthorizeUrl` for openai-codex includes `model.request`
- [x] `http-llm.test.ts` — existing openai-codex routing test still passes
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)