### PR TITLE
fix(#640): route all OAuth LLM providers through code-paste flow

### DIFF
--- a/packages/dashboard/src/__tests__/settings-providers.test.ts
+++ b/packages/dashboard/src/__tests__/settings-providers.test.ts
@@ -7,8 +7,8 @@ import type { Credential, ProviderInfo } from "@/lib/api-client"
  * Validates the static mapping is correct without requiring React rendering.
  */
 
-const CODE_PASTE_PROVIDER_IDS = new Set(["anthropic"])
-const CODE_PASTE_ONLY_PROVIDER_IDS = new Set(["anthropic"])
+const CODE_PASTE_PROVIDER_IDS = new Set(["anthropic", "google-antigravity", "openai-codex"])
+const CODE_PASTE_ONLY_PROVIDER_IDS = new Set(["anthropic", "google-antigravity", "openai-codex"])
 
 /**
  * credentialLabel — mirrors the helper in settings/page.tsx.
@@ -24,16 +24,22 @@ describe("settings page code-paste providers", () => {
     expect(CODE_PASTE_PROVIDER_IDS.has("anthropic")).toBe(true)
   })
 
-  it("does not identify redirect-flow providers as code-paste", () => {
-    expect(CODE_PASTE_PROVIDER_IDS.has("google-antigravity")).toBe(false)
-    expect(CODE_PASTE_PROVIDER_IDS.has("openai-codex")).toBe(false)
+  it("identifies google-antigravity as a code-paste provider", () => {
+    expect(CODE_PASTE_PROVIDER_IDS.has("google-antigravity")).toBe(true)
+  })
+
+  it("identifies openai-codex as a code-paste provider", () => {
+    expect(CODE_PASTE_PROVIDER_IDS.has("openai-codex")).toBe(true)
+  })
+
+  it("does not identify non-OAuth providers as code-paste", () => {
     expect(CODE_PASTE_PROVIDER_IDS.has("openai")).toBe(false)
     expect(CODE_PASTE_PROVIDER_IDS.has("google-ai-studio")).toBe(false)
     expect(CODE_PASTE_PROVIDER_IDS.has("github")).toBe(false)
   })
 
-  it("contains exactly 1 provider", () => {
-    expect(CODE_PASTE_PROVIDER_IDS.size).toBe(1)
+  it("contains exactly 3 providers", () => {
+    expect(CODE_PASTE_PROVIDER_IDS.size).toBe(3)
   })
 })
 
@@ -42,9 +48,12 @@ describe("settings page code-paste-only providers", () => {
     expect(CODE_PASTE_ONLY_PROVIDER_IDS.has("anthropic")).toBe(true)
   })
 
-  it("does not mark redirect-flow providers as code-paste-only", () => {
-    expect(CODE_PASTE_ONLY_PROVIDER_IDS.has("google-antigravity")).toBe(false)
-    expect(CODE_PASTE_ONLY_PROVIDER_IDS.has("openai-codex")).toBe(false)
+  it("identifies google-antigravity as code-paste-only", () => {
+    expect(CODE_PASTE_ONLY_PROVIDER_IDS.has("google-antigravity")).toBe(true)
+  })
+
+  it("identifies openai-codex as code-paste-only", () => {
+    expect(CODE_PASTE_ONLY_PROVIDER_IDS.has("openai-codex")).toBe(true)
   })
 
   it("all code-paste-only providers are also code-paste providers", () => {
@@ -53,8 +62,8 @@ describe("settings page code-paste-only providers", () => {
     }
   })
 
-  it("contains exactly 1 provider", () => {
-    expect(CODE_PASTE_ONLY_PROVIDER_IDS.size).toBe(1)
+  it("contains exactly 3 providers", () => {
+    expect(CODE_PASTE_ONLY_PROVIDER_IDS.size).toBe(3)
   })
 })
 

--- a/packages/dashboard/src/app/settings/page.tsx
+++ b/packages/dashboard/src/app/settings/page.tsx
@@ -98,14 +98,12 @@ function CredentialHealthDetails({
   )
 }
 
-/** Code-paste providers that use the init/exchange flow (Anthropic only — device code). */
-const CODE_PASTE_PROVIDER_IDS = new Set(["anthropic"])
-
 /**
- * Providers that display a device code instead of redirecting to localhost.
- * For these, we skip the popup entirely and show a code-paste input immediately.
+ * All OAuth LLM providers use the code-paste flow with embedded client credentials.
+ * These providers redirect to localhost which is unreachable from a remote dashboard,
+ * so we skip the popup entirely and show a code-paste input immediately.
  */
-const CODE_PASTE_ONLY_PROVIDER_IDS = new Set(["anthropic"])
+const CODE_PASTE_ONLY_PROVIDER_IDS = new Set(["anthropic", "google-antigravity", "openai-codex"])
 
 // ---------------------------------------------------------------------------
 // Settings page inner (wrapped in Suspense)
@@ -217,11 +215,6 @@ function SettingsInner() {
       setCodePasteSubmitting(false)
     }
   }, [popup, popupProvider, codePastePastedUrl, fetchData])
-
-  // Connect OAuth provider (redirect-based, for providers with registered callbacks)
-  const connectOAuth = useCallback((provider: string) => {
-    window.location.href = `/api/auth/connect/${provider}`
-  }, [])
 
   // Save API key
   const saveApiKey = useCallback(async () => {
@@ -409,7 +402,6 @@ function SettingsInner() {
           {llmProviders.map((p) => {
             const cred = getCredentialForProvider(p.id)
             const isOAuth = p.authType === "oauth"
-            const isCodePaste = CODE_PASTE_PROVIDER_IDS.has(p.id)
 
             return (
               <div
@@ -492,18 +484,10 @@ function SettingsInner() {
                         Disconnect
                       </button>
                     </>
-                  ) : isOAuth && isCodePaste ? (
-                    <button
-                      type="button"
-                      onClick={() => void startPopupFlow(p.id)}
-                      className="min-h-[44px] rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-content hover:bg-primary/90 transition-colors"
-                    >
-                      Connect
-                    </button>
                   ) : isOAuth ? (
                     <button
                       type="button"
-                      onClick={() => connectOAuth(p.id)}
+                      onClick={() => void startPopupFlow(p.id)}
                       className="min-h-[44px] rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-content hover:bg-primary/90 transition-colors"
                     >
                       Connect
@@ -603,7 +587,9 @@ function SettingsInner() {
                     ) : (
                       <button
                         type="button"
-                        onClick={() => connectOAuth(p.id)}
+                        onClick={() => {
+                          window.location.href = `/api/auth/connect/${p.id}`
+                        }}
                         className="min-h-[44px] rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-content hover:bg-primary/90 transition-colors"
                       >
                         Connect


### PR DESCRIPTION
Closes #640

## Problem
Settings page `connectOAuth()` redirected to `/api/auth/connect/:provider` (env-var-dependent redirect route) for Google Antigravity and OpenAI Codex. These providers have localhost redirect URIs, making the redirect flow unusable from a remote dashboard.

## Fix
- Add `google-antigravity` and `openai-codex` to `CODE_PASTE_ONLY_PROVIDER_IDS`
- Remove separate `CODE_PASTE_PROVIDER_IDS` (consolidated — all code-paste providers are code-paste-only)
- Remove `connectOAuth()` function — all OAuth LLM providers now use `startPopupFlow()` which goes through the `/auth/connect/:provider/init` + `/exchange` code-paste flow with embedded client credentials
- No env vars needed for LLM provider OAuth

## Files Changed
- `packages/dashboard/src/app/settings/page.tsx` — routing fix
- `packages/dashboard/src/__tests__/settings-providers.test.ts` — updated assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for google-antigravity and openai-codex as code-paste providers in settings.

* **Improvements**
  * Simplified OAuth provider connection flow with unified popup and code-paste handling for a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->