### PR TITLE
fix(#656): route Antigravity through proxy instead of direct Vertex AI

### DIFF
--- a/packages/control-plane/src/__tests__/http-llm.test.ts
+++ b/packages/control-plane/src/__tests__/http-llm.test.ts
@@ -1332,7 +1332,7 @@ describe("HttpLlmBackend — 401 token refresh retry", () => {
 // ---------------------------------------------------------------------------
 
 describe("HttpLlmBackend — credential provider routing", () => {
-  it("routes google-antigravity to Vertex AI client with path rewriting and authToken", async () => {
+  it("routes google-antigravity to proxy with authToken", async () => {
     const backend = new HttpLlmBackend()
     await backend.start({ provider: "anthropic", apiKey: "global-key" })
 
@@ -1354,15 +1354,10 @@ describe("HttpLlmBackend — credential provider routing", () => {
     const client = (handle as any).client as {
       baseURL: string
       authToken: string | null
-      vertexProjectId: string
-      vertexRegion: string
     }
-    // Vertex AI base URL does NOT include the project path — path rewriting
-    // appends /projects/{project}/locations/{region}/publishers/anthropic/models/{model}:rawPredict
-    expect(client.baseURL).toBe("https://us-east5-aiplatform.googleapis.com/v1")
+    // Default Antigravity proxy — no direct Vertex AI access
+    expect(client.baseURL).toBe("https://daily-cloudcode-pa.sandbox.googleapis.com")
     expect(client.authToken).toBe("gcp-oauth-token")
-    expect(client.vertexProjectId).toBe("my-gcp-project-123")
-    expect(client.vertexRegion).toBe("us-east5")
 
     await handle.cancel("test")
   })
@@ -1454,7 +1449,7 @@ describe("HttpLlmBackend — credential provider routing", () => {
     await handle.cancel("test")
   })
 
-  it("falls back to default project when accountId is missing", async () => {
+  it("falls back to default proxy when accountId is missing", async () => {
     const backend = new HttpLlmBackend()
     await backend.start({ provider: "anthropic", apiKey: "global-key" })
 
@@ -1465,7 +1460,7 @@ describe("HttpLlmBackend — credential provider routing", () => {
           provider: "google-antigravity",
           token: "gcp-oauth-token",
           credentialId: "cred-gcp-no-account",
-          // accountId omitted — falls back to default project
+          // accountId omitted — still routes through proxy
         },
       },
     })
@@ -1476,11 +1471,9 @@ describe("HttpLlmBackend — credential provider routing", () => {
     const client = (handle as any).client as {
       baseURL: string
       authToken: string | null
-      vertexProjectId: string
     }
-    // Without accountId, Vertex client stores default project internally
-    expect(client.baseURL).toBe("https://us-east5-aiplatform.googleapis.com/v1")
-    expect(client.vertexProjectId).toBe("anthropic-cortex-default")
+    // Without accountId, still uses the default Antigravity proxy
+    expect(client.baseURL).toBe("https://daily-cloudcode-pa.sandbox.googleapis.com")
     expect(client.authToken).toBe("gcp-oauth-token")
 
     await handle.cancel("test")
@@ -1549,7 +1542,7 @@ describe("HttpLlmBackend — credential provider routing", () => {
     }
   })
 
-  it("rewrites /v1/messages path to Vertex AI rawPredict format", async () => {
+  it("does not rewrite paths — proxy accepts standard Anthropic API format", async () => {
     const backend = new HttpLlmBackend()
     await backend.start({ provider: "anthropic", apiKey: "global-key" })
 
@@ -1559,7 +1552,7 @@ describe("HttpLlmBackend — credential provider routing", () => {
         llmCredential: {
           provider: "google-antigravity",
           token: "gcp-oauth-token",
-          credentialId: "cred-gcp-rewrite",
+          credentialId: "cred-gcp-proxy",
           accountId: "my-project-42",
         },
       },
@@ -1568,30 +1561,10 @@ describe("HttpLlmBackend — credential provider routing", () => {
     const handle = await backend.executeTask(task)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    const client = (handle as any).client as unknown as {
-      baseURL: string
-      buildRequest(opts: Record<string, unknown>): Promise<{ url: string }>
-    }
-    // Verify the base URL no longer embeds the project path — path rewriting
-    // in buildRequest produces the correct Vertex AI endpoint at call time.
-    expect(client.baseURL).toBe("https://us-east5-aiplatform.googleapis.com/v1")
-
-    // Verify buildRequest rewrites the path correctly
-    const reqOpts = await client.buildRequest({
-      path: "/v1/messages",
-      method: "post",
-      body: {
-        model: "claude-sonnet-4-5-20250929",
-        stream: true,
-        messages: [{ role: "user", content: "test" }],
-      },
-    })
-
-    const reqUrl = reqOpts.url
-    expect(reqUrl).toContain("/projects/my-project-42/locations/us-east5/publishers/anthropic")
-    expect(reqUrl).toContain("/models/claude-sonnet-4-5-20250929:streamRawPredict")
-    // Must NOT contain the old double-/v1 pattern
-    expect(reqUrl).not.toContain("/publishers/anthropic/v1/messages")
+    const client = (handle as any).client as { baseURL: string; authToken: string | null }
+    // All Antigravity routing goes through the proxy — no Vertex AI direct access
+    expect(client.baseURL).toBe("https://daily-cloudcode-pa.sandbox.googleapis.com")
+    expect(client.authToken).toBe("gcp-oauth-token")
 
     await handle.cancel("test")
   })

--- a/packages/control-plane/src/backends/http-llm.ts
+++ b/packages/control-plane/src/backends/http-llm.ts
@@ -208,8 +208,7 @@ export class HttpLlmBackend implements ExecutionBackend {
     if (cred) {
       const credProvider = mapCredentialProvider(cred.provider)
       if (credProvider === "anthropic") {
-        // Google Antigravity routes through Vertex AI with Bearer auth.
-        // cloudcode-pa.googleapis.com is only for quota queries, NOT message routing.
+        // Google Antigravity routes through the Antigravity proxy with Bearer auth.
         const isAntigravity = cred.provider === "google-antigravity"
         // Antigravity: Bearer auth (Google Vertex AI requires it)
         // Anthropic OAuth: x-api-key header (Anthropic requires it, NOT Bearer)
@@ -219,28 +218,16 @@ export class HttpLlmBackend implements ExecutionBackend {
 
         let client: Anthropic
         let clientBaseUrl = baseUrl
-        let antigravityInfo: { projectId: string; region: string } | undefined
 
         if (isAntigravity) {
           const routing = resolveAntigravityRouting(cred.baseUrl, cred.accountId)
           clientBaseUrl = routing.baseUrl
-          if (routing.type === "vertex") {
-            // Native Vertex AI — needs path rewriting from /v1/messages
-            // to /models/{model}:streamRawPredict
-            antigravityInfo = { projectId: routing.projectId, region: routing.region }
-            client = new AntigravityAnthropicClient({
-              authToken: cred.token,
-              projectId: routing.projectId,
-              region: routing.region,
-            })
-          } else {
-            // Custom proxy that accepts standard Anthropic API format
-            client = new Anthropic({
-              authToken: cred.token,
-              apiKey: null as unknown as string,
-              baseURL: routing.baseUrl,
-            })
-          }
+          // Proxy accepts standard Anthropic API format — no path rewriting needed
+          client = new Anthropic({
+            authToken: cred.token,
+            apiKey: null as unknown as string,
+            baseURL: routing.baseUrl,
+          })
         } else {
           client = new Anthropic({
             ...(useBearer ? { authToken: cred.token, apiKey: null } : { apiKey: cred.token }),
@@ -254,7 +241,6 @@ export class HttpLlmBackend implements ExecutionBackend {
             credentialId: cred.credentialId,
             baseUrl: clientBaseUrl,
             useAuthToken: useBearer,
-            antigravity: antigravityInfo,
           }),
         )
       }
@@ -349,8 +335,6 @@ interface RefreshOpts {
   baseUrl?: string
   /** When true, use Bearer auth (`authToken`) instead of `apiKey` for the Anthropic SDK. */
   useAuthToken?: boolean
-  /** Vertex AI project/region for Antigravity clients (requires path rewriting). */
-  antigravity?: { projectId: string; region: string }
 }
 
 /** Returns true if the error is a 401 authentication error from an LLM SDK. */
@@ -395,99 +379,28 @@ function mapCredentialProvider(provider: string): LlmProvider {
  *   1. Explicit `baseUrl` on the credential ref (set by provider config) — assumed
  *      to be a custom proxy that accepts standard Anthropic API format.
  *   2. `ANTIGRAVITY_BASE_URL` env var — same assumption.
- *   3. Native Vertex AI endpoint — requires path rewriting from /v1/messages to
- *      /models/{model}:streamRawPredict (the standard Anthropic SDK path is not
- *      a valid Vertex AI endpoint).
- *
- * Returns either:
- *   - `{ type: "proxy", baseUrl }` for cases 1/2 (custom proxy, no rewrite needed)
- *   - `{ type: "vertex", baseUrl, projectId, region }` for case 3 (needs rewrite)
+ *   3. Default Antigravity proxy — accepts standard Anthropic `/v1/messages` format.
+ *      Consumer OAuth tokens cannot access Vertex AI directly (401/403).
  */
-type AntigravityRouting =
-  | { type: "proxy"; baseUrl: string }
-  | { type: "vertex"; baseUrl: string; projectId: string; region: string }
+interface AntigravityRouting {
+  type: "proxy"
+  baseUrl: string
+}
 
 function resolveAntigravityRouting(
   credBaseUrl?: string | null,
-  accountId?: string | null,
+  _accountId?: string | null,
 ): AntigravityRouting {
   if (credBaseUrl) return { type: "proxy", baseUrl: credBaseUrl }
 
   const envUrl = process.env.ANTIGRAVITY_BASE_URL
   if (envUrl) return { type: "proxy", baseUrl: envUrl }
 
-  const region = process.env.ANTIGRAVITY_REGION ?? "us-east5"
-  const projectId = accountId ?? process.env.ANTIGRAVITY_PROJECT ?? "anthropic-cortex-default"
+  // Default: use the Antigravity proxy (not direct Vertex AI)
   return {
-    type: "vertex",
-    baseUrl: `https://${region}-aiplatform.googleapis.com/v1`,
-    projectId,
-    region,
+    type: "proxy",
+    baseUrl: "https://daily-cloudcode-pa.sandbox.googleapis.com",
   }
-}
-
-// ---------------------------------------------------------------------------
-// Antigravity Vertex AI client
-// ---------------------------------------------------------------------------
-
-/**
- * Anthropic SDK client that rewrites /v1/messages paths to the Vertex AI
- * rawPredict endpoint format.
- *
- * Google Vertex AI does not serve a /v1/messages endpoint. The official
- * @anthropic-ai/vertex-sdk rewrites the path to:
- *   /projects/{project}/locations/{region}/publishers/anthropic/models/{model}:{specifier}
- *
- * This class replicates that behaviour so we can use the standard Anthropic SDK
- * (with our own OAuth token management) against Vertex AI.
- */
-const VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16"
-const VERTEX_MESSAGE_ENDPOINTS = new Set(["/v1/messages", "/v1/messages?beta=true"])
-
-interface AntigravityClientOpts {
-  authToken: string
-  projectId: string
-  region: string
-}
-
-class AntigravityAnthropicClient extends Anthropic {
-  private readonly vertexProjectId: string
-  private readonly vertexRegion: string
-
-  constructor(opts: AntigravityClientOpts) {
-    super({
-      authToken: opts.authToken,
-      apiKey: null as unknown as string,
-      baseURL: `https://${opts.region}-aiplatform.googleapis.com/v1`,
-    })
-    this.vertexProjectId = opts.projectId
-    this.vertexRegion = opts.region
-  }
-
-  /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any */
-  override async buildRequest(options: any): Promise<any> {
-    // Inject Vertex anthropic_version into the body (required by Vertex AI)
-    if (
-      typeof options.body === "object" &&
-      options.body !== null &&
-      !options.body.anthropic_version
-    ) {
-      options.body.anthropic_version = VERTEX_ANTHROPIC_VERSION
-    }
-
-    // Rewrite /v1/messages → Vertex AI rawPredict / streamRawPredict
-    if (VERTEX_MESSAGE_ENDPOINTS.has(options.path as string) && options.method === "post") {
-      const body = options.body as Record<string, unknown>
-      const model = body.model as string
-      body.model = undefined
-      const stream = (body.stream as boolean) ?? false
-      const specifier = stream ? "streamRawPredict" : "rawPredict"
-      options.path = `/projects/${this.vertexProjectId}/locations/${this.vertexRegion}/publishers/anthropic/models/${model}:${specifier}`
-    }
-
-    return super.buildRequest(options)
-  }
-  /* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any */
 }
 
 function toOpenAITools(defs: ToolDefinition[]): OpenAI.ChatCompletionTool[] {
@@ -518,7 +431,6 @@ class AnthropicHandle implements ExecutionHandle {
   private readonly credentialId?: string
   private readonly baseUrl?: string
   private readonly useAuthToken: boolean
-  private readonly antigravity?: { projectId: string; region: string }
 
   constructor(
     private readonly task: ExecutionTask,
@@ -536,7 +448,6 @@ class AnthropicHandle implements ExecutionHandle {
     this.credentialId = refreshOpts?.credentialId
     this.baseUrl = refreshOpts?.baseUrl
     this.useAuthToken = refreshOpts?.useAuthToken ?? false
-    this.antigravity = refreshOpts?.antigravity
   }
 
   async *events(): AsyncIterable<OutputEvent> {
@@ -662,18 +573,12 @@ class AnthropicHandle implements ExecutionHandle {
             lastRetryTurn = turn
             const newToken = await this.tokenRefresher(this.credentialId)
             if (newToken) {
-              this.client = this.antigravity
-                ? new AntigravityAnthropicClient({
-                    authToken: newToken,
-                    projectId: this.antigravity.projectId,
-                    region: this.antigravity.region,
-                  })
-                : new Anthropic({
-                    ...(this.useAuthToken
-                      ? { authToken: newToken, apiKey: null }
-                      : { apiKey: newToken }),
-                    ...(this.baseUrl ? { baseURL: this.baseUrl } : {}),
-                  })
+              this.client = new Anthropic({
+                ...(this.useAuthToken
+                  ? { authToken: newToken, apiKey: null }
+                  : { apiKey: newToken }),
+                ...(this.baseUrl ? { baseURL: this.baseUrl } : {}),
+              })
               turn-- // retry this turn
               continue
             }


### PR DESCRIPTION
Default Antigravity routing now uses the proxy (`daily-cloudcode-pa.sandbox.googleapis.com`) instead of direct Vertex AI. Consumer OAuth tokens cannot access Vertex AI directly (401/403).

Removes dead `AntigravityAnthropicClient` class and path-rewriting logic.

Closes #656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Antigravity authentication routing by consolidating proxy-based request handling and removing separate Vertex AI-specific routing logic, resulting in a more streamlined per-job credential flow.

* **Tests**
  * Updated test expectations to validate proxy-based routing and standard API formatting for Antigravity scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->