### PR TITLE
fix(#646): remove unused config JSON field from agent form and all references

### DIFF
--- a/packages/control-plane/src/routes/agents.ts
+++ b/packages/control-plane/src/routes/agents.ts
@@ -47,7 +47,6 @@ interface CreateAgentBody {
   skill_config?: Record<string, unknown>
   resource_limits?: Record<string, unknown>
   channel_permissions?: Record<string, unknown>
-  config?: Record<string, unknown>
 }
 
 interface UpdateAgentBody {
@@ -58,7 +57,6 @@ interface UpdateAgentBody {
   skill_config?: Record<string, unknown>
   resource_limits?: Record<string, unknown>
   channel_permissions?: Record<string, unknown>
-  config?: Record<string, unknown>
   status?: AgentStatus
 }
 
@@ -424,7 +422,6 @@ export function agentRoutes(deps: AgentRouteDeps) {
               skill_config: { type: "object" },
               resource_limits: { type: "object" },
               channel_permissions: { type: "object" },
-              config: { type: "object" },
             },
             required: ["name", "role"],
           },
@@ -450,7 +447,6 @@ export function agentRoutes(deps: AgentRouteDeps) {
             skill_config: body.skill_config ?? {},
             resource_limits: body.resource_limits ?? {},
             channel_permissions: body.channel_permissions ?? {},
-            config: body.config ?? {},
           })
           .returningAll()
           .executeTakeFirstOrThrow()
@@ -682,7 +678,6 @@ export function agentRoutes(deps: AgentRouteDeps) {
               skill_config: { type: "object" },
               resource_limits: { type: "object" },
               channel_permissions: { type: "object" },
-              config: { type: "object" },
               status: { type: "string", enum: ["ACTIVE", "DISABLED", "ARCHIVED"] },
             },
           },
@@ -705,7 +700,6 @@ export function agentRoutes(deps: AgentRouteDeps) {
         if (body.resource_limits !== undefined) updateValues.resource_limits = body.resource_limits
         if (body.channel_permissions !== undefined)
           updateValues.channel_permissions = body.channel_permissions
-        if (body.config !== undefined) updateValues.config = body.config
         if (body.status !== undefined) {
           updateValues.status = body.status
           // Reset circuit breaker history when (re-)activating an agent (#443)

--- a/packages/dashboard/fixtures/api-responses/agent-detail.json
+++ b/packages/dashboard/fixtures/api-responses/agent-detail.json
@@ -8,7 +8,6 @@
   "skill_config": {},
   "resource_limits": {},
   "channel_permissions": {},
-  "config": {},
   "status": "ACTIVE",
   "created_at": "2025-01-15T10:30:00.000Z",
   "updated_at": "2025-01-15T10:30:00.000Z",

--- a/packages/dashboard/src/__tests__/schemas.test.ts
+++ b/packages/dashboard/src/__tests__/schemas.test.ts
@@ -136,11 +136,9 @@ describe("AgentDetailSchema", () => {
       ...validAgent,
       status: "QUARANTINED",
       checkpoint: { job_id: "job-1", saved_at: "2026-01-01T00:00:00Z", crc32: 12345 },
-      config: { quarantine_reason: "repeated failures" },
     }
     const result = AgentDetailSchema.parse(detail)
     expect(result.status).toBe("QUARANTINED")
-    expect(result.config).toEqual({ quarantine_reason: "repeated failures" })
   })
 })
 

--- a/packages/dashboard/src/app/agents/[agentId]/page.tsx
+++ b/packages/dashboard/src/app/agents/[agentId]/page.tsx
@@ -289,7 +289,6 @@ export default function AgentDetailPage({ params }: Props): React.JSX.Element {
         <div className="flex w-80 min-w-0 shrink-0 flex-col gap-6">
           <SteerInput agentId={agentId} />
           <ModelConfigPanel agent={liveAgent} onSave={() => void refetch()} />
-          <AgentConfigPanel agent={liveAgent} onSave={() => void refetch()} />
           <CredentialBindingPanel
             agentId={agentId}
             modelId={
@@ -368,7 +367,6 @@ export default function AgentDetailPage({ params }: Props): React.JSX.Element {
           <div className="flex flex-col gap-4">
             <SteerInput agentId={agentId} />
             <ModelConfigPanel agent={liveAgent} onSave={() => void refetch()} />
-            <AgentConfigPanel agent={liveAgent} onSave={() => void refetch()} />
             <CredentialBindingPanel
               agentId={agentId}
               modelId={
@@ -749,113 +747,6 @@ function ModelConfigPanel({
               {currentPrompt ? <span className="line-clamp-3">{currentPrompt}</span> : "Not set"}
             </span>
           </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
-function AgentConfigPanel({
-  agent,
-  onSave,
-}: {
-  agent: AgentDetail
-  onSave: () => void
-}): React.JSX.Element {
-  const [editing, setEditing] = useState(false)
-  const [configJson, setConfigJson] = useState("")
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const configData = agent.config ?? {}
-
-  const handleEdit = useCallback(() => {
-    setConfigJson(JSON.stringify(configData, null, 2))
-    setError(null)
-    setEditing(true)
-  }, [configData])
-
-  const handleCancel = useCallback(() => {
-    setEditing(false)
-    setError(null)
-  }, [])
-
-  const handleSave = useCallback(async () => {
-    setSaving(true)
-    setError(null)
-    try {
-      const parsed = JSON.parse(configJson) as Record<string, unknown>
-      await updateAgent(agent.id, { config: parsed })
-      setEditing(false)
-      onSave()
-    } catch (err) {
-      setError(err instanceof SyntaxError ? "Invalid JSON" : "Failed to save configuration")
-    } finally {
-      setSaving(false)
-    }
-  }, [agent.id, configJson, onSave])
-
-  const entries = Object.entries(configData)
-
-  return (
-    <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-primary/10 dark:bg-primary/5">
-      <div className="mb-4 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <span className="material-symbols-outlined text-primary">tune</span>
-          <h3 className="text-xs font-bold uppercase tracking-widest text-slate-500">
-            Configuration
-          </h3>
-        </div>
-        {!editing && (
-          <button
-            onClick={handleEdit}
-            className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
-          >
-            <span className="material-symbols-outlined text-sm">edit</span>
-            Edit
-          </button>
-        )}
-      </div>
-
-      {editing ? (
-        <div className="space-y-3">
-          <textarea
-            value={configJson}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setConfigJson(e.target.value)}
-            rows={6}
-            disabled={saving}
-            className="w-full resize-none rounded-lg border border-slate-300 bg-white px-3 py-2 font-mono text-xs text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary dark:border-slate-600 dark:bg-slate-800 dark:text-white"
-          />
-          {error && <p className="text-xs font-medium text-red-500">{error}</p>}
-          <div className="flex justify-end gap-2">
-            <button
-              onClick={handleCancel}
-              disabled={saving}
-              className="rounded-md border border-slate-300 px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={() => void handleSave()}
-              disabled={saving}
-              className="rounded-md bg-primary px-3 py-1 text-xs font-semibold text-white hover:bg-primary/90 disabled:opacity-50"
-            >
-              {saving ? "Saving..." : "Save"}
-            </button>
-          </div>
-        </div>
-      ) : entries.length === 0 ? (
-        <p className="text-sm text-slate-500">No configuration set.</p>
-      ) : (
-        <div className="space-y-2">
-          {entries.map(([key, value]) => (
-            <div key={key} className="flex items-start justify-between gap-2">
-              <span className="text-xs font-medium text-slate-500">{key}</span>
-              <span className="text-right font-mono text-xs text-slate-700 dark:text-slate-300">
-                {JSON.stringify(value)}
-              </span>
-            </div>
-          ))}
         </div>
       )}
     </div>

--- a/packages/dashboard/src/components/agents/deploy-agent-modal.tsx
+++ b/packages/dashboard/src/components/agents/deploy-agent-modal.tsx
@@ -38,7 +38,7 @@ export function DeployAgentModal({
   const [description, setDescription] = useState("")
   const [model, setModel] = useState("")
   const [systemPrompt, setSystemPrompt] = useState("")
-  const [configJson, setConfigJson] = useState("")
+
   const { addToast } = useToast()
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -49,7 +49,6 @@ export function DeployAgentModal({
     setDescription("")
     setModel("")
     setSystemPrompt("")
-    setConfigJson("")
     setError(null)
   }, [])
 
@@ -68,17 +67,6 @@ export function DeployAgentModal({
       setError(null)
 
       try {
-        let parsedConfig: Record<string, unknown> | undefined
-        if (configJson.trim()) {
-          try {
-            parsedConfig = JSON.parse(configJson.trim()) as Record<string, unknown>
-          } catch {
-            setError("Invalid JSON in configuration")
-            setSubmitting(false)
-            return
-          }
-        }
-
         const modelConfig: Record<string, unknown> = {}
         if (model.trim()) modelConfig.model = model.trim()
         if (systemPrompt.trim()) modelConfig.systemPrompt = systemPrompt.trim()
@@ -88,7 +76,6 @@ export function DeployAgentModal({
           role: role.trim(),
           description: description.trim() || undefined,
           model_config: Object.keys(modelConfig).length > 0 ? modelConfig : undefined,
-          config: parsedConfig,
         }
         await createAgent(body)
         resetForm()
@@ -100,7 +87,7 @@ export function DeployAgentModal({
         setSubmitting(false)
       }
     },
-    [name, role, description, model, systemPrompt, configJson, submitting, resetForm, onSuccess],
+    [name, role, description, model, systemPrompt, submitting, resetForm, onSuccess],
   )
 
   if (!open) return null
@@ -223,23 +210,6 @@ export function DeployAgentModal({
               rows={4}
               disabled={submitting}
               className="w-full resize-none rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:ring-1 focus:ring-primary dark:border-slate-600 dark:bg-slate-800 dark:text-white"
-            />
-          </div>
-
-          {/* Configuration (JSON) */}
-          <div>
-            <label className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">
-              Configuration (JSON)
-            </label>
-            <textarea
-              value={configJson}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                setConfigJson(e.target.value)
-              }
-              placeholder='{"key": "value"}'
-              rows={3}
-              disabled={submitting}
-              className="w-full resize-none rounded-lg border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:ring-1 focus:ring-primary dark:border-slate-600 dark:bg-slate-800 dark:text-white"
             />
           </div>
 

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -475,7 +475,6 @@ export interface CreateAgentRequest {
   skill_config?: Record<string, unknown>
   resource_limits?: Record<string, unknown>
   channel_permissions?: Record<string, unknown>
-  config?: Record<string, unknown>
 }
 
 export interface UpdateAgentRequest {
@@ -486,7 +485,6 @@ export interface UpdateAgentRequest {
   skill_config?: Record<string, unknown>
   resource_limits?: Record<string, unknown>
   channel_permissions?: Record<string, unknown>
-  config?: Record<string, unknown>
   status?: "ACTIVE" | "DISABLED" | "ARCHIVED"
 }
 

--- a/packages/dashboard/src/lib/schemas/agents.ts
+++ b/packages/dashboard/src/lib/schemas/agents.ts
@@ -38,7 +38,7 @@ export const AgentDetailSchema = AgentSummarySchema.extend({
   skill_config: z.record(z.string(), z.unknown()).optional().nullable(),
   resource_limits: z.record(z.string(), z.unknown()).optional().nullable(),
   channel_permissions: z.record(z.string(), z.unknown()).optional().nullable(),
-  config: z.record(z.string(), z.unknown()).optional().nullable(),
+
   checkpoint: CheckpointSchema.optional().nullable(),
 })
 


### PR DESCRIPTION
Closes #646

## Problem
The agent `config` field (generic JSONB catch-all) was exposed in the Deploy Agent form and Agent Detail page but nothing in the codebase reads it for any behavior. Dead weight that confuses users.

## Changes
Removed all references to the unused `config` field:

- **Deploy modal** — removed `configJson` state, textarea, and `config` from request body
- **Agent detail page** — removed entire `AgentConfigPanel` component (113 lines)
- **API client** — removed `config` from `CreateAgentRequest` and `UpdateAgentRequest` types
- **Zod schema** — removed `config` from `AgentDetailSchema`
- **Control plane routes** — removed `config` from create/update agent body parsing and DB writes
- **Test fixtures** — removed `config` from agent detail fixture

DB column is preserved (no migration needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed agent configuration support across the app: users can no longer provide or edit custom agent config when creating or updating agents. The agent configuration panel and the JSON configuration input in deployment flows have been removed; related agent detail views and fixtures/tests were updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->