### PR TITLE
docs: add deployment topology and auth provider reference

### DIFF
--- a/docs/AUTH-PROVIDERS.md
+++ b/docs/AUTH-PROVIDERS.md
@@ -3,16 +3,17 @@
 ## Architecture
 
 Cortex Plane mirrors OpenClaw's auth-profiles pattern:
+
 - **OAuth providers**: Client credentials embedded in code (no env vars needed)
 - **API key providers**: User enters key in Settings UI, encrypted and stored in DB
 - **Per-agent binding**: Each agent binds to a specific credential for LLM access
 
 ## Dashboard Login (redirect-based OAuth)
 
-| Provider | Env Vars Required | Flow |
-|----------|-------------------|------|
-| GitHub | `OAUTH_GITHUB_CLIENT_ID`, `OAUTH_GITHUB_CLIENT_SECRET` | Redirect to GitHub → callback → session |
-| Google | `OAUTH_GOOGLE_CLIENT_ID`, `OAUTH_GOOGLE_CLIENT_SECRET` | Redirect to Google → callback → session |
+| Provider | Env Vars Required                                      | Flow                                    |
+| -------- | ------------------------------------------------------ | --------------------------------------- |
+| GitHub   | `OAUTH_GITHUB_CLIENT_ID`, `OAUTH_GITHUB_CLIENT_SECRET` | Redirect to GitHub → callback → session |
+| Google   | `OAUTH_GOOGLE_CLIENT_ID`, `OAUTH_GOOGLE_CLIENT_SECRET` | Redirect to Google → callback → session |
 
 These are the only OAuth providers that need env vars — they handle user authentication, not LLM access.
 
@@ -21,13 +22,14 @@ These are the only OAuth providers that need env vars — they handle user authe
 These use embedded client credentials from `CODE_PASTE_PROVIDERS` in `oauth-providers.ts`.
 **No env vars needed.**
 
-| Provider ID | Name | Source | Auth Pattern |
-|-------------|------|--------|--------------|
+| Provider ID          | Name               | Source           | Auth Pattern                       |
+| -------------------- | ------------------ | ---------------- | ---------------------------------- |
 | `google-antigravity` | Google Antigravity | OpenClaw `pi-ai` | Google OAuth2 + PKCE, Bearer token |
-| `openai-codex` | OpenAI Codex | OpenClaw `pi-ai` | OpenAI OAuth2 + PKCE |
-| `anthropic` | Anthropic | OpenClaw `pi-ai` | Code-paste only (device code) |
+| `openai-codex`       | OpenAI Codex       | OpenClaw `pi-ai` | OpenAI OAuth2 + PKCE               |
+| `anthropic`          | Anthropic          | OpenClaw `pi-ai` | Code-paste only (device code)      |
 
 ### Code-Paste Flow
+
 1. Dashboard calls `GET /auth/connect/:provider/init` → gets `authUrl`, `codeVerifier`, `state`
 2. User opens `authUrl` in popup/new tab, authorizes
 3. Provider redirects to `localhost:*` (unreadable by dashboard since it's remote)
@@ -36,30 +38,31 @@ These use embedded client credentials from `CODE_PASTE_PROVIDERS` in `oauth-prov
 6. Control-plane exchanges code for tokens, encrypts, stores in DB
 
 ### Token Refresh
+
 - Antigravity: Google OAuth2 refresh flow (Bearer auth)
 - OpenAI Codex: OpenAI OAuth2 refresh flow
 - Anthropic: Anthropic OAuth2 refresh flow (apiKey, not Bearer — see PR #618)
 
 ## LLM Providers — API Key
 
-| Provider | How to Add | Storage |
-|----------|------------|---------|
-| Anthropic | Settings page → "Add API Key" | Encrypted in DB |
-| OpenAI | Settings page → "Add API Key" | Encrypted in DB |
+| Provider         | How to Add                    | Storage         |
+| ---------------- | ----------------------------- | --------------- |
+| Anthropic        | Settings page → "Add API Key" | Encrypted in DB |
+| OpenAI           | Settings page → "Add API Key" | Encrypted in DB |
 | Google AI Studio | Settings page → "Add API Key" | Encrypted in DB |
 
 API keys are encrypted with `CREDENTIAL_MASTER_KEY` (AES-256-GCM) before storage.
 
 ## OpenClaw Parity Status
 
-| OpenClaw Provider | Cortex Plane | Status |
-|-------------------|--------------|--------|
-| `anthropic` | ✅ `CODE_PASTE_PROVIDERS` | Working (code-paste only) |
+| OpenClaw Provider    | Cortex Plane              | Status                                     |
+| -------------------- | ------------------------- | ------------------------------------------ |
+| `anthropic`          | ✅ `CODE_PASTE_PROVIDERS` | Working (code-paste only)                  |
 | `google-antigravity` | ✅ `CODE_PASTE_PROVIDERS` | ⚠️ Settings UI routes to wrong flow (#640) |
-| `openai-codex` | ✅ `CODE_PASTE_PROVIDERS` | ⚠️ Settings UI routes to wrong flow (#640) |
-| `github-copilot` | ❌ Not added | Tracked in #642 |
-| `google-gemini-cli` | ❌ Not added | Tracked in #643 |
-| API key (any) | ✅ Settings UI | Needs e2e verification (#644) |
+| `openai-codex`       | ✅ `CODE_PASTE_PROVIDERS` | ⚠️ Settings UI routes to wrong flow (#640) |
+| `github-copilot`     | ❌ Not added              | Tracked in #642                            |
+| `google-gemini-cli`  | ❌ Not added              | Tracked in #643                            |
+| API key (any)        | ✅ Settings UI            | Needs e2e verification (#644)              |
 
 ## Agent Credential Binding
 
@@ -70,12 +73,12 @@ API keys are encrypted with `CREDENTIAL_MASTER_KEY` (AES-256-GCM) before storage
 
 ## Files
 
-| File | Purpose |
-|------|---------|
-| `packages/control-plane/src/auth/oauth-providers.ts` | Code-paste provider registry (embedded credentials) |
-| `packages/control-plane/src/auth/oauth-service.ts` | Token exchange and refresh |
-| `packages/control-plane/src/auth/credential-service.ts` | Credential CRUD, encryption, health checks |
-| `packages/control-plane/src/routes/auth.ts` | All auth routes (login, connect, code-paste) |
-| `packages/control-plane/src/config.ts` | Env var parsing for redirect-based OAuth |
-| `packages/dashboard/src/app/settings/page.tsx` | Provider connection UI |
-| `packages/dashboard/src/hooks/use-oauth-popup.ts` | Popup/code-paste flow hook |
+| File                                                    | Purpose                                             |
+| ------------------------------------------------------- | --------------------------------------------------- |
+| `packages/control-plane/src/auth/oauth-providers.ts`    | Code-paste provider registry (embedded credentials) |
+| `packages/control-plane/src/auth/oauth-service.ts`      | Token exchange and refresh                          |
+| `packages/control-plane/src/auth/credential-service.ts` | Credential CRUD, encryption, health checks          |
+| `packages/control-plane/src/routes/auth.ts`             | All auth routes (login, connect, code-paste)        |
+| `packages/control-plane/src/config.ts`                  | Env var parsing for redirect-based OAuth            |
+| `packages/dashboard/src/app/settings/page.tsx`          | Provider connection UI                              |
+| `packages/dashboard/src/hooks/use-oauth-popup.ts`       | Popup/code-paste flow hook                          |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,23 +2,23 @@
 
 ## Infrastructure
 
-| Component | Host | Details |
-|-----------|------|---------|
-| Proxmox VE | lnx-pegasus | Hypervisor for all VMs |
-| k3s cluster | `cortex-plane` VM (VMID 110) | 8GB RAM, 80GB disk, IP 10.244.7.110 |
-| Dashboard URL | `https://cortex-demo.tail0c4aa.ts.net` | Exposed via Tailscale proxy |
-| GHA Runner | On the `cortex-plane` VM | Labels: `[self-hosted, linux, cortex-k3s]` |
+| Component     | Host                                   | Details                                    |
+| ------------- | -------------------------------------- | ------------------------------------------ |
+| Proxmox VE    | lnx-pegasus                            | Hypervisor for all VMs                     |
+| k3s cluster   | `cortex-plane` VM (VMID 110)           | 8GB RAM, 80GB disk, IP 10.244.7.110        |
+| Dashboard URL | `https://cortex-demo.tail0c4aa.ts.net` | Exposed via Tailscale proxy                |
+| GHA Runner    | On the `cortex-plane` VM               | Labels: `[self-hosted, linux, cortex-k3s]` |
 
 ## Kubernetes (namespace: `cortex`)
 
-| Pod | Purpose |
-|-----|---------|
-| `control-plane` | Fastify API server (port 4000) |
-| `dashboard` | Next.js frontend (port 3000) |
-| `postgresql-{1,2,3}` | CloudNativePG 3-node cluster |
-| `postgresql-rw-pooler` (x2) | PgBouncer connection pooling |
-| `qdrant` | Vector database |
-| `tailscale-proxy` | Ingress via Tailscale |
+| Pod                         | Purpose                        |
+| --------------------------- | ------------------------------ |
+| `control-plane`             | Fastify API server (port 4000) |
+| `dashboard`                 | Next.js frontend (port 3000)   |
+| `postgresql-{1,2,3}`        | CloudNativePG 3-node cluster   |
+| `postgresql-rw-pooler` (x2) | PgBouncer connection pooling   |
+| `qdrant`                    | Vector database                |
+| `tailscale-proxy`           | Ingress via Tailscale          |
 
 ## CI/CD Pipeline
 
@@ -43,23 +43,24 @@ ssh cortex-plane 'k3s kubectl logs -n cortex deployment/control-plane --tail=50'
 
 ## Secrets (k8s `control-plane-secrets`)
 
-| Key | Purpose | Required |
-|-----|---------|----------|
-| `DATABASE_URL` | CloudNativePG pooler connection | Yes |
-| `CREDENTIAL_MASTER_KEY` | AES-256-GCM encryption for stored credentials | Yes |
-| `OAUTH_GITHUB_CLIENT_ID` | Dashboard login | Yes |
-| `OAUTH_GITHUB_CLIENT_SECRET` | Dashboard login | Yes |
+| Key                          | Purpose                                       | Required |
+| ---------------------------- | --------------------------------------------- | -------- |
+| `DATABASE_URL`               | CloudNativePG pooler connection               | Yes      |
+| `CREDENTIAL_MASTER_KEY`      | AES-256-GCM encryption for stored credentials | Yes      |
+| `OAUTH_GITHUB_CLIENT_ID`     | Dashboard login                               | Yes      |
+| `OAUTH_GITHUB_CLIENT_SECRET` | Dashboard login                               | Yes      |
 
 **NOT needed as env vars** (embedded in code):
+
 - LLM OAuth credentials (Antigravity, Codex, Anthropic) — hardcoded in `oauth-providers.ts`
 - LLM API keys — stored per-user in DB, encrypted with `CREDENTIAL_MASTER_KEY`
 
 ## ConfigMaps
 
-| ConfigMap | Key Values |
-|-----------|------------|
+| ConfigMap              | Key Values                                                          |
+| ---------------------- | ------------------------------------------------------------------- |
 | `control-plane-config` | `DASHBOARD_URL`, `QDRANT_URL`, `PORT=4000`, `LOG_LEVEL`, `NODE_ENV` |
-| `dashboard-config` | `CORTEX_API_URL=http://control-plane:4000`, `PORT=3000` |
+| `dashboard-config`     | `CORTEX_API_URL=http://control-plane:4000`, `PORT=3000`             |
 
 ## Manual Operations
 


### PR DESCRIPTION
Adds two reference docs to prevent rediscovery of deployment and auth architecture:

- **docs/DEPLOYMENT.md** — Infrastructure topology, k8s namespace, CI/CD pipeline, SSH access, secrets, manual operations
- **docs/AUTH-PROVIDERS.md** — OAuth and API key provider reference, OpenClaw parity status, code-paste flow, credential binding

No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for authentication providers and LLM configuration, covering OAuth redirects, credential flows, token refresh, and credential binding.
  * Added deployment topology and operations documentation, including infrastructure setup, Kubernetes namespace and pod roles, CI/CD pipeline steps, and manual deployment/maintenance procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->