### PR TITLE
fix(#610): approvals page — clear approve/deny UX, context preview

### DIFF
--- a/packages/dashboard/src/app/approvals/page.tsx
+++ b/packages/dashboard/src/app/approvals/page.tsx
@@ -288,6 +288,7 @@ export default function ApprovalsPage(): React.JSX.Element {
   const [riskFilter, setRiskFilter] = useState<RiskFilter>("ALL")
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [confirmState, setConfirmState] = useState<CardConfirmState | null>(null)
+  const [bulkSelectedIds, setBulkSelectedIds] = useState<Set<string>>(new Set())
 
   // Fetch approvals from API — wire status filter to query params
   const { data, isLoading, error, errorCode, refetch } = useApiQuery(
@@ -471,6 +472,55 @@ export default function ApprovalsPage(): React.JSX.Element {
     setSelectedId(null)
   }, [refetch])
 
+  // Auto-refresh fallback: poll every 15s when SSE is disconnected
+  useEffect(() => {
+    if (connected) return
+    const interval = setInterval(() => void refetch(), 15_000)
+    return () => clearInterval(interval)
+  }, [connected, refetch])
+
+  // Bulk selection handlers
+  const handleBulkToggle = useCallback((id: string) => {
+    setBulkSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const pendingApprovals = useMemo(
+    () => approvals.filter((a) => a.status === "PENDING"),
+    [approvals],
+  )
+
+  const handleBulkSelectAll = useCallback(() => {
+    setBulkSelectedIds(new Set(pendingApprovals.map((a) => a.id)))
+  }, [pendingApprovals])
+
+  const handleBulkDeselectAll = useCallback(() => {
+    setBulkSelectedIds(new Set())
+  }, [])
+
+  const [bulkDeciding, setBulkDeciding] = useState(false)
+
+  const handleBulkDecision = useCallback(
+    async (decision: "APPROVED" | "REJECTED") => {
+      if (bulkSelectedIds.size === 0) return
+      setBulkDeciding(true)
+      try {
+        await Promise.all(
+          Array.from(bulkSelectedIds).map((id) => decide(id, decision, "dashboard-user")),
+        )
+        setBulkSelectedIds(new Set())
+        void refetch()
+      } finally {
+        setBulkDeciding(false)
+      }
+    },
+    [bulkSelectedIds, decide, refetch],
+  )
+
   const selectedApproval = approvals.find((a) => a.id === selectedId)
 
   // Use per-approval audit entries when selected, otherwise global
@@ -549,6 +599,53 @@ export default function ApprovalsPage(): React.JSX.Element {
           </div>
         </header>
 
+        {/* Bulk action bar */}
+        {bulkSelectedIds.size > 0 && (
+          <div className="flex-shrink-0 border-b border-slate-200 bg-blue-50 px-6 py-3 dark:border-slate-800 dark:bg-blue-950/30">
+            <div className="mx-auto flex max-w-4xl items-center justify-between">
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-semibold text-text-main">
+                  {bulkSelectedIds.size} selected
+                </span>
+                <button
+                  type="button"
+                  onClick={handleBulkSelectAll}
+                  className="text-xs font-medium text-primary hover:underline"
+                >
+                  Select all pending ({pendingApprovals.length})
+                </button>
+                <button
+                  type="button"
+                  onClick={handleBulkDeselectAll}
+                  className="text-xs font-medium text-text-muted hover:underline"
+                >
+                  Clear
+                </button>
+              </div>
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  disabled={bulkDeciding}
+                  onClick={() => void handleBulkDecision("REJECTED")}
+                  className="flex items-center gap-2 rounded-lg border border-red-300 bg-red-50 px-5 py-2 text-sm font-bold text-red-600 transition-all hover:bg-red-100 active:scale-95 disabled:opacity-50 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-400"
+                >
+                  <span className="material-symbols-outlined text-[18px]">block</span>
+                  Deny All
+                </button>
+                <button
+                  type="button"
+                  disabled={bulkDeciding}
+                  onClick={() => void handleBulkDecision("APPROVED")}
+                  className="flex items-center gap-2 rounded-lg bg-emerald-600 px-6 py-2 text-sm font-bold text-white shadow-lg shadow-emerald-600/25 transition-all hover:bg-emerald-700 active:scale-95 disabled:opacity-50"
+                >
+                  <span className="material-symbols-outlined text-[18px]">check_circle</span>
+                  Approve All
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* Card list */}
         <div className="flex-1 overflow-y-auto p-6 pb-24 scrollbar-hide lg:pb-6">
           <div className="mx-auto max-w-4xl">
@@ -572,6 +669,8 @@ export default function ApprovalsPage(): React.JSX.Element {
                 onRequestContext={(id) => setSelectedId(id)}
                 filter={statusFilter}
                 riskFilter={riskFilter}
+                bulkSelectedIds={bulkSelectedIds}
+                onBulkToggle={handleBulkToggle}
               />
             )}
           </div>

--- a/packages/dashboard/src/components/approvals/approval-card.tsx
+++ b/packages/dashboard/src/components/approvals/approval-card.tsx
@@ -20,6 +20,8 @@ interface ApprovalCardProps {
   onApprove?: (id: string) => void
   onReject?: (id: string) => void
   onRequestContext?: (id: string) => void
+  bulkSelected?: boolean
+  onBulkToggle?: (id: string) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -159,12 +161,22 @@ export function ApprovalCard({
   onApprove,
   onReject,
   onRequestContext,
+  bulkSelected,
+  onBulkToggle,
 }: ApprovalCardProps): React.JSX.Element {
   const risk = classifyRisk(approval)
   const { display: countdown, expired, urgent } = useCountdown(approval.expires_at)
   const tags = deriveTags(approval)
   const isPending = approval.status === "PENDING"
   const agentName = approval.requested_by_agent_id ?? "Unknown Agent"
+  const detail = approval.action_detail ?? {}
+
+  // Extract context fields from action_detail for inline preview
+  const toolName = typeof detail.tool_name === "string" ? detail.tool_name : null
+  const parameters =
+    typeof detail.parameters === "object" && detail.parameters !== null
+      ? (detail.parameters as Record<string, unknown>)
+      : null
 
   return (
     <div
@@ -183,6 +195,23 @@ export function ApprovalCard({
 
       {/* Card body */}
       <div className="flex gap-5 p-5 pl-6">
+        {/* Bulk select checkbox (pending only) */}
+        {isPending && onBulkToggle && (
+          <div className="mt-1 flex-shrink-0">
+            <input
+              type="checkbox"
+              checked={bulkSelected ?? false}
+              onChange={(e) => {
+                e.stopPropagation()
+                onBulkToggle(approval.id)
+              }}
+              onClick={(e) => e.stopPropagation()}
+              className="size-5 cursor-pointer rounded border-slate-300 text-primary accent-primary"
+              aria-label={`Select approval ${approval.id.slice(0, 8)}`}
+            />
+          </div>
+        )}
+
         {/* Risk icon circle */}
         <div className="mt-1 flex-shrink-0">
           <div
@@ -237,10 +266,32 @@ export function ApprovalCard({
           <h3 className="truncate text-lg font-bold text-text-main">{approval.action_summary}</h3>
 
           {/* Description */}
-          {typeof approval.action_detail?.description === "string" && (
+          {typeof detail.description === "string" && (
             <p className="mt-1 line-clamp-3 text-sm leading-relaxed text-text-muted">
-              {approval.action_detail.description}
+              {detail.description}
             </p>
+          )}
+
+          {/* Inline context preview: tool call + parameters */}
+          {(toolName || parameters) && (
+            <div className="mt-2 rounded-lg border border-surface-border bg-bg-light p-3">
+              {toolName && (
+                <div className="flex items-center gap-2">
+                  <span className="material-symbols-outlined text-[14px] text-text-muted">
+                    terminal
+                  </span>
+                  <span className="text-xs font-medium text-text-muted">Tool call:</span>
+                  <code className="rounded bg-secondary px-1.5 py-0.5 font-mono text-xs font-semibold text-text-main">
+                    {toolName}
+                  </code>
+                </div>
+              )}
+              {parameters && (
+                <pre className="mt-1.5 max-h-24 overflow-auto font-mono text-[11px] leading-relaxed text-text-muted">
+                  {JSON.stringify(parameters, null, 2)}
+                </pre>
+              )}
+            </div>
           )}
 
           {/* Tags */}
@@ -258,30 +309,43 @@ export function ApprovalCard({
             ))}
           </div>
 
-          {/* Requester / Agent */}
-          <div className="mt-3 flex items-center gap-2">
-            <div className="flex size-6 items-center justify-center rounded-full bg-blue-500/10 ring-2 ring-surface-light">
-              <span className="text-[10px] font-bold text-primary">{getInitials(agentName)}</span>
+          {/* Requester / Agent + Job context */}
+          <div className="mt-3 flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <div className="flex size-6 items-center justify-center rounded-full bg-blue-500/10 ring-2 ring-surface-light">
+                <span className="text-[10px] font-bold text-primary">{getInitials(agentName)}</span>
+              </div>
+              <span className="text-xs text-text-muted">
+                {approval.requested_by_agent_id ? (
+                  <Link
+                    href={`/agents/${approval.requested_by_agent_id}`}
+                    className="font-medium text-text-main hover:text-primary"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {agentName}
+                  </Link>
+                ) : (
+                  <span className="font-medium text-text-main">{agentName}</span>
+                )}
+              </span>
             </div>
-            <span className="text-xs text-text-muted">
-              Requested by{" "}
-              {approval.requested_by_agent_id ? (
+            {approval.job_id && (
+              <div className="flex items-center gap-1.5 text-xs text-text-muted">
+                <span className="material-symbols-outlined text-[14px]">work</span>
                 <Link
-                  href={`/agents/${approval.requested_by_agent_id}`}
-                  className="font-medium text-text-main hover:text-primary"
+                  href={`/jobs/${approval.job_id}`}
+                  className="font-mono font-medium text-text-main hover:text-primary"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  {agentName}
+                  Job #{approval.job_id.slice(0, 8)}
                 </Link>
-              ) : (
-                <span className="font-medium text-text-main">{agentName}</span>
-              )}
-            </span>
+              </div>
+            )}
           </div>
         </div>
       </div>
 
-      {/* Card footer with actions */}
+      {/* Card footer with prominent actions */}
       {isPending && (
         <div className="sticky bottom-0 z-10 flex items-center justify-between border-t border-surface-border bg-surface-light/90 px-5 py-3 backdrop-blur-md">
           <button
@@ -294,16 +358,17 @@ export function ApprovalCard({
           >
             Request Context
           </button>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             <button
               type="button"
               onClick={(e) => {
                 e.stopPropagation()
                 onReject?.(approval.id)
               }}
-              className="rounded-lg px-4 py-2 text-xs font-bold uppercase tracking-wider text-red-500 transition-colors hover:bg-red-500/10"
+              className="flex items-center gap-2 rounded-lg border border-red-300 bg-red-50 px-5 py-2.5 text-sm font-bold text-red-600 transition-all hover:bg-red-100 active:scale-95 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-400 dark:hover:bg-red-500/20"
             >
-              Reject
+              <span className="material-symbols-outlined text-[18px]">block</span>
+              Deny
             </button>
             <button
               type="button"
@@ -311,9 +376,9 @@ export function ApprovalCard({
                 e.stopPropagation()
                 onApprove?.(approval.id)
               }}
-              className="flex items-center gap-2 rounded-lg bg-primary px-6 py-2 text-xs font-bold uppercase tracking-wider text-white shadow-md shadow-primary/20 transition-all hover:bg-primary/90 active:scale-95"
+              className="flex items-center gap-2 rounded-lg bg-emerald-600 px-6 py-2.5 text-sm font-bold text-white shadow-lg shadow-emerald-600/25 transition-all hover:bg-emerald-700 active:scale-95"
             >
-              <span className="material-symbols-outlined text-[16px]">check_circle</span>
+              <span className="material-symbols-outlined text-[18px]">check_circle</span>
               Approve
             </button>
           </div>

--- a/packages/dashboard/src/components/approvals/approval-list.tsx
+++ b/packages/dashboard/src/components/approvals/approval-list.tsx
@@ -14,6 +14,8 @@ interface ApprovalListProps {
   onRequestContext?: (id: string) => void
   filter?: ApprovalStatus | "ALL"
   riskFilter?: string
+  bulkSelectedIds?: Set<string>
+  onBulkToggle?: (id: string) => void
 }
 
 export function ApprovalList({
@@ -25,6 +27,8 @@ export function ApprovalList({
   onRequestContext,
   filter = "ALL",
   riskFilter = "ALL",
+  bulkSelectedIds,
+  onBulkToggle,
 }: ApprovalListProps): React.JSX.Element {
   const filtered = approvals.filter((a) => {
     if (filter !== "ALL" && a.status !== filter) return false
@@ -80,6 +84,8 @@ export function ApprovalList({
           onApprove={onApprove}
           onReject={onReject}
           onRequestContext={onRequestContext}
+          bulkSelected={bulkSelectedIds?.has(approval.id)}
+          onBulkToggle={onBulkToggle}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- **Inline context preview**: Tool call name and parameters shown directly on approval cards without clicking
- **Agent + job context**: Agent name links to agent page, job ID links to job page
- **Prominent Approve/Deny buttons**: Color-coded (emerald/red), larger, with icons for one-click decisions
- **Bulk approve/deny**: Checkbox per card, Select All / Clear, bulk Approve All / Deny All bar
- **Auto-refresh fallback**: 15s polling when SSE stream disconnects

Closes #610

## Test plan
- [ ] Verify approval cards show tool_name and parameters from action_detail inline
- [ ] Verify job ID link renders next to agent name
- [ ] Verify Approve (green) and Deny (red) buttons are prominent and one-click
- [ ] Verify bulk selection checkboxes appear on pending approvals
- [ ] Verify Select All / Approve All / Deny All work correctly
- [ ] Verify auto-refresh polls when SSE is disconnected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk selection and batch approval/denial of multiple items simultaneously
  * Added auto-refresh fallback when real-time updates are unavailable
  * Enhanced approval details with inline tool information and parameters preview
  * Included job context and requester information in approval cards

* **UI/UX Updates**
  * Updated button labels for clarity
  * Improved layout and spacing for better information visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->