### PR TITLE
fix(#602): agent detail mobile tabs — priority tabs with overflow menu

### DIFF
--- a/packages/dashboard/src/app/agents/[agentId]/page.tsx
+++ b/packages/dashboard/src/app/agents/[agentId]/page.tsx
@@ -47,6 +47,20 @@ const MOBILE_TABS = [
 ] as const
 type MobileTab = (typeof MOBILE_TABS)[number]
 
+/** Tabs always visible in the mobile bar */
+const PRIORITY_TABS: readonly MobileTab[] = ["Output", "Chat", "Details"] as const
+
+/** Tabs hidden behind the "More" overflow menu on mobile */
+const OVERFLOW_TABS: readonly MobileTab[] = [
+  "Jobs",
+  "Operations",
+  "Channels",
+  "Credentials",
+  "Users",
+  "Browser",
+  "Memory",
+] as const
+
 // ---------------------------------------------------------------------------
 // Resource mock helpers (will be replaced by real telemetry SSE)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #602

## Summary
- Split mobile tabs into 3 priority tabs (Output, Chat, Details) shown inline + "More" dropdown for overflow tabs (Jobs, Channels, Credentials, Browser, Memory)
- Minimum 44px touch targets on all tab buttons and dropdown items
- "More" button shows active tab name and primary highlight when an overflow tab is selected
- Dropdown closes on outside click
- Works on 375px viewport (iPhone SE)

## Test plan
- [ ] Verify on 375px viewport: 4 inline buttons (Output, Chat, Details, More) fit without scrolling
- [ ] Tap each priority tab — content switches, active tab highlighted
- [ ] Tap More — dropdown appears with 5 overflow tabs
- [ ] Select an overflow tab — content switches, More button shows tab name with primary color
- [ ] Tap outside dropdown — it closes
- [ ] Desktop (lg+) — mobile tab bar hidden, 3-column layout unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned mobile tab navigation on the agent details page: priority tabs (Output, Chat, Details) display inline while additional tabs move to an overflow "More" menu. Improved menu open/close behavior, outside-click dismissal, and active-tab handling for clearer and more reliable mobile tab switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->