### PR TITLE
feat(#641): add Google AI Studio provider and Gemini models

### DIFF
--- a/packages/control-plane/src/backends/http-llm.ts
+++ b/packages/control-plane/src/backends/http-llm.ts
@@ -244,16 +244,17 @@ export class HttpLlmBackend implements ExecutionBackend {
           }),
         )
       }
-      // OpenAI or other providers
+      // OpenAI or other providers — resolve base URL from credential or provider default
+      const openaiBaseUrl = cred.baseUrl ?? baseUrl ?? resolveOpenAICompatibleBaseUrl(cred.provider)
       const client = new OpenAI({
         apiKey: cred.token,
-        ...(baseUrl ? { baseURL: baseUrl } : {}),
+        ...(openaiBaseUrl ? { baseURL: openaiBaseUrl } : {}),
       })
       return Promise.resolve(
         new OpenAIHandle(task, client, model, startTime, registry, {
           tokenRefresher,
           credentialId: cred.credentialId,
-          baseUrl,
+          baseUrl: openaiBaseUrl,
         }),
       )
     }
@@ -370,6 +371,17 @@ function toAnthropicTools(defs: ToolDefinition[]): Anthropic.Tool[] {
 function mapCredentialProvider(provider: string): LlmProvider {
   if (provider === "anthropic" || provider === "google-antigravity") return "anthropic"
   return "openai"
+}
+
+/**
+ * Return the default base URL for OpenAI-compatible providers that use
+ * a non-standard endpoint. Returns undefined for native OpenAI providers.
+ */
+function resolveOpenAICompatibleBaseUrl(provider: string): string | undefined {
+  if (provider === "google-ai-studio") {
+    return "https://generativelanguage.googleapis.com/v1beta/openai/"
+  }
+  return undefined
 }
 
 /**

--- a/packages/control-plane/src/observability/model-pricing.ts
+++ b/packages/control-plane/src/observability/model-pricing.ts
@@ -55,6 +55,20 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
     inputPerMToken: 0.15,
     outputPerMToken: 0.6,
   },
+
+  // Gemini
+  "gemini-2.5-pro": {
+    inputPerMToken: 1.25,
+    outputPerMToken: 10.0,
+  },
+  "gemini-2.5-flash": {
+    inputPerMToken: 0.15,
+    outputPerMToken: 0.6,
+  },
+  "gemini-2.0-flash": {
+    inputPerMToken: 0.1,
+    outputPerMToken: 0.4,
+  },
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds google-ai-studio as an OpenAI-compatible provider routing to `generativelanguage.googleapis.com/v1beta/openai/`. Adds Gemini model pricing (2.5-pro, 2.5-flash, 2.0-flash).

Closes #641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new Gemini models: `gemini-2.5-pro`, `gemini-2.5-flash`, and `gemini-2.0-flash` with updated pricing information.

* **Improvements**
  * Enhanced OpenAI-compatible API endpoint resolution for improved provider compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->