### PR TITLE
feat(#665): replace static model catalogue with dynamic provider discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ qdrant_data/
 deploy/k8s/overlays/dev/secrets.yaml
 .test-pgdata-*/
 TASK.md
+deploy/k8s/**/secrets.yaml

--- a/packages/control-plane/src/__tests__/credential-routes.test.ts
+++ b/packages/control-plane/src/__tests__/credential-routes.test.ts
@@ -1,9 +1,31 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
 import Fastify from "fastify"
-import { describe, expect, it, vi } from "vitest"
+import { beforeAll, describe, expect, it, vi } from "vitest"
 
 import type { CredentialSummary } from "../auth/credential-service.js"
+import { modelDiscoveryService } from "../observability/model-providers.js"
 import { credentialRoutes } from "../routes/credentials.js"
+
+// Seed discovery cache so modelsForProvider returns data in tests
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const cache = (modelDiscoveryService as any).cache as Map<string, unknown>
+  cache.set("anthropic", {
+    models: [
+      { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", providers: ["anthropic"] },
+      { id: "claude-opus-4-6", label: "Claude Opus 4.6", providers: ["anthropic"] },
+      { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", providers: ["anthropic"] },
+    ],
+    expiresAt: Date.now() + 60 * 60 * 1000,
+  })
+  cache.set("openai", {
+    models: [
+      { id: "gpt-4o", label: "GPT-4o", providers: ["openai"] },
+      { id: "gpt-4o-mini", label: "GPT-4o Mini", providers: ["openai"] },
+    ],
+    expiresAt: Date.now() + 60 * 60 * 1000,
+  })
+})
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/control-plane/src/__tests__/model-routes.test.ts
+++ b/packages/control-plane/src/__tests__/model-routes.test.ts
@@ -1,17 +1,53 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument */
 import Fastify from "fastify"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { MODEL_CATALOGUE } from "../observability/model-providers.js"
+import { ModelDiscoveryService } from "../auth/model-discovery.js"
 import { modelRoutes } from "../routes/models.js"
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-async function buildTestApp() {
+function seedDiscovery(svc: ModelDiscoveryService): void {
+  const providers: Record<string, { id: string; label: string; providers: string[] }[]> = {
+    anthropic: [
+      { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", providers: ["anthropic"] },
+      { id: "claude-opus-4-6", label: "Claude Opus 4.6", providers: ["anthropic"] },
+      { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", providers: ["anthropic"] },
+    ],
+    openai: [
+      { id: "gpt-4o", label: "GPT-4o", providers: ["openai"] },
+      { id: "gpt-4o-mini", label: "GPT-4o Mini", providers: ["openai"] },
+    ],
+    "google-ai-studio": [
+      { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro", providers: ["google-ai-studio"] },
+      { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash", providers: ["google-ai-studio"] },
+      { id: "gemini-2.0-flash", label: "Gemini 2.0 Flash", providers: ["google-ai-studio"] },
+    ],
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const cache = (svc as any).cache as Map<string, unknown>
+  for (const [providerId, models] of Object.entries(providers)) {
+    cache.set(providerId, { models, expiresAt: Date.now() + 60 * 60 * 1000 })
+  }
+}
+
+let discovery: ModelDiscoveryService
+
+beforeEach(() => {
+  discovery = new ModelDiscoveryService()
+  seedDiscovery(discovery)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+async function buildTestApp(deps?: Parameters<typeof modelRoutes>[0]) {
   const app = Fastify({ logger: false })
-  await app.register(modelRoutes())
+  await app.register(modelRoutes({ ...deps, discoveryService: discovery }))
   return app
 }
 
@@ -20,18 +56,15 @@ async function buildTestApp() {
 // ---------------------------------------------------------------------------
 
 describe("GET /models", () => {
-  it("returns the full model catalogue", async () => {
+  it("returns discovered models", async () => {
     const app = await buildTestApp()
 
-    const res = await app.inject({
-      method: "GET",
-      url: "/models",
-    })
+    const res = await app.inject({ method: "GET", url: "/models" })
 
     expect(res.statusCode).toBe(200)
     const body = res.json()
     expect(body.models).toBeDefined()
-    expect(body.models).toEqual(MODEL_CATALOGUE)
+    expect(body.models.length).toBeGreaterThan(0)
   })
 
   it("includes at least one Anthropic and one OpenAI model", async () => {
@@ -88,8 +121,22 @@ describe("GET /models", () => {
     expect(new Set(ids).size).toBe(ids.length)
   })
 
-  it("returns full catalogue when credentialAware=true but no deps provided", async () => {
-    const app = await buildTestApp()
+  it("returns empty array when cache is empty", async () => {
+    const emptyDiscovery = new ModelDiscoveryService()
+    const app = Fastify({ logger: false })
+    await app.register(modelRoutes({ discoveryService: emptyDiscovery }))
+
+    const res = await app.inject({ method: "GET", url: "/models" })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.models).toEqual([])
+  })
+
+  it("returns empty when credentialAware=true but no deps provided", async () => {
+    const emptyDiscovery = new ModelDiscoveryService()
+    const app = Fastify({ logger: false })
+    await app.register(modelRoutes({ discoveryService: emptyDiscovery }))
 
     const res = await app.inject({
       method: "GET",
@@ -98,7 +145,7 @@ describe("GET /models", () => {
 
     expect(res.statusCode).toBe(200)
     const body = res.json()
-    expect(body.models).toEqual(MODEL_CATALOGUE)
+    expect(body.models).toEqual([])
   })
 
   it("filters models when credentialAware=true and user has credentials", async () => {
@@ -123,6 +170,7 @@ describe("GET /models", () => {
       modelRoutes({
         credentialService: mockCredentialService as never,
         sessionService: mockSessionService as never,
+        discoveryService: discovery,
       }),
     )
 
@@ -157,6 +205,7 @@ describe("GET /models", () => {
       modelRoutes({
         credentialService: mockCredentialService as never,
         sessionService: mockSessionService as never,
+        discoveryService: discovery,
       }),
     )
 
@@ -167,6 +216,6 @@ describe("GET /models", () => {
 
     expect(res.statusCode).toBe(200)
     const body = res.json()
-    expect(body.models).toEqual(MODEL_CATALOGUE)
+    expect(body.models.length).toBeGreaterThan(0)
   })
 })

--- a/packages/control-plane/src/auth/__tests__/model-discovery.test.ts
+++ b/packages/control-plane/src/auth/__tests__/model-discovery.test.ts
@@ -1,0 +1,372 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ModelDiscoveryService } from "../model-discovery.js"
+
+// ---------------------------------------------------------------------------
+// Global fetch mock
+// ---------------------------------------------------------------------------
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic
+// ---------------------------------------------------------------------------
+
+describe("discoverModels — anthropic", () => {
+  it("parses Anthropic models list", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [{ id: "claude-sonnet-4-6" }, { id: "claude-opus-4-6" }],
+      }),
+    )
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("anthropic", { apiKey: "sk-test" })
+
+    expect(models).toHaveLength(2)
+    expect(models[0]!.id).toBe("claude-sonnet-4-6")
+    expect(models[0]!.providers).toEqual(["anthropic"])
+    expect(models[1]!.id).toBe("claude-opus-4-6")
+
+    // Verify correct headers
+    const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit]
+    expect(url).toContain("/v1/models")
+    expect((init.headers as Record<string, string>)["x-api-key"]).toBe("sk-test")
+    expect((init.headers as Record<string, string>)["anthropic-version"]).toBe("2023-06-01")
+  })
+
+  it("uses Bearer auth when accessToken provided", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [{ id: "claude-haiku-4-5" }] }))
+
+    const svc = new ModelDiscoveryService()
+    await svc.discoverModels("anthropic", { accessToken: "oauth-tok" })
+
+    const [, init] = fetchMock.mock.calls[0]! as [string, RequestInit]
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer oauth-tok")
+  })
+
+  it("returns empty array on failure", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 401))
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("anthropic", { apiKey: "bad" })
+
+    expect(models).toEqual([])
+  })
+
+  it("returns empty array on network error", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network error"))
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("anthropic", { apiKey: "sk-test" })
+
+    expect(models).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// OpenAI
+// ---------------------------------------------------------------------------
+
+describe("discoverModels — openai", () => {
+  it("filters to chat models", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          { id: "gpt-4o" },
+          { id: "gpt-4o-mini" },
+          { id: "dall-e-3" },
+          { id: "text-embedding-ada-002" },
+          { id: "o1-preview" },
+          { id: "o3-mini" },
+          { id: "o4-mini" },
+        ],
+      }),
+    )
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("openai", { apiKey: "sk-openai" })
+
+    const ids = models.map((m) => m.id)
+    expect(ids).toContain("gpt-4o")
+    expect(ids).toContain("gpt-4o-mini")
+    expect(ids).toContain("o1-preview")
+    expect(ids).toContain("o3-mini")
+    expect(ids).toContain("o4-mini")
+    expect(ids).not.toContain("dall-e-3")
+    expect(ids).not.toContain("text-embedding-ada-002")
+
+    // All should have openai provider
+    for (const m of models) {
+      expect(m.providers).toEqual(["openai"])
+    }
+  })
+
+  it("openai-codex tags models with openai-codex provider", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [{ id: "gpt-4o" }] }))
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("openai-codex", { accessToken: "tok" })
+
+    expect(models[0]!.providers).toEqual(["openai-codex"])
+  })
+
+  it("returns empty on failure", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 500))
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("openai", { apiKey: "sk-bad" })
+
+    expect(models).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Google AI Studio
+// ---------------------------------------------------------------------------
+
+describe("discoverModels — google-ai-studio", () => {
+  it("strips models/ prefix from names", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        models: [{ name: "models/gemini-2.5-pro" }, { name: "models/gemini-2.5-flash" }],
+      }),
+    )
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("google-ai-studio", { apiKey: "AIza-test" })
+
+    expect(models).toHaveLength(2)
+    expect(models[0]!.id).toBe("gemini-2.5-pro")
+    expect(models[0]!.providers).toEqual(["google-ai-studio"])
+    expect(models[1]!.id).toBe("gemini-2.5-flash")
+
+    // API key should be in the URL
+    const [url] = fetchMock.mock.calls[0]! as [string]
+    expect(url).toContain("key=AIza-test")
+  })
+
+  it("returns empty without apiKey", async () => {
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("google-ai-studio", { accessToken: "tok" })
+    expect(models).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Google Antigravity
+// ---------------------------------------------------------------------------
+
+describe("discoverModels — google-antigravity", () => {
+  it("calls the Antigravity proxy models endpoint", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [{ id: "claude-sonnet-4-6" }, { id: "gemini-2.5-pro" }],
+      }),
+    )
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("google-antigravity", { accessToken: "goog-tok" })
+
+    expect(models).toHaveLength(2)
+    expect(models[0]!.providers).toEqual(["google-antigravity"])
+
+    const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit]
+    expect(url).toContain("/v1/models")
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer goog-tok")
+  })
+
+  it("uses ANTIGRAVITY_BASE_URL env var", async () => {
+    const original = process.env.ANTIGRAVITY_BASE_URL
+    process.env.ANTIGRAVITY_BASE_URL = "https://custom-proxy.example.com"
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [{ id: "claude-opus-4-6" }] }))
+
+    const svc = new ModelDiscoveryService()
+    await svc.discoverModels("google-antigravity", { accessToken: "tok" })
+
+    const [url] = fetchMock.mock.calls[0]! as [string]
+    expect(url).toBe("https://custom-proxy.example.com/v1/models")
+
+    if (original === undefined) {
+      delete process.env.ANTIGRAVITY_BASE_URL
+    } else {
+      process.env.ANTIGRAVITY_BASE_URL = original
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GitHub Copilot
+// ---------------------------------------------------------------------------
+
+describe("discoverModels — github-copilot", () => {
+  it("parses GitHub Copilot models", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [{ id: "gpt-4o" }, { id: "claude-sonnet-4-6" }],
+      }),
+    )
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("github-copilot", { accessToken: "gh-tok" })
+
+    expect(models).toHaveLength(2)
+    expect(models[0]!.providers).toEqual(["github-copilot"])
+
+    const [url] = fetchMock.mock.calls[0]! as [string]
+    expect(url).toContain("githubcopilot.com/models")
+  })
+
+  it("handles array response format", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([{ id: "gpt-4o" }]))
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("github-copilot", { accessToken: "gh-tok" })
+
+    expect(models).toHaveLength(1)
+    expect(models[0]!.id).toBe("gpt-4o")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Google Gemini CLI
+// ---------------------------------------------------------------------------
+
+describe("discoverModels — google-gemini-cli", () => {
+  it("parses Gemini models with OAuth token", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        models: [{ name: "models/gemini-2.0-flash" }],
+      }),
+    )
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("google-gemini-cli", { accessToken: "oauth-tok" })
+
+    expect(models).toHaveLength(1)
+    expect(models[0]!.id).toBe("gemini-2.0-flash")
+    expect(models[0]!.providers).toEqual(["google-gemini-cli"])
+
+    const [, init] = fetchMock.mock.calls[0]! as [string, RequestInit]
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer oauth-tok")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unknown provider
+// ---------------------------------------------------------------------------
+
+describe("discoverModels — unknown provider", () => {
+  it("returns empty for unknown providers", async () => {
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("some-unknown", { apiKey: "key" })
+    expect(models).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cache behaviour
+// ---------------------------------------------------------------------------
+
+describe("cache", () => {
+  it("caches results per provider", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [{ id: "claude-sonnet-4-6" }] }))
+
+    const svc = new ModelDiscoveryService()
+    await svc.discoverModels("anthropic", { apiKey: "sk-test" })
+
+    const cached = svc.getCachedModels("anthropic")
+    expect(cached).toHaveLength(1)
+    expect(cached[0]!.id).toBe("claude-sonnet-4-6")
+  })
+
+  it("returns empty for uncached providers", () => {
+    const svc = new ModelDiscoveryService()
+    expect(svc.getCachedModels("openai")).toEqual([])
+  })
+
+  it("invalidate clears cache for a provider", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [{ id: "gpt-4o" }] }))
+
+    const svc = new ModelDiscoveryService()
+    await svc.discoverModels("openai", { apiKey: "sk-openai" })
+
+    expect(svc.getCachedModels("openai")).toHaveLength(1)
+
+    svc.invalidate("openai")
+    expect(svc.getCachedModels("openai")).toEqual([])
+  })
+
+  it("invalidateAll clears all caches", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "claude-sonnet-4-6" }] }))
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "gpt-4o" }] }))
+
+    const svc = new ModelDiscoveryService()
+    await svc.discoverModels("anthropic", { apiKey: "sk-a" })
+    await svc.discoverModels("openai", { apiKey: "sk-o" })
+
+    expect(svc.getAllCachedModels()).toHaveLength(2)
+
+    svc.invalidateAll()
+    expect(svc.getAllCachedModels()).toEqual([])
+  })
+
+  it("does not cache empty results", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 401))
+
+    const svc = new ModelDiscoveryService()
+    await svc.discoverModels("anthropic", { apiKey: "bad" })
+
+    expect(svc.getCachedModels("anthropic")).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getAllCachedModels — deduplication
+// ---------------------------------------------------------------------------
+
+describe("getAllCachedModels", () => {
+  it("merges providers for duplicate model IDs", async () => {
+    // Same model ID from two providers
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "claude-sonnet-4-6" }] }))
+      .mockResolvedValueOnce(
+        jsonResponse({ data: [{ id: "claude-sonnet-4-6" }, { id: "gemini-2.5-pro" }] }),
+      )
+
+    const svc = new ModelDiscoveryService()
+    await svc.discoverModels("anthropic", { apiKey: "sk-a" })
+    await svc.discoverModels("google-antigravity", { accessToken: "tok" })
+
+    const all = svc.getAllCachedModels()
+    const claude = all.find((m) => m.id === "claude-sonnet-4-6")
+    expect(claude).toBeDefined()
+    expect(claude!.providers).toContain("anthropic")
+    expect(claude!.providers).toContain("google-antigravity")
+
+    const gemini = all.find((m) => m.id === "gemini-2.5-pro")
+    expect(gemini).toBeDefined()
+    expect(gemini!.providers).toEqual(["google-antigravity"])
+  })
+})

--- a/packages/control-plane/src/auth/model-discovery.ts
+++ b/packages/control-plane/src/auth/model-discovery.ts
@@ -1,0 +1,287 @@
+/**
+ * Dynamic model discovery from LLM provider APIs.
+ *
+ * Replaces the static MODEL_CATALOGUE with live discovery. Each provider
+ * exposes a models endpoint; this service calls them and caches results
+ * with a 1-hour TTL.
+ */
+
+import type { ModelInfo } from "../observability/model-providers.js"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ProviderCredential {
+  accessToken?: string
+  apiKey?: string
+}
+
+interface CacheEntry {
+  models: ModelInfo[]
+  expiresAt: number
+}
+
+// ---------------------------------------------------------------------------
+// Provider-specific discovery
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour
+
+/** Chat-model filter for OpenAI: keep only models whose id matches these. */
+const OPENAI_CHAT_RE = /gpt|o1|o3|o4/i
+
+function labelFromId(id: string): string {
+  return id
+    .replace(/^models\//, "")
+    .split("-")
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(" ")
+}
+
+async function fetchJson(url: string, init: RequestInit): Promise<unknown> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 15_000)
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal })
+    if (!res.ok) return null
+    return res.json()
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-provider discovery functions
+// ---------------------------------------------------------------------------
+
+async function discoverAnthropic(cred: ProviderCredential): Promise<ModelInfo[]> {
+  const headers: Record<string, string> = {
+    "anthropic-version": "2023-06-01",
+  }
+  if (cred.apiKey) {
+    headers["x-api-key"] = cred.apiKey
+  } else if (cred.accessToken) {
+    headers["Authorization"] = `Bearer ${cred.accessToken}`
+  } else {
+    return []
+  }
+
+  const data = (await fetchJson("https://api.anthropic.com/v1/models", {
+    method: "GET",
+    headers,
+  })) as { data?: { id: string }[] } | null
+  if (!data?.data) return []
+
+  return data.data.map((m) => ({
+    id: m.id,
+    label: labelFromId(m.id),
+    providers: ["anthropic"],
+  }))
+}
+
+async function discoverOpenAI(
+  cred: ProviderCredential,
+  providerIds: string[],
+): Promise<ModelInfo[]> {
+  const token = cred.accessToken ?? cred.apiKey
+  if (!token) return []
+
+  const data = (await fetchJson("https://api.openai.com/v1/models", {
+    method: "GET",
+    headers: { Authorization: `Bearer ${token}` },
+  })) as { data?: { id: string }[] } | null
+  if (!data?.data) return []
+
+  return data.data
+    .filter((m) => OPENAI_CHAT_RE.test(m.id))
+    .map((m) => ({
+      id: m.id,
+      label: labelFromId(m.id),
+      providers: providerIds,
+    }))
+}
+
+async function discoverGoogleAIStudio(cred: ProviderCredential): Promise<ModelInfo[]> {
+  const key = cred.apiKey
+  if (!key) return []
+
+  const data = (await fetchJson(
+    `https://generativelanguage.googleapis.com/v1beta/models?key=${key}`,
+    { method: "GET" },
+  )) as { models?: { name: string }[] } | null
+  if (!data?.models) return []
+
+  return data.models.map((m) => {
+    const id = m.name.replace(/^models\//, "")
+    return {
+      id,
+      label: labelFromId(id),
+      providers: ["google-ai-studio"],
+    }
+  })
+}
+
+async function discoverGoogleAntigravity(cred: ProviderCredential): Promise<ModelInfo[]> {
+  const token = cred.accessToken
+  if (!token) return []
+
+  const baseUrl =
+    process.env.ANTIGRAVITY_BASE_URL ?? "https://daily-cloudcode-pa.sandbox.googleapis.com"
+
+  // Try Anthropic-format models endpoint on the proxy
+  const data = (await fetchJson(`${baseUrl}/v1/models`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "anthropic-version": "2023-06-01",
+    },
+  })) as { data?: { id: string }[] } | null
+  if (!data?.data) return []
+
+  return data.data.map((m) => ({
+    id: m.id,
+    label: labelFromId(m.id),
+    providers: ["google-antigravity"],
+  }))
+}
+
+async function discoverGitHubCopilot(cred: ProviderCredential): Promise<ModelInfo[]> {
+  const token = cred.accessToken
+  if (!token) return []
+
+  const data = (await fetchJson("https://api.githubcopilot.com/models", {
+    method: "GET",
+    headers: { Authorization: `Bearer ${token}` },
+  })) as { data?: { id: string }[] } | { id: string }[] | null
+  if (!data) return []
+
+  // Response may be { data: [...] } or directly [...]
+  const items = Array.isArray(data) ? data : (data as { data?: { id: string }[] }).data
+  if (!items) return []
+
+  return items.map((m) => ({
+    id: m.id,
+    label: labelFromId(m.id),
+    providers: ["github-copilot"],
+  }))
+}
+
+async function discoverGeminiCli(cred: ProviderCredential): Promise<ModelInfo[]> {
+  const token = cred.accessToken
+  if (!token) return []
+
+  // Same as Google AI Studio but with OAuth bearer instead of API key
+  const data = (await fetchJson("https://generativelanguage.googleapis.com/v1beta/models", {
+    method: "GET",
+    headers: { Authorization: `Bearer ${token}` },
+  })) as { models?: { name: string }[] } | null
+  if (!data?.models) return []
+
+  return data.models.map((m) => {
+    const id = m.name.replace(/^models\//, "")
+    return {
+      id,
+      label: labelFromId(id),
+      providers: ["google-gemini-cli"],
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// ModelDiscoveryService
+// ---------------------------------------------------------------------------
+
+export class ModelDiscoveryService {
+  private cache = new Map<string, CacheEntry>()
+
+  /**
+   * Discover models from a provider's API.
+   * Results are cached with 1h TTL.
+   */
+  async discoverModels(providerId: string, credential: ProviderCredential): Promise<ModelInfo[]> {
+    let models: ModelInfo[]
+
+    switch (providerId) {
+      case "anthropic":
+        models = await discoverAnthropic(credential)
+        break
+      case "openai":
+        models = await discoverOpenAI(credential, ["openai"])
+        break
+      case "openai-codex":
+        models = await discoverOpenAI(credential, ["openai-codex"])
+        break
+      case "google-ai-studio":
+        models = await discoverGoogleAIStudio(credential)
+        break
+      case "google-antigravity":
+        models = await discoverGoogleAntigravity(credential)
+        break
+      case "github-copilot":
+        models = await discoverGitHubCopilot(credential)
+        break
+      case "google-gemini-cli":
+        models = await discoverGeminiCli(credential)
+        break
+      default:
+        models = []
+    }
+
+    if (models.length > 0) {
+      this.cache.set(providerId, {
+        models,
+        expiresAt: Date.now() + CACHE_TTL_MS,
+      })
+    }
+
+    return models
+  }
+
+  /**
+   * Return cached models for a provider, or empty array if cache is
+   * empty / expired.
+   */
+  getCachedModels(providerId: string): ModelInfo[] {
+    const entry = this.cache.get(providerId)
+    if (!entry || Date.now() > entry.expiresAt) return []
+    return entry.models
+  }
+
+  /**
+   * Return all discovered models across all cached providers.
+   * Deduplicates by model ID, merging provider arrays.
+   */
+  getAllCachedModels(): ModelInfo[] {
+    const merged = new Map<string, ModelInfo>()
+    for (const entry of this.cache.values()) {
+      if (Date.now() > entry.expiresAt) continue
+      for (const m of entry.models) {
+        const existing = merged.get(m.id)
+        if (existing) {
+          const providerSet = new Set([...existing.providers, ...m.providers])
+          existing.providers = [...providerSet]
+        } else {
+          merged.set(m.id, { ...m, providers: [...m.providers] })
+        }
+      }
+    }
+    return [...merged.values()]
+  }
+
+  /**
+   * Invalidate cache for a specific provider (e.g. on credential add/remove).
+   */
+  invalidate(providerId: string): void {
+    this.cache.delete(providerId)
+  }
+
+  /**
+   * Invalidate all cached models.
+   */
+  invalidateAll(): void {
+    this.cache.clear()
+  }
+}

--- a/packages/control-plane/src/observability/__tests__/model-providers.test.ts
+++ b/packages/control-plane/src/observability/__tests__/model-providers.test.ts
@@ -1,33 +1,75 @@
 import { describe, expect, it } from "vitest"
 
-import { MODEL_CATALOGUE, modelsForProvider, providersForModel } from "../model-providers.js"
+import { ModelDiscoveryService } from "../../auth/model-discovery.js"
+import { modelDiscoveryService, modelsForProvider, providersForModel } from "../model-providers.js"
 
-describe("model-providers", () => {
+// ---------------------------------------------------------------------------
+// Seed the shared discovery service with models so lookup helpers work
+// ---------------------------------------------------------------------------
+
+function seedCache(svc: ModelDiscoveryService): void {
+  // Directly populate cache by calling discoverModels-like internals.
+  // We use the public API: populate via cache entries.
+  const providers: Record<string, { id: string; label: string; providers: string[] }[]> = {
+    anthropic: [
+      { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", providers: ["anthropic"] },
+      { id: "claude-opus-4-6", label: "Claude Opus 4.6", providers: ["anthropic"] },
+      { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", providers: ["anthropic"] },
+    ],
+    "google-antigravity": [
+      { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", providers: ["google-antigravity"] },
+      { id: "claude-opus-4-6", label: "Claude Opus 4.6", providers: ["google-antigravity"] },
+      { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", providers: ["google-antigravity"] },
+      { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro", providers: ["google-antigravity"] },
+      { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash", providers: ["google-antigravity"] },
+      { id: "gemini-2.0-flash", label: "Gemini 2.0 Flash", providers: ["google-antigravity"] },
+    ],
+    openai: [
+      { id: "gpt-4o", label: "GPT-4o", providers: ["openai"] },
+      { id: "gpt-4o-mini", label: "GPT-4o Mini", providers: ["openai"] },
+    ],
+    "openai-codex": [
+      { id: "gpt-4o", label: "GPT-4o", providers: ["openai-codex"] },
+      { id: "gpt-4o-mini", label: "GPT-4o Mini", providers: ["openai-codex"] },
+    ],
+    "google-ai-studio": [
+      { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro", providers: ["google-ai-studio"] },
+      { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash", providers: ["google-ai-studio"] },
+      { id: "gemini-2.0-flash", label: "Gemini 2.0 Flash", providers: ["google-ai-studio"] },
+    ],
+  }
+
+  // Use internal cache access for test seeding
+  for (const [providerId, models] of Object.entries(providers)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    ;(svc as any).cache.set(providerId, {
+      models,
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    })
+  }
+}
+
+// Seed the shared singleton for these tests
+seedCache(modelDiscoveryService)
+
+describe("model-providers (dynamic)", () => {
   describe("providersForModel", () => {
     it("returns anthropic + google-antigravity for claude models", () => {
-      expect(providersForModel("claude-sonnet-4-6")).toEqual(["anthropic", "google-antigravity"])
-      expect(providersForModel("claude-opus-4-6")).toEqual(["anthropic", "google-antigravity"])
-      expect(providersForModel("claude-haiku-4-5")).toEqual(["anthropic", "google-antigravity"])
+      const p = providersForModel("claude-sonnet-4-6")
+      expect(p).toContain("anthropic")
+      expect(p).toContain("google-antigravity")
     })
 
     it("returns openai + openai-codex for gpt models", () => {
-      expect(providersForModel("gpt-4o")).toEqual(["openai", "openai-codex"])
-      expect(providersForModel("gpt-4o-mini")).toEqual(["openai", "openai-codex"])
+      const p = providersForModel("gpt-4o")
+      expect(p).toContain("openai")
+      expect(p).toContain("openai-codex")
     })
 
     it("returns google-antigravity + google-ai-studio for gemini models", () => {
-      expect(providersForModel("gemini-2.5-pro")).toEqual([
-        "google-antigravity",
-        "google-ai-studio",
-      ])
-      expect(providersForModel("gemini-2.5-flash")).toEqual([
-        "google-antigravity",
-        "google-ai-studio",
-      ])
-      expect(providersForModel("gemini-2.0-flash")).toEqual([
-        "google-antigravity",
-        "google-ai-studio",
-      ])
+      const p = providersForModel("gemini-2.5-pro")
+      expect(p).toContain("google-antigravity")
+      expect(p).toContain("google-ai-studio")
     })
 
     it("returns undefined for unknown models", () => {
@@ -43,7 +85,6 @@ describe("model-providers", () => {
       expect(ids).toContain("claude-opus-4-6")
       expect(ids).toContain("claude-haiku-4-5")
       expect(ids).not.toContain("gpt-4o")
-      expect(ids).not.toContain("gemini-2.5-pro")
     })
 
     it("returns claude + gemini models for google-antigravity provider", () => {
@@ -51,8 +92,6 @@ describe("model-providers", () => {
       const ids = models.map((m) => m.id)
       expect(ids).toContain("claude-sonnet-4-6")
       expect(ids).toContain("gemini-2.5-pro")
-      expect(ids).toContain("gemini-2.5-flash")
-      expect(ids).toContain("gemini-2.0-flash")
       expect(ids).not.toContain("gpt-4o")
     })
 
@@ -71,7 +110,6 @@ describe("model-providers", () => {
       expect(ids).toContain("gpt-4o")
       expect(ids).toContain("gpt-4o-mini")
       expect(ids).not.toContain("claude-sonnet-4-6")
-      expect(ids).not.toContain("gemini-2.5-pro")
     })
 
     it("returns empty array for providers with no models", () => {
@@ -80,9 +118,10 @@ describe("model-providers", () => {
     })
   })
 
-  describe("MODEL_CATALOGUE", () => {
+  describe("getAllCachedModels", () => {
     it("every entry has id, label, and non-empty providers", () => {
-      for (const m of MODEL_CATALOGUE) {
+      const all = modelDiscoveryService.getAllCachedModels()
+      for (const m of all) {
         expect(m.id).toBeTruthy()
         expect(m.label).toBeTruthy()
         expect(m.providers.length).toBeGreaterThan(0)
@@ -90,7 +129,7 @@ describe("model-providers", () => {
     })
 
     it("includes gemini models", () => {
-      const ids = MODEL_CATALOGUE.map((m) => m.id)
+      const ids = modelDiscoveryService.getAllCachedModels().map((m) => m.id)
       expect(ids).toContain("gemini-2.5-pro")
       expect(ids).toContain("gemini-2.5-flash")
       expect(ids).toContain("gemini-2.0-flash")

--- a/packages/control-plane/src/observability/index.ts
+++ b/packages/control-plane/src/observability/index.ts
@@ -12,7 +12,7 @@ export { ExecutionRegistry } from "./execution-registry.js"
 export type { ModelPricing } from "./model-pricing.js"
 export { DEFAULT_PRICING, estimateCost, MODEL_PRICING } from "./model-pricing.js"
 export type { ModelInfo } from "./model-providers.js"
-export { MODEL_CATALOGUE, modelsForProvider, providersForModel } from "./model-providers.js"
+export { modelDiscoveryService, modelsForProvider, providersForModel } from "./model-providers.js"
 export type {
   AgentEventInput,
   AgentEventRow,

--- a/packages/control-plane/src/observability/model-providers.ts
+++ b/packages/control-plane/src/observability/model-providers.ts
@@ -1,11 +1,12 @@
 /**
  * Model-to-provider mapping.
  *
- * Maps LLM model IDs to the provider credential IDs that can serve them.
- * Used by the credential resolver in agent-execute to select the correct
- * bound credential for a given model, and by the dashboard to display
- * which models each connected provider enables.
+ * Previously a static catalogue; now delegates to ModelDiscoveryService
+ * for dynamically discovered models. The lookup helpers remain for
+ * backward compatibility with the credential resolver and pricing table.
  */
+
+import { ModelDiscoveryService } from "../auth/model-discovery.js"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -19,62 +20,14 @@ export interface ModelInfo {
 }
 
 // ---------------------------------------------------------------------------
-// Model catalogue
+// Shared discovery service singleton
 // ---------------------------------------------------------------------------
 
-/**
- * All known models with their compatible provider credential IDs.
- *
- * Keep in sync with {@link MODEL_PRICING} and the dashboard AVAILABLE_MODELS.
- */
-export const MODEL_CATALOGUE: ModelInfo[] = [
-  {
-    id: "claude-sonnet-4-6",
-    label: "Claude Sonnet 4.6",
-    providers: ["anthropic", "google-antigravity"],
-  },
-  {
-    id: "claude-opus-4-6",
-    label: "Claude Opus 4.6",
-    providers: ["anthropic", "google-antigravity"],
-  },
-  {
-    id: "claude-haiku-4-5",
-    label: "Claude Haiku 4.5",
-    providers: ["anthropic", "google-antigravity"],
-  },
-  {
-    id: "gpt-4o",
-    label: "GPT-4o",
-    providers: ["openai", "openai-codex"],
-  },
-  {
-    id: "gpt-4o-mini",
-    label: "GPT-4o Mini",
-    providers: ["openai", "openai-codex"],
-  },
-  {
-    id: "gemini-2.5-pro",
-    label: "Gemini 2.5 Pro",
-    providers: ["google-antigravity", "google-ai-studio"],
-  },
-  {
-    id: "gemini-2.5-flash",
-    label: "Gemini 2.5 Flash",
-    providers: ["google-antigravity", "google-ai-studio"],
-  },
-  {
-    id: "gemini-2.0-flash",
-    label: "Gemini 2.0 Flash",
-    providers: ["google-antigravity", "google-ai-studio"],
-  },
-]
+export const modelDiscoveryService = new ModelDiscoveryService()
 
 // ---------------------------------------------------------------------------
-// Lookup helpers
+// Lookup helpers (read from discovery cache)
 // ---------------------------------------------------------------------------
-
-const modelMap = new Map(MODEL_CATALOGUE.map((m) => [m.id, m]))
 
 /**
  * Return the provider credential IDs compatible with the given model.
@@ -82,12 +35,14 @@ const modelMap = new Map(MODEL_CATALOGUE.map((m) => [m.id, m]))
  * any llm_provider credential).
  */
 export function providersForModel(modelId: string): string[] | undefined {
-  return modelMap.get(modelId)?.providers
+  const all = modelDiscoveryService.getAllCachedModels()
+  const found = all.find((m) => m.id === modelId)
+  return found?.providers
 }
 
 /**
  * Return the models available through a given provider credential ID.
  */
 export function modelsForProvider(providerId: string): ModelInfo[] {
-  return MODEL_CATALOGUE.filter((m) => m.providers.includes(providerId))
+  return modelDiscoveryService.getCachedModels(providerId)
 }

--- a/packages/control-plane/src/routes/models.ts
+++ b/packages/control-plane/src/routes/models.ts
@@ -2,47 +2,49 @@
  * Model Catalogue Routes
  *
  * Endpoints for listing available LLM models:
- *   GET /models — return the full model catalogue
- *   GET /models?credentialAware=true — filter to models the user has credentials for
+ *   GET  /models — return discovered models (optionally credential-filtered)
+ *   POST /models/refresh — force re-discovery from provider APIs
  */
 
 import type { FastifyInstance, FastifyRequest } from "fastify"
 
 import type { CredentialService } from "../auth/credential-service.js"
+import type { ModelDiscoveryService } from "../auth/model-discovery.js"
 import type { SessionService } from "../auth/session-service.js"
 import { createRequireAuth, type PreHandler } from "../middleware/auth.js"
 import type { AuthenticatedRequest } from "../middleware/types.js"
-import { MODEL_CATALOGUE } from "../observability/model-providers.js"
+import { modelDiscoveryService } from "../observability/model-providers.js"
 
 interface ModelRouteDeps {
   credentialService?: CredentialService
   sessionService?: SessionService
+  discoveryService?: ModelDiscoveryService
 }
 
 export function modelRoutes(deps?: ModelRouteDeps) {
+  const discovery = deps?.discoveryService ?? modelDiscoveryService
+
   return function register(app: FastifyInstance): void {
     /**
-     * GET /models — list all known models with their compatible providers.
+     * GET /models — list all discovered models with their compatible providers.
      *
-     * When ?credentialAware=true and the user is authenticated, filters the
-     * catalogue to models where at least one provider matches a user credential.
-     * Without the param or when unauthenticated: returns the full catalogue.
+     * When ?credentialAware=true and the user is authenticated, filters to
+     * models where at least one provider matches a user credential.
+     * Without the param or when unauthenticated: returns all cached models.
      */
     app.get(
       "/models",
       async (request: FastifyRequest<{ Querystring: { credentialAware?: string } }>) => {
+        const allModels = discovery.getAllCachedModels()
         const wantFiltering = request.query.credentialAware === "true"
 
         if (wantFiltering && deps?.credentialService && deps?.sessionService) {
-          // Try to authenticate — build a one-off preHandler
           const requireAuth: PreHandler = createRequireAuth({
             config: { apiKeys: [], requireAuth: true },
             sessionService: deps.sessionService,
           })
 
           try {
-            // Attempt auth — if it fails the preHandler sends a reply, but
-            // since we catch, we fall through to return the full catalogue.
             const fakeReply = {
               sent: false,
               code(status: number) {
@@ -64,7 +66,7 @@ export function modelRoutes(deps?: ModelRouteDeps) {
                 credentialClass: "llm_provider",
               })
               const userProviders = new Set(credentials.map((c) => c.provider))
-              const filtered = MODEL_CATALOGUE.filter((m) =>
+              const filtered = allModels.filter((m) =>
                 m.providers.some((p) => userProviders.has(p)),
               )
               return { models: filtered }
@@ -74,8 +76,73 @@ export function modelRoutes(deps?: ModelRouteDeps) {
           }
         }
 
-        return { models: MODEL_CATALOGUE }
+        return { models: allModels }
       },
     )
+
+    /**
+     * POST /models/refresh — force re-discovery of models from provider APIs.
+     *
+     * Requires authentication. Iterates over the user's llm_provider credentials,
+     * calls the provider's models API, and refreshes the cache.
+     */
+    app.post("/models/refresh", async (request: FastifyRequest, reply) => {
+      if (!deps?.credentialService || !deps?.sessionService) {
+        reply
+          .status(501)
+          .send({ error: "not_configured", message: "Credential service not available" })
+        return
+      }
+
+      const requireAuth: PreHandler = createRequireAuth({
+        config: { apiKeys: [], requireAuth: true },
+        sessionService: deps.sessionService,
+      })
+
+      const fakeReply = {
+        sent: false,
+        code(status: number) {
+          this.sent = true
+          this._status = status
+          return this
+        },
+        _status: 200,
+        send() {
+          this.sent = true
+          return this
+        },
+      }
+      await requireAuth(request, fakeReply as unknown as import("fastify").FastifyReply)
+
+      if (fakeReply.sent) {
+        reply.status(401).send({ error: "unauthorized" })
+        return
+      }
+
+      const principal = (request as AuthenticatedRequest).principal
+      const credentials = await deps.credentialService.listCredentials(principal.userId, {
+        credentialClass: "llm_provider",
+      })
+
+      let discovered = 0
+      for (const cred of credentials) {
+        // We cannot decrypt tokens here — the discovery service accepts
+        // the token directly. For refresh we use getAccessToken which
+        // decrypts and refreshes as needed.
+        const tokenResult = await deps.credentialService.getAccessToken(
+          principal.userId,
+          cred.provider,
+        )
+        if (!tokenResult) continue
+
+        const models = await discovery.discoverModels(cred.provider, {
+          accessToken: tokenResult.token,
+          apiKey: cred.credentialType === "api_key" ? tokenResult.token : undefined,
+        })
+        discovered += models.length
+      }
+
+      return { ok: true, modelsDiscovered: discovered }
+    })
   }
 }

--- a/packages/dashboard/src/__tests__/deploy-agent-modal.test.ts
+++ b/packages/dashboard/src/__tests__/deploy-agent-modal.test.ts
@@ -3,50 +3,11 @@ import path from "node:path"
 
 import { describe, expect, it } from "vitest"
 
-import { AVAILABLE_MODELS } from "@/components/agents/deploy-agent-modal"
-
 const SRC_DIR = path.resolve(__dirname, "..")
 
 function readSrc(relative: string): string {
   return readFileSync(path.join(SRC_DIR, relative), "utf-8")
 }
-
-// ---------------------------------------------------------------------------
-// AVAILABLE_MODELS constant
-// ---------------------------------------------------------------------------
-
-describe("AVAILABLE_MODELS", () => {
-  it("contains at least one model", () => {
-    expect(AVAILABLE_MODELS.length).toBeGreaterThan(0)
-  })
-
-  it("every entry has id, label, and provider", () => {
-    for (const m of AVAILABLE_MODELS) {
-      expect(typeof m.id).toBe("string")
-      expect(m.id.length).toBeGreaterThan(0)
-      expect(typeof m.label).toBe("string")
-      expect(m.label.length).toBeGreaterThan(0)
-      expect(typeof m.provider).toBe("string")
-      expect(m.provider.length).toBeGreaterThan(0)
-    }
-  })
-
-  it("has unique model ids", () => {
-    const ids = AVAILABLE_MODELS.map((m) => m.id)
-    expect(new Set(ids).size).toBe(ids.length)
-  })
-
-  it("includes the default fallback model (claude-sonnet-4-6)", () => {
-    const ids = AVAILABLE_MODELS.map((m) => m.id)
-    expect(ids).toContain("claude-sonnet-4-6")
-  })
-
-  it("includes anthropic and openai providers", () => {
-    const providers = new Set(AVAILABLE_MODELS.map((m) => m.provider))
-    expect(providers.has("anthropic")).toBe(true)
-    expect(providers.has("openai")).toBe(true)
-  })
-})
 
 // ---------------------------------------------------------------------------
 // model_config construction (mirrors deploy-agent-modal handleSubmit logic)
@@ -106,9 +67,14 @@ describe("Deploy modal structure", () => {
     expect(content).toContain('data-testid="deploy-model-select"')
   })
 
-  it("exports AVAILABLE_MODELS list", () => {
-    expect(content).toContain("AVAILABLE_MODELS")
-    expect(content).toContain("claude-sonnet-4-6")
+  it("uses useModels hook for dynamic model fetching", () => {
+    expect(content).toContain("useModels")
+    expect(content).toContain("models")
+  })
+
+  it("shows empty state when no models available", () => {
+    expect(content).toContain("No models available")
+    expect(content).toContain("Connect a provider")
   })
 
   it("includes model in model_config when building request body", () => {

--- a/packages/dashboard/src/__tests__/model-config.test.ts
+++ b/packages/dashboard/src/__tests__/model-config.test.ts
@@ -3,7 +3,6 @@ import path from "node:path"
 
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { AVAILABLE_MODELS } from "@/components/agents/deploy-agent-modal"
 import { updateAgent } from "@/lib/api-client"
 
 // ---------------------------------------------------------------------------
@@ -138,9 +137,14 @@ describe("Deploy modal model selector", () => {
     expect(content).toContain('data-testid="deploy-model-select"')
   })
 
-  it("exports AVAILABLE_MODELS list", () => {
-    expect(content).toContain("AVAILABLE_MODELS")
-    expect(content).toContain("claude-sonnet-4-6")
+  it("uses useModels hook for dynamic model list", () => {
+    expect(content).toContain("useModels")
+    expect(content).toContain("models")
+  })
+
+  it("shows empty state when no models available", () => {
+    expect(content).toContain("No models available")
+    expect(content).toContain("Connect a provider")
   })
 
   it("includes model in model_config when building request body", () => {
@@ -157,37 +161,6 @@ describe("Deploy modal model selector", () => {
 
   it("requires model for form submission", () => {
     expect(content).toContain("!model.trim()")
-  })
-})
-
-// ---------------------------------------------------------------------------
-// AVAILABLE_MODELS constant validation
-// ---------------------------------------------------------------------------
-
-describe("AVAILABLE_MODELS", () => {
-  it("contains at least one model", () => {
-    expect(AVAILABLE_MODELS.length).toBeGreaterThan(0)
-  })
-
-  it("every entry has id, label, and provider", () => {
-    for (const m of AVAILABLE_MODELS) {
-      expect(typeof m.id).toBe("string")
-      expect(m.id.length).toBeGreaterThan(0)
-      expect(typeof m.label).toBe("string")
-      expect(m.label.length).toBeGreaterThan(0)
-      expect(typeof m.provider).toBe("string")
-      expect(m.provider.length).toBeGreaterThan(0)
-    }
-  })
-
-  it("has unique model ids", () => {
-    const ids = AVAILABLE_MODELS.map((m) => m.id)
-    expect(new Set(ids).size).toBe(ids.length)
-  })
-
-  it("includes the default fallback model (claude-sonnet-4-6)", () => {
-    const ids = AVAILABLE_MODELS.map((m) => m.id)
-    expect(ids).toContain("claude-sonnet-4-6")
   })
 })
 
@@ -353,9 +326,8 @@ describe("useModels hook", () => {
     expect(content).toContain("listModels")
   })
 
-  it("provides fallback models", () => {
-    expect(content).toContain("FALLBACK_MODELS")
-    expect(content).toContain("claude-sonnet-4-6")
+  it("starts with empty model list", () => {
+    expect(content).toContain("useState<ModelInfo[]>([])")
   })
 
   it("returns models and isLoading", () => {

--- a/packages/dashboard/src/components/agents/credential-binding.tsx
+++ b/packages/dashboard/src/components/agents/credential-binding.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { useAuth } from "@/components/auth-provider"
 import { useToast } from "@/components/layout/toast"
+import { useModels } from "@/hooks/use-models"
 import {
   type AgentCredentialBinding,
   bindAgentCredential,
@@ -12,8 +13,6 @@ import {
   listCredentials,
   unbindAgentCredential,
 } from "@/lib/api-client"
-
-import { AVAILABLE_MODELS } from "./deploy-agent-modal"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -323,17 +322,6 @@ function BindingRow({ binding, onUnbind }: BindingRowProps): React.JSX.Element {
 // Main export
 // ---------------------------------------------------------------------------
 
-/** Map a model ID → set of compatible provider credential IDs. */
-const MODEL_PROVIDER_MAP: Record<string, string[]> = {}
-for (const m of AVAILABLE_MODELS) {
-  // Each model's `provider` field is the primary provider. Also allow
-  // the OAuth variants (e.g. google-antigravity for anthropic models).
-  const providers: string[] = [m.provider]
-  if (m.provider === "anthropic") providers.push("google-antigravity")
-  if (m.provider === "openai") providers.push("openai-codex")
-  MODEL_PROVIDER_MAP[m.id] = providers
-}
-
 export interface CredentialBindingPanelProps {
   agentId: string
   /** The model ID from agent.model_config.model (used for provider match warnings). */
@@ -346,6 +334,7 @@ export function CredentialBindingPanel({
 }: CredentialBindingPanelProps): React.JSX.Element {
   const { user } = useAuth()
   const { addToast } = useToast()
+  const { models: availableModels } = useModels()
   const isAdmin = user?.role === "admin"
 
   const [bindings, setBindings] = useState<AgentCredentialBinding[]>([])
@@ -358,6 +347,15 @@ export function CredentialBindingPanel({
   const [bindingInProgress, setBindingInProgress] = useState(false)
   const [unbindTarget, setUnbindTarget] = useState<AgentCredentialBinding | null>(null)
   const [unbindingInProgress, setUnbindingInProgress] = useState(false)
+
+  // Build model → providers map from dynamic model list
+  const modelProviderMap = useMemo(() => {
+    const map: Record<string, string[]> = {}
+    for (const m of availableModels) {
+      map[m.id] = m.providers
+    }
+    return map
+  }, [availableModels])
 
   const fetchBindings = useCallback(async () => {
     setLoadingBindings(true)
@@ -427,14 +425,14 @@ export function CredentialBindingPanel({
   // Check if any bound LLM credential matches the agent's selected model provider
   const providerMismatch = useMemo(() => {
     if (!modelId) return null
-    const compatibleProviders = MODEL_PROVIDER_MAP[modelId]
+    const compatibleProviders = modelProviderMap[modelId]
     if (!compatibleProviders) return null
     const llmBindings = bindings.filter((b) => b.credentialClass === "llm_provider")
     if (llmBindings.length === 0) return { missing: true, providers: compatibleProviders }
     const hasMatch = llmBindings.some((b) => compatibleProviders.includes(b.provider))
     if (hasMatch) return null
     return { missing: false, providers: compatibleProviders }
-  }, [modelId, bindings])
+  }, [modelId, bindings, modelProviderMap])
 
   return (
     <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-primary/10 dark:bg-primary/5">

--- a/packages/dashboard/src/components/agents/deploy-agent-modal.tsx
+++ b/packages/dashboard/src/components/agents/deploy-agent-modal.tsx
@@ -12,24 +12,6 @@ import {
   listCredentials,
 } from "@/lib/api-client"
 
-// ---------------------------------------------------------------------------
-// Available models — keep in sync with control-plane MODEL_CATALOGUE.
-// Retained as a static export for backward compatibility (credential-binding,
-// tests). Components should prefer the useModels() hook which fetches from
-// the GET /models API endpoint.
-// ---------------------------------------------------------------------------
-
-export const AVAILABLE_MODELS = [
-  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", provider: "anthropic" },
-  { id: "claude-opus-4-6", label: "Claude Opus 4.6", provider: "anthropic" },
-  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", provider: "anthropic" },
-  { id: "gpt-4o", label: "GPT-4o", provider: "openai" },
-  { id: "gpt-4o-mini", label: "GPT-4o Mini", provider: "openai" },
-  { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro", provider: "google-ai-studio" },
-  { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash", provider: "google-ai-studio" },
-  { id: "gemini-2.0-flash", label: "Gemini 2.0 Flash", provider: "google-ai-studio" },
-] as const
-
 interface DeployAgentModalProps {
   open: boolean
   onClose: () => void

--- a/packages/dashboard/src/hooks/use-models.ts
+++ b/packages/dashboard/src/hooks/use-models.ts
@@ -5,47 +5,9 @@ import { useEffect, useState } from "react"
 import { listModels, type ModelInfo } from "@/lib/api-client"
 
 /**
- * Hardcoded fallback in case the API is unreachable.
- * Keep in sync with control-plane MODEL_CATALOGUE.
- */
-const FALLBACK_MODELS: ModelInfo[] = [
-  {
-    id: "claude-sonnet-4-6",
-    label: "Claude Sonnet 4.6",
-    providers: ["anthropic", "google-antigravity"],
-  },
-  {
-    id: "claude-opus-4-6",
-    label: "Claude Opus 4.6",
-    providers: ["anthropic", "google-antigravity"],
-  },
-  {
-    id: "claude-haiku-4-5",
-    label: "Claude Haiku 4.5",
-    providers: ["anthropic", "google-antigravity"],
-  },
-  { id: "gpt-4o", label: "GPT-4o", providers: ["openai", "openai-codex"] },
-  { id: "gpt-4o-mini", label: "GPT-4o Mini", providers: ["openai", "openai-codex"] },
-  {
-    id: "gemini-2.5-pro",
-    label: "Gemini 2.5 Pro",
-    providers: ["google-antigravity", "google-ai-studio"],
-  },
-  {
-    id: "gemini-2.5-flash",
-    label: "Gemini 2.5 Flash",
-    providers: ["google-antigravity", "google-ai-studio"],
-  },
-  {
-    id: "gemini-2.0-flash",
-    label: "Gemini 2.0 Flash",
-    providers: ["google-antigravity", "google-ai-studio"],
-  },
-]
-
-/**
  * Fetch the model catalogue from the API.
- * Returns the fallback list immediately while loading, then swaps in the API result.
+ * Starts with an empty list and populates from the API response.
+ * Returns empty array when no providers are connected.
  *
  * @param credentialAware — when true, requests credential-filtered models
  */
@@ -53,7 +15,7 @@ export function useModels(opts?: { credentialAware?: boolean }): {
   models: ModelInfo[]
   isLoading: boolean
 } {
-  const [models, setModels] = useState<ModelInfo[]>(FALLBACK_MODELS)
+  const [models, setModels] = useState<ModelInfo[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const credentialAware = opts?.credentialAware ?? false
 
@@ -61,12 +23,12 @@ export function useModels(opts?: { credentialAware?: boolean }): {
     let cancelled = false
     listModels({ credentialAware })
       .then((res) => {
-        if (!cancelled && res.models.length > 0) {
+        if (!cancelled) {
           setModels(res.models)
         }
       })
       .catch(() => {
-        // Keep fallback models on failure
+        // Keep empty on failure
       })
       .finally(() => {
         if (!cancelled) setIsLoading(false)


### PR DESCRIPTION
Adds ModelDiscoveryService that queries provider APIs for available models with 1h cached TTL. Removes all hardcoded model IDs. Dashboard fetches models dynamically. Added secrets.yaml to gitignore — operators create their own from .env.example.

Closes #665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced dynamic model discovery that fetches available models directly from connected providers instead of a static catalog.
  * Added ability to manually refresh available models after connecting new provider credentials.

* **Changes**
  * Model availability now reflects real-time provider data and connected credentials rather than a fixed list.
  * UI updated to dynamically load and display models; displays "No models available" until providers are connected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->