### PR TITLE
fix(#663): show error state when OAuth refresh has failed

### DIFF
--- a/packages/dashboard/src/__tests__/credential-health.test.ts
+++ b/packages/dashboard/src/__tests__/credential-health.test.ts
@@ -47,6 +47,32 @@ describe("tokenExpiry", () => {
     expect(result.severity).toBe("ok")
   })
 
+  it("returns Auto-renewing for active OAuth with errors but token not yet expired", () => {
+    const cred = makeCred({
+      credentialType: "oauth",
+      status: "active",
+      tokenExpiresAt: "2026-03-09T13:00:00.000Z",
+      errorCount: 2,
+      lastError: "rate_limited",
+    })
+    const result = tokenExpiry(cred, now)!
+    expect(result.label).toBe("Auto-renewing")
+    expect(result.severity).toBe("ok")
+  })
+
+  it("shows expiry when active OAuth token expired and refresh failed", () => {
+    const cred = makeCred({
+      credentialType: "oauth",
+      status: "active",
+      tokenExpiresAt: "2026-03-09T11:00:00.000Z",
+      errorCount: 3,
+      lastError: "token refresh failed: invalid_grant",
+    })
+    const result = tokenExpiry(cred, now)!
+    expect(result.severity).toBe("danger")
+    expect(result.label).toMatch(/^Expired/)
+  })
+
   it("returns expiry countdown for non-active OAuth credentials", () => {
     const cred = makeCred({
       credentialType: "oauth",

--- a/packages/dashboard/src/lib/credential-health.ts
+++ b/packages/dashboard/src/lib/credential-health.ts
@@ -30,9 +30,14 @@ export function tokenExpiry(cred: Credential, now: Date = new Date()): ExpiryInf
 
   // Active OAuth credentials are refreshed automatically by the server.
   // Showing a countdown is misleading because the token will be renewed
-  // before it actually expires.
+  // before it actually expires — unless the refresh has failed, in which
+  // case we fall through and show the real expiry/error state.
   if (cred.credentialType === "oauth" && cred.status === "active") {
-    return { label: "Auto-renewing", severity: "ok" }
+    const expired = new Date(cred.tokenExpiresAt).getTime() <= now.getTime()
+    const hasError = (cred.errorCount != null && cred.errorCount > 0) || !!cred.lastError
+    if (!(expired && hasError)) {
+      return { label: "Auto-renewing", severity: "ok" }
+    }
   }
 
   const expiresAt = new Date(cred.tokenExpiresAt)


### PR DESCRIPTION
Auto-renewing badge now checks errorCount/lastError — falls through to expiry display when refresh has actually failed.

Closes #663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OAuth credential health monitoring. The system now accurately detects when active OAuth tokens have expired or when automatic renewal has failed, displaying correct status indicators and severity levels instead of a generic auto-renewal message. This provides improved visibility into credential health issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->