### PR TITLE
fix(#667): allow OAuth providers with empty client secret and unify registration

### DIFF
--- a/packages/control-plane/src/__tests__/auth-connect-callback.test.ts
+++ b/packages/control-plane/src/__tests__/auth-connect-callback.test.ts
@@ -30,6 +30,32 @@ const mockDecodeState = vi.hoisted(() =>
   }),
 )
 
+const mockGetCodePasteProvider = vi.hoisted(() =>
+  vi.fn().mockImplementation((provider: string) => {
+    if (provider === "google-antigravity") {
+      return {
+        id: "google-antigravity",
+        clientId: "test-client-id",
+        clientSecret: "test-client-secret",
+        authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+        tokenUrl: "https://oauth2.googleapis.com/token",
+        redirectUri: "http://localhost:51121/oauth-callback",
+        scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+        usePkce: true,
+      }
+    }
+    return undefined
+  }),
+)
+
+vi.mock("../auth/oauth-providers.js", async (importOriginal) => {
+  const original = await importOriginal<Record<string, unknown>>()
+  return {
+    ...original,
+    getCodePasteProvider: mockGetCodePasteProvider,
+  }
+})
+
 vi.mock("../auth/antigravity-project.js", () => ({
   discoverAntigravityProject: mockDiscoverProject,
 }))

--- a/packages/control-plane/src/__tests__/config.test.ts
+++ b/packages/control-plane/src/__tests__/config.test.ts
@@ -230,6 +230,31 @@ describe("loadConfig", () => {
       expect(config.auth!.slackUser!.clientSecret).toBe("slack-client-secret")
     })
 
+    it("registers provider when CLIENT_SECRET is empty string", () => {
+      const config = loadConfig({
+        DATABASE_URL: "postgres://localhost/test",
+        CREDENTIAL_MASTER_KEY: "test-master-key",
+        OAUTH_ANTHROPIC_CLIENT_ID: "anthropic-client-id",
+        OAUTH_ANTHROPIC_CLIENT_SECRET: "",
+      })
+      expect(config.auth).toBeDefined()
+      expect(config.auth!.anthropic).toBeDefined()
+      expect(config.auth!.anthropic!.clientId).toBe("anthropic-client-id")
+      expect(config.auth!.anthropic!.clientSecret).toBe("")
+    })
+
+    it("registers provider when CLIENT_SECRET env var is absent", () => {
+      const config = loadConfig({
+        DATABASE_URL: "postgres://localhost/test",
+        CREDENTIAL_MASTER_KEY: "test-master-key",
+        OAUTH_OPENAI_CODEX_CLIENT_ID: "codex-client-id",
+      })
+      expect(config.auth).toBeDefined()
+      expect(config.auth!.openaiCodex).toBeDefined()
+      expect(config.auth!.openaiCodex!.clientId).toBe("codex-client-id")
+      expect(config.auth!.openaiCodex!.clientSecret).toBe("")
+    })
+
     it("leaves user service providers undefined when env vars are missing", () => {
       const config = loadConfig({
         DATABASE_URL: "postgres://localhost/test",

--- a/packages/control-plane/src/config.ts
+++ b/packages/control-plane/src/config.ts
@@ -166,11 +166,10 @@ function parseOAuthProvider(
   prefix: string,
 ): OAuthProviderConfig | undefined {
   const clientId = env[`OAUTH_${prefix}_CLIENT_ID`]
-  const clientSecret = env[`OAUTH_${prefix}_CLIENT_SECRET`]
-  if (!clientId || !clientSecret) return undefined
+  if (!clientId) return undefined
   return {
     clientId,
-    clientSecret,
+    clientSecret: env[`OAUTH_${prefix}_CLIENT_SECRET`] ?? "",
     authUrl: env[`OAUTH_${prefix}_AUTH_URL`],
     tokenUrl: env[`OAUTH_${prefix}_TOKEN_URL`],
   }

--- a/packages/control-plane/src/routes/auth.ts
+++ b/packages/control-plane/src/routes/auth.ts
@@ -611,11 +611,19 @@ function getConnectProviderConfig(
   provider: string,
   authConfig: AuthOAuthConfig,
 ): OAuthProviderConfig | undefined {
+  // LLM providers: use code-paste registry as single source of truth
+  const codePaste = getCodePasteProvider(provider)
+  if (codePaste) {
+    return {
+      clientId: codePaste.clientId,
+      clientSecret: codePaste.clientSecret,
+      authUrl: codePaste.authUrl,
+      tokenUrl: codePaste.tokenUrl,
+    }
+  }
+
+  // User service providers: use authConfig (redirect-based OAuth)
   switch (provider) {
-    case "google-antigravity":
-      return authConfig.googleAntigravity
-    case "openai-codex":
-      return authConfig.openaiCodex
     case "google-workspace":
       return authConfig.googleWorkspace
     case "github-user":


### PR DESCRIPTION
## What's broken
PKCE-only providers (Anthropic, OpenAI Codex) have empty client secrets. parseOAuthProvider rejected them. Also unified getConnectProviderConfig to use code-paste registry as single source of truth.

## Verification
1. Set OAUTH_ANTHROPIC_CLIENT_ID with no CLIENT_SECRET → provider registers
2. Connect flow initiates successfully

Closes #667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth providers now support optional client secret configuration, allowing more flexible provider setup.
  * Code-paste provider configuration now takes precedence in the authentication flow.

* **Tests**
  * Added test coverage for OAuth provider configuration with missing or empty client secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->