### PR TITLE
fix(#651): show auto-renewing badge for OAuth credentials

### DIFF
--- a/packages/dashboard/src/__tests__/credential-health.test.ts
+++ b/packages/dashboard/src/__tests__/credential-health.test.ts
@@ -36,6 +36,40 @@ describe("tokenExpiry", () => {
     expect(tokenExpiry(makeCred({ tokenExpiresAt: null }), now)).toBeNull()
   })
 
+  it("returns Auto-renewing for active OAuth credentials", () => {
+    const cred = makeCred({
+      credentialType: "oauth",
+      status: "active",
+      tokenExpiresAt: "2026-03-09T12:15:00.000Z",
+    })
+    const result = tokenExpiry(cred, now)!
+    expect(result.label).toBe("Auto-renewing")
+    expect(result.severity).toBe("ok")
+  })
+
+  it("returns expiry countdown for non-active OAuth credentials", () => {
+    const cred = makeCred({
+      credentialType: "oauth",
+      status: "error",
+      tokenExpiresAt: "2026-03-09T11:00:00.000Z",
+    })
+    const result = tokenExpiry(cred, now)!
+    expect(result.severity).toBe("danger")
+    expect(result.label).toMatch(/^Expired/)
+  })
+
+  it("returns expiry countdown for API key credentials", () => {
+    const cred = makeCred({
+      credentialType: "api_key",
+      status: "active",
+      tokenExpiresAt: "2026-03-09T18:00:00.000Z",
+    })
+    const result = tokenExpiry(cred, now)!
+    expect(result.severity).toBe("warning")
+    expect(result.label).toMatch(/^Expires in/)
+    expect(result.label).toContain("6h")
+  })
+
   it("returns danger when token is already expired", () => {
     const cred = makeCred({ tokenExpiresAt: "2026-03-09T11:00:00.000Z" })
     const result = tokenExpiry(cred, now)!

--- a/packages/dashboard/src/app/settings/page.tsx
+++ b/packages/dashboard/src/app/settings/page.tsx
@@ -74,19 +74,24 @@ function CredentialHealthDetails({
       {cred.lastUsedAt && (
         <p className="text-text-muted">Last used: {new Date(cred.lastUsedAt).toLocaleString()}</p>
       )}
-      {expiry && (
-        <p
-          className={
-            expiry.severity === "danger"
-              ? "text-danger"
-              : expiry.severity === "warning"
-                ? "text-warning"
-                : "text-text-muted"
-          }
-        >
-          {expiry.label}
-        </p>
-      )}
+      {expiry &&
+        (expiry.label === "Auto-renewing" ? (
+          <span className="inline-block rounded-full bg-success/10 px-2 py-0.5 text-[10px] font-bold uppercase text-success">
+            Auto-renewing
+          </span>
+        ) : (
+          <p
+            className={
+              expiry.severity === "danger"
+                ? "text-danger"
+                : expiry.severity === "warning"
+                  ? "text-warning"
+                  : "text-text-muted"
+            }
+          >
+            {expiry.label}
+          </p>
+        ))}
       {refresh && <p className="text-text-muted">{refresh}</p>}
       {err && (
         <div className="mt-1 rounded border border-danger/20 bg-danger/5 px-2 py-1">

--- a/packages/dashboard/src/lib/credential-health.ts
+++ b/packages/dashboard/src/lib/credential-health.ts
@@ -12,18 +12,28 @@ import type { Credential } from "./api-client"
 // ---------------------------------------------------------------------------
 
 export interface ExpiryInfo {
-  /** Human-readable label, e.g. "Expires in 2h 15m" or "Expired 3d ago" */
+  /** Human-readable label, e.g. "Expires in 2h 15m", "Expired 3d ago", or "Auto-renewing" */
   label: string
-  /** Severity for styling: "ok" (>24h), "warning" (<24h), "danger" (expired) */
+  /** Severity for styling: "ok" (>24h or auto-renewing), "warning" (<24h), "danger" (expired) */
   severity: "ok" | "warning" | "danger"
 }
 
 /**
- * Compute a human-readable expiry summary for an OAuth credential.
+ * Compute a human-readable expiry summary for a credential.
  * Returns null for credentials without a tokenExpiresAt timestamp.
+ *
+ * Active OAuth credentials are auto-refreshed server-side, so we show
+ * "Auto-renewing" instead of a raw countdown that goes stale immediately.
  */
 export function tokenExpiry(cred: Credential, now: Date = new Date()): ExpiryInfo | null {
   if (!cred.tokenExpiresAt) return null
+
+  // Active OAuth credentials are refreshed automatically by the server.
+  // Showing a countdown is misleading because the token will be renewed
+  // before it actually expires.
+  if (cred.credentialType === "oauth" && cred.status === "active") {
+    return { label: "Auto-renewing", severity: "ok" }
+  }
 
   const expiresAt = new Date(cred.tokenExpiresAt)
   const diffMs = expiresAt.getTime() - now.getTime()


### PR DESCRIPTION
Active OAuth credentials are auto-refreshed server-side. Shows "Auto-renewing" badge instead of misleading countdown.

Closes #651

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth credentials now display "Auto-renewing" status when active instead of expiry countdown information.

* **Tests**
  * Added test coverage for credential expiry scenarios, including auto-renewing, expired, and expiring credential states across different credential types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->