### PR TITLE
fix(#674): port Antigravity provider integration from OpenClaw reference

### DIFF
--- a/packages/control-plane/src/__tests__/http-llm.test.ts
+++ b/packages/control-plane/src/__tests__/http-llm.test.ts
@@ -1355,9 +1355,12 @@ describe("HttpLlmBackend — credential provider routing", () => {
       baseURL: string
       authToken: string | null
     }
-    // Default Antigravity proxy — no direct Vertex AI access
-    expect(client.baseURL).toBe("https://daily-cloudcode-pa.sandbox.googleapis.com")
-    expect(client.authToken).toBe("gcp-oauth-token")
+    // Default Antigravity routing: production endpoint first, then sandbox fallback
+    expect(client.baseURL).toBe("https://cloudcode-pa.googleapis.com")
+    // Token wrapping: JSON.stringify({ token, projectId }) for Antigravity
+    expect(client.authToken).toBe(
+      JSON.stringify({ token: "gcp-oauth-token", projectId: "my-gcp-project-123" }),
+    )
 
     await handle.cancel("test")
   })
@@ -1472,8 +1475,9 @@ describe("HttpLlmBackend — credential provider routing", () => {
       baseURL: string
       authToken: string | null
     }
-    // Without accountId, still uses the default Antigravity proxy
-    expect(client.baseURL).toBe("https://daily-cloudcode-pa.sandbox.googleapis.com")
+    // Without accountId, still uses the default Antigravity production endpoint
+    expect(client.baseURL).toBe("https://cloudcode-pa.googleapis.com")
+    // No projectId available — token sent unwrapped
     expect(client.authToken).toBe("gcp-oauth-token")
 
     await handle.cancel("test")
@@ -1501,7 +1505,10 @@ describe("HttpLlmBackend — credential provider routing", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     const client = (handle as any).client as { baseURL: string; authToken: string | null }
     expect(client.baseURL).toBe("https://custom-proxy.example.com/v1")
-    expect(client.authToken).toBe("gcp-oauth-token")
+    // Token wrapping: JSON.stringify({ token, projectId }) for Antigravity
+    expect(client.authToken).toBe(
+      JSON.stringify({ token: "gcp-oauth-token", projectId: "my-project" }),
+    )
 
     await handle.cancel("test")
   })
@@ -1562,9 +1569,12 @@ describe("HttpLlmBackend — credential provider routing", () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     const client = (handle as any).client as { baseURL: string; authToken: string | null }
-    // All Antigravity routing goes through the proxy — no Vertex AI direct access
-    expect(client.baseURL).toBe("https://daily-cloudcode-pa.sandbox.googleapis.com")
-    expect(client.authToken).toBe("gcp-oauth-token")
+    // Default Antigravity routing: production endpoint first, then sandbox fallback
+    expect(client.baseURL).toBe("https://cloudcode-pa.googleapis.com")
+    // Token wrapping: JSON.stringify({ token, projectId }) for Antigravity
+    expect(client.authToken).toBe(
+      JSON.stringify({ token: "gcp-oauth-token", projectId: "my-project-42" }),
+    )
 
     await handle.cancel("test")
   })

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -36,6 +36,7 @@ import { MemorySyncService } from "./memory/sync-service.js"
 import { loadAuthConfig } from "./middleware/api-keys.js"
 import { AgentEventEmitter } from "./observability/event-emitter.js"
 import { ExecutionRegistry } from "./observability/execution-registry.js"
+import { modelDiscoveryService } from "./observability/model-providers.js"
 import { BrowserObservationService } from "./observation/service.js"
 import { agentChannelRoutes } from "./routes/agent-channels.js"
 import { agentCheckpointRoutes } from "./routes/agent-checkpoints.js"
@@ -423,9 +424,21 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
   // Register auth + credential management routes (if OAuth configured)
   if (config.auth && sessionService && credentialService) {
     await app.register(
-      authRoutes({ db, authConfig: config.auth, sessionService, credentialService }),
+      authRoutes({
+        db,
+        authConfig: config.auth,
+        sessionService,
+        credentialService,
+        modelDiscovery: modelDiscoveryService,
+      }),
     )
-    await app.register(credentialRoutes({ credentialService, sessionService }))
+    await app.register(
+      credentialRoutes({
+        credentialService,
+        sessionService,
+        modelDiscovery: modelDiscoveryService,
+      }),
+    )
   }
 
   // Register model catalogue route (public, optionally credential-aware)
@@ -469,6 +482,44 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
       await memoryScheduler.flushAllPending(workerUtils)
     },
   })
+
+  // Auto-discover models for all active LLM credentials on startup (fire-and-forget).
+  // Populates the model discovery cache so the model catalogue endpoint returns
+  // results immediately without waiting for a manual refresh.
+  if (credentialService) {
+    void (async () => {
+      try {
+        // Find distinct (provider, user) pairs for active LLM credentials
+        const activeCreds = await db
+          .selectFrom("provider_credential")
+          .select(["provider", "credential_type", "user_account_id"])
+          .where("credential_class", "=", "llm_provider")
+          .where("status", "=", "active")
+          .execute()
+
+        // Deduplicate by provider — only need one credential per provider for discovery
+        const seenProviders = new Set<string>()
+        for (const row of activeCreds) {
+          if (seenProviders.has(row.provider)) continue
+          seenProviders.add(row.provider)
+          try {
+            const result = await credentialService.getAccessToken(row.user_account_id, row.provider)
+            if (result) {
+              const cred =
+                row.credential_type === "api_key"
+                  ? { apiKey: result.token }
+                  : { accessToken: result.token }
+              await modelDiscoveryService.discoverModels(row.provider, cred)
+            }
+          } catch {
+            // Non-fatal: skip providers whose tokens are expired/missing
+          }
+        }
+      } catch {
+        // Non-fatal: startup discovery is best-effort
+      }
+    })()
+  }
 
   // Shut down SSE connections + observation service + browser services + backend registry on app close
   app.addHook("onClose", async () => {

--- a/packages/control-plane/src/auth/model-discovery.ts
+++ b/packages/control-plane/src/auth/model-discovery.ts
@@ -124,28 +124,41 @@ async function discoverGoogleAIStudio(cred: ProviderCredential): Promise<ModelIn
   })
 }
 
+/**
+ * Antigravity endpoint candidates for model discovery (prod first, then sandbox).
+ * Mirrors the endpoint fallback strategy from the OpenClaw reference.
+ */
+const ANTIGRAVITY_DISCOVERY_ENDPOINTS = [
+  "https://cloudcode-pa.googleapis.com",
+  "https://daily-cloudcode-pa.sandbox.googleapis.com",
+] as const
+
 async function discoverGoogleAntigravity(cred: ProviderCredential): Promise<ModelInfo[]> {
   const token = cred.accessToken
   if (!token) return []
 
-  const baseUrl =
-    process.env.ANTIGRAVITY_BASE_URL ?? "https://daily-cloudcode-pa.sandbox.googleapis.com"
+  const envUrl = process.env.ANTIGRAVITY_BASE_URL
+  const endpoints = envUrl ? [envUrl] : [...ANTIGRAVITY_DISCOVERY_ENDPOINTS]
 
-  // Try Anthropic-format models endpoint on the proxy
-  const data = (await fetchJson(`${baseUrl}/v1/models`, {
-    method: "GET",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "anthropic-version": "2023-06-01",
-    },
-  })) as { data?: { id: string }[] } | null
-  if (!data?.data) return []
+  // Try each endpoint with Anthropic-format models endpoint
+  for (const baseUrl of endpoints) {
+    const data = (await fetchJson(`${baseUrl}/v1/models`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "anthropic-version": "2023-06-01",
+      },
+    })) as { data?: { id: string }[] } | null
+    if (data?.data && data.data.length > 0) {
+      return data.data.map((m) => ({
+        id: m.id,
+        label: labelFromId(m.id),
+        providers: ["google-antigravity"],
+      }))
+    }
+  }
 
-  return data.data.map((m) => ({
-    id: m.id,
-    label: labelFromId(m.id),
-    providers: ["google-antigravity"],
-  }))
+  return []
 }
 
 async function discoverGitHubCopilot(cred: ProviderCredential): Promise<ModelInfo[]> {

--- a/packages/control-plane/src/backends/http-llm.ts
+++ b/packages/control-plane/src/backends/http-llm.ts
@@ -222,9 +222,11 @@ export class HttpLlmBackend implements ExecutionBackend {
         if (isAntigravity) {
           const routing = resolveAntigravityRouting(cred.baseUrl, cred.accountId)
           clientBaseUrl = routing.baseUrl
+          // Wrap token with projectId for Antigravity (OpenClaw pattern)
+          const wrappedToken = wrapAntigravityToken(cred.token, cred.accountId)
           // Proxy accepts standard Anthropic API format — no path rewriting needed
           client = new Anthropic({
-            authToken: cred.token,
+            authToken: wrappedToken,
             apiKey: null as unknown as string,
             baseURL: routing.baseUrl,
           })
@@ -385,13 +387,22 @@ function resolveOpenAICompatibleBaseUrl(provider: string): string | undefined {
 }
 
 /**
+ * Antigravity endpoint candidates, tried in order (prod first, then sandbox).
+ * Mirrors the endpoint fallback strategy from the OpenClaw reference.
+ */
+const ANTIGRAVITY_ENDPOINTS = [
+  "https://cloudcode-pa.googleapis.com",
+  "https://daily-cloudcode-pa.sandbox.googleapis.com",
+] as const
+
+/**
  * Resolve Antigravity routing config.
  *
  * Priority:
  *   1. Explicit `baseUrl` on the credential ref (set by provider config) — assumed
  *      to be a custom proxy that accepts standard Anthropic API format.
  *   2. `ANTIGRAVITY_BASE_URL` env var — same assumption.
- *   3. Default Antigravity proxy — accepts standard Anthropic `/v1/messages` format.
+ *   3. Endpoint fallback: try prod first, then sandbox.
  *      Consumer OAuth tokens cannot access Vertex AI directly (401/403).
  */
 interface AntigravityRouting {
@@ -408,11 +419,169 @@ function resolveAntigravityRouting(
   const envUrl = process.env.ANTIGRAVITY_BASE_URL
   if (envUrl) return { type: "proxy", baseUrl: envUrl }
 
-  // Default: use the Antigravity proxy (not direct Vertex AI)
+  // Default: production endpoint (falls back on 401/connection failure)
   return {
     type: "proxy",
-    baseUrl: "https://daily-cloudcode-pa.sandbox.googleapis.com",
+    baseUrl: ANTIGRAVITY_ENDPOINTS[0],
   }
+}
+
+/**
+ * Return the next Antigravity endpoint to try after a failure, or null if
+ * all candidates have been exhausted.
+ */
+function nextAntigravityEndpoint(currentBaseUrl: string): string | null {
+  const idx = ANTIGRAVITY_ENDPOINTS.indexOf(
+    currentBaseUrl as (typeof ANTIGRAVITY_ENDPOINTS)[number],
+  )
+  if (idx >= 0 && idx + 1 < ANTIGRAVITY_ENDPOINTS.length) {
+    return ANTIGRAVITY_ENDPOINTS[idx + 1] ?? null
+  }
+  return null
+}
+
+/**
+ * Wrap an OAuth access token for Antigravity.
+ *
+ * The Antigravity proxy expects the auth token to be a JSON blob containing
+ * both the OAuth bearer token and the GCP project ID (discovered during
+ * the OAuth flow and stored as `accountId` on the credential).
+ *
+ * Pattern from OpenClaw's `getApiKey()`:
+ *   JSON.stringify({ token: credentials.access, projectId: credentials.projectId })
+ */
+function wrapAntigravityToken(rawToken: string, projectId?: string | null): string {
+  if (!projectId) return rawToken
+  return JSON.stringify({ token: rawToken, projectId })
+}
+
+/**
+ * Strip HTML tags and collapse whitespace from an error message.
+ * LLM providers sometimes return raw HTML error pages; showing those in the
+ * chat UI is ugly and unhelpful.
+ */
+function sanitizeProviderErrorMessage(message: string): string {
+  if (!/<[a-z/][\s\S]*>/i.test(message)) return message
+  return message
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s{2,}/g, " ")
+    .trim()
+}
+
+/**
+ * Sanitize thinking blocks in conversation history for Antigravity Claude.
+ *
+ * Antigravity Claude rejects unsigned thinking blocks. This function:
+ * - Converts unsigned thinking blocks to plain text (preserving reasoning)
+ * - Maps Anthropic-style `signature` field to `thinkingSignature`
+ * - Validates signatures are base64-encoded
+ *
+ * Pattern from OpenClaw's `sanitizeAntigravityThinkingBlocks()`.
+ */
+const ANTIGRAVITY_SIG_RE = /^[A-Za-z0-9+/]+=*$/
+
+function sanitizeAntigravityConversationHistory<T extends { role: string; content: string }>(
+  history: T[],
+  isAntigravityClaude: boolean,
+): T[] {
+  if (!isAntigravityClaude) return history
+  return history.map((turn) => {
+    if (turn.role !== "assistant") return turn
+
+    // Try to parse content as JSON array of blocks (structured content)
+    let blocks: unknown[]
+    try {
+      blocks = JSON.parse(turn.content) as unknown[]
+      if (!Array.isArray(blocks)) return turn
+    } catch {
+      return turn // plain text content, no thinking blocks
+    }
+
+    let changed = false
+    const sanitized = blocks
+      .map((block) => {
+        if (!block || typeof block !== "object") return block
+        const rec = block as Record<string, unknown>
+        if (rec.type !== "thinking") return block
+
+        // Check for a valid base64 signature
+        const sig = rec.thinkingSignature ?? rec.signature ?? rec.thought_signature
+        if (
+          typeof sig === "string" &&
+          sig.length > 0 &&
+          sig.length % 4 === 0 &&
+          ANTIGRAVITY_SIG_RE.test(sig)
+        ) {
+          // Valid signature — keep thinking block, normalize field name
+          if (rec.thinkingSignature !== sig) {
+            changed = true
+            return { ...rec, thinkingSignature: sig }
+          }
+          return block
+        }
+
+        // No valid signature — convert to text to preserve reasoning content
+        const text = typeof rec.thinking === "string" ? rec.thinking : ""
+        if (text.trim()) {
+          changed = true
+          return { type: "text", text }
+        }
+        changed = true
+        return null // drop empty unsigned thinking blocks
+      })
+      .filter(Boolean)
+
+    if (!changed) return turn
+    return { ...turn, content: JSON.stringify(sanitized) }
+  })
+}
+
+/**
+ * Strip unsupported JSON Schema keywords from tool input schemas for
+ * Antigravity (same restriction as google-gemini-cli — Cloud Code Assist
+ * uses OpenAPI 3.03 `parameters` format for both Gemini and Claude models).
+ */
+const ANTIGRAVITY_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
+  "patternProperties",
+  "additionalProperties",
+  "$schema",
+  "$id",
+  "$ref",
+  "$defs",
+  "definitions",
+  "examples",
+  "format",
+  "minLength",
+  "maxLength",
+  "minimum",
+  "maximum",
+  "multipleOf",
+  "pattern",
+  "minItems",
+  "maxItems",
+  "uniqueItems",
+  "minProperties",
+  "maxProperties",
+])
+
+function stripUnsupportedSchemaKeywords(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return schema
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+    if (ANTIGRAVITY_UNSUPPORTED_SCHEMA_KEYWORDS.has(key)) continue
+    out[key] = value && typeof value === "object" ? stripUnsupportedSchemaKeywords(value) : value
+  }
+  return out
+}
+
+function sanitizeAntigravityToolSchemas(defs: ToolDefinition[]): ToolDefinition[] {
+  return defs.map((t) => {
+    if (!t.inputSchema || typeof t.inputSchema !== "object") return t
+    return {
+      ...t,
+      inputSchema: stripUnsupportedSchemaKeywords(t.inputSchema) as typeof t.inputSchema,
+    }
+  })
 }
 
 function toOpenAITools(defs: ToolDefinition[]): OpenAI.ChatCompletionTool[] {
@@ -441,7 +610,7 @@ class AnthropicHandle implements ExecutionHandle {
 
   private readonly tokenRefresher?: TokenRefresher
   private readonly credentialId?: string
-  private readonly baseUrl?: string
+  private baseUrl?: string
   private readonly useAuthToken: boolean
 
   constructor(
@@ -468,9 +637,17 @@ class AnthropicHandle implements ExecutionHandle {
     const systemPrompt = this.task.context.systemPrompt || "You are a helpful assistant."
     const messages: Anthropic.MessageParam[] = []
 
-    // Replay conversation history
+    // Detect Antigravity Claude for thinking block sanitization
+    const isAntigravityClaude =
+      this.task.constraints.llmCredential?.provider === "google-antigravity" &&
+      this.model.toLowerCase().includes("claude")
+
+    // Replay conversation history (sanitize thinking blocks for Antigravity Claude)
     if (this.task.instruction.conversationHistory) {
-      for (const turn of this.task.instruction.conversationHistory) {
+      const history = isAntigravityClaude
+        ? sanitizeAntigravityConversationHistory(this.task.instruction.conversationHistory, true)
+        : this.task.instruction.conversationHistory
+      for (const turn of history) {
         messages.push({ role: turn.role, content: turn.content })
       }
     }
@@ -478,10 +655,15 @@ class AnthropicHandle implements ExecutionHandle {
     messages.push({ role: "user", content: this.task.instruction.prompt })
 
     // Resolve available tools based on task constraints
-    const toolDefs = this.toolRegistry.resolve(
+    let toolDefs = this.toolRegistry.resolve(
       this.task.constraints.allowedTools,
       this.task.constraints.deniedTools,
     )
+    // Antigravity uses the same OpenAPI 3.03 parameters format as google-gemini-cli;
+    // strip unsupported JSON Schema keywords to prevent rejection.
+    if (this.task.constraints.llmCredential?.provider === "google-antigravity") {
+      toolDefs = sanitizeAntigravityToolSchemas(toolDefs)
+    }
     const anthropicTools = toAnthropicTools(toolDefs)
 
     let fullText = ""
@@ -595,6 +777,28 @@ class AnthropicHandle implements ExecutionHandle {
               continue
             }
           }
+
+          // Antigravity endpoint fallback: on connection failure, try next endpoint
+          if (
+            this.baseUrl &&
+            this.task.constraints.llmCredential?.provider === "google-antigravity" &&
+            turn === 0
+          ) {
+            const fallback = nextAntigravityEndpoint(this.baseUrl)
+            if (fallback) {
+              this.baseUrl = fallback
+              const cred = this.task.constraints.llmCredential
+              const wrappedToken = wrapAntigravityToken(cred.token, cred.accountId)
+              this.client = new Anthropic({
+                authToken: wrappedToken,
+                apiKey: null as unknown as string,
+                baseURL: fallback,
+              })
+              turn-- // retry this turn with fallback endpoint
+              continue
+            }
+          }
+
           throw err
         }
       }
@@ -629,7 +833,8 @@ class AnthropicHandle implements ExecutionHandle {
     } catch (err) {
       if (this.cancelled) return
 
-      const errorMsg = err instanceof Error ? err.message : "Unknown error"
+      const rawMsg = err instanceof Error ? err.message : "Unknown error"
+      const errorMsg = sanitizeProviderErrorMessage(rawMsg)
       const execResult: ExecutionResult = {
         taskId: this.taskId,
         status: "failed",
@@ -931,7 +1136,8 @@ class OpenAIHandle implements ExecutionHandle {
     } catch (err) {
       if (this.cancelled) return
 
-      const errorMsg = err instanceof Error ? err.message : "Unknown error"
+      const rawMsg = err instanceof Error ? err.message : "Unknown error"
+      const errorMsg = sanitizeProviderErrorMessage(rawMsg)
       const execResult: ExecutionResult = {
         taskId: this.taskId,
         status: "failed",

--- a/packages/control-plane/src/routes/auth.ts
+++ b/packages/control-plane/src/routes/auth.ts
@@ -15,6 +15,7 @@ import type { Kysely } from "kysely"
 
 import { discoverAntigravityProject } from "../auth/antigravity-project.js"
 import type { CredentialService } from "../auth/credential-service.js"
+import type { ModelDiscoveryService } from "../auth/model-discovery.js"
 import { getCodePasteProvider, getUserServiceProvider } from "../auth/oauth-providers.js"
 import {
   buildAuthorizeUrl,
@@ -42,10 +43,11 @@ interface AuthRouteDeps {
   authConfig: AuthOAuthConfig
   sessionService: SessionService
   credentialService: CredentialService
+  modelDiscovery?: ModelDiscoveryService
 }
 
 export function authRoutes(deps: AuthRouteDeps) {
-  const { db, authConfig, sessionService, credentialService } = deps
+  const { db, authConfig, sessionService, credentialService, modelDiscovery } = deps
 
   return function register(app: FastifyInstance): void {
     const isSecure = authConfig.dashboardUrl.startsWith("https")
@@ -425,6 +427,13 @@ export function authRoutes(deps: AuthRouteDeps) {
             scopes: userServiceDef?.defaultScopes,
           })
 
+          // Auto-trigger model discovery for the new credential (fire-and-forget)
+          if (modelDiscovery) {
+            modelDiscovery
+              .discoverModels(provider, { accessToken: tokens.access_token })
+              .catch(() => {})
+          }
+
           reply.redirect(`${authConfig.dashboardUrl}/settings?connected=${provider}`)
         } catch (err) {
           request.log.error(err, `Provider connect error for ${provider}`)
@@ -575,6 +584,13 @@ export function authRoutes(deps: AuthRouteDeps) {
             accountId,
             scopes: providerReg.scopes,
           })
+
+          // Auto-trigger model discovery for the new credential (fire-and-forget)
+          if (modelDiscovery) {
+            modelDiscovery
+              .discoverModels(provider, { accessToken: tokens.access_token })
+              .catch(() => {})
+          }
 
           return {
             ok: true,

--- a/packages/control-plane/src/routes/credentials.ts
+++ b/packages/control-plane/src/routes/credentials.ts
@@ -14,6 +14,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
 
 import { CredentialService, SUPPORTED_PROVIDERS } from "../auth/credential-service.js"
+import type { ModelDiscoveryService } from "../auth/model-discovery.js"
 import type { SessionService } from "../auth/session-service.js"
 import { createRequireAuth, createRequireRole, type PreHandler } from "../middleware/auth.js"
 import type { AuthenticatedRequest } from "../middleware/types.js"
@@ -24,10 +25,11 @@ const TOOL_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/
 interface CredentialRouteDeps {
   credentialService: CredentialService
   sessionService: SessionService
+  modelDiscovery?: ModelDiscoveryService
 }
 
 export function credentialRoutes(deps: CredentialRouteDeps) {
-  const { credentialService, sessionService } = deps
+  const { credentialService, sessionService, modelDiscovery } = deps
 
   const requireAuth: PreHandler = createRequireAuth({
     config: { apiKeys: [], requireAuth: true },
@@ -134,6 +136,11 @@ export function credentialRoutes(deps: CredentialRouteDeps) {
           apiKey,
           { displayLabel },
         )
+
+        // Auto-trigger model discovery for the new credential (fire-and-forget)
+        if (modelDiscovery) {
+          modelDiscovery.discoverModels(provider, { apiKey }).catch(() => {})
+        }
 
         reply.status(201).send({ credential })
       },


### PR DESCRIPTION
## Summary

Fixes #674 — Ports the working Antigravity provider integration patterns from the OpenClaw reference implementation on this host.

## Changes (343 lines, 6 files)

### Endpoint fallback + project ID (`http-llm.ts`)
- Tries `cloudcode-pa.googleapis.com` (prod) first, falls back to sandbox
- `nextAntigravityEndpoint()` for retry on connection failure

### Token wrapping (`http-llm.ts`)
- `wrapAntigravityToken()` — JSON `{token, projectId}` format matching OpenClaw `buildOAuthApiKey()`

### Thinking block sanitization (`http-llm.ts`)
- `sanitizeAntigravityConversationHistory()` — converts unsigned thinking blocks to text, maps signature formats, validates base64
- Pattern from OpenClaw `sanitizeAntigravityThinkingBlocks()`

### Tool schema sanitization (`http-llm.ts`)
- `stripUnsupportedSchemaKeywords()` for Antigravity (same restrictions as google-gemini-cli)

### Error sanitization (`http-llm.ts`)
- `sanitizeProviderErrorMessage()` strips raw HTML from error responses

### Model discovery (`model-discovery.ts`, `app.ts`, `credentials.ts`, `auth.ts`)
- Fixed `discoverGoogleAntigravity()` to use correct endpoint
- Auto-discover on startup + credential create + OAuth completion

## Testing
- `pnpm build` ✅
- `pnpm test` ✅ (2705 passed, 0 failed)

## Deploy Notes
Set `ANTIGRAVITY_BASE_URL` env var OR rely on default prod endpoint (`cloudcode-pa.googleapis.com`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic model discovery on application startup for all configured LLM providers, ensuring available models are cached before processing requests.

* **Improvements**
  * Enhanced Google Antigravity credential routing with automatic multi-endpoint fallback support for improved reliability.
  * Improved error messages with formatting and sanitization for better clarity and readability.
  * Optimized conversation history and tool schema handling for advanced model providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->