### PR TITLE
fix(#684): add static fallback model catalogue for providers without discovery API

### DIFF
--- a/packages/control-plane/src/auth/__tests__/model-discovery.test.ts
+++ b/packages/control-plane/src/auth/__tests__/model-discovery.test.ts
@@ -62,22 +62,29 @@ describe("discoverModels — anthropic", () => {
     expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer oauth-tok")
   })
 
-  it("returns empty array on failure", async () => {
+  it("falls back to static catalogue on API failure", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({}, 401))
+
+    vi.spyOn(console, "warn").mockImplementation(() => {})
 
     const svc = new ModelDiscoveryService()
     const models = await svc.discoverModels("anthropic", { apiKey: "bad" })
 
-    expect(models).toEqual([])
+    // Static catalogue kicks in for anthropic
+    expect(models.length).toBeGreaterThan(0)
+    expect(models.some((m) => m.id === "claude-sonnet-4-5")).toBe(true)
   })
 
-  it("returns empty array on network error", async () => {
+  it("falls back to static catalogue on network error", async () => {
     fetchMock.mockRejectedValueOnce(new Error("network error"))
+
+    vi.spyOn(console, "warn").mockImplementation(() => {})
 
     const svc = new ModelDiscoveryService()
     const models = await svc.discoverModels("anthropic", { apiKey: "sk-test" })
 
-    expect(models).toEqual([])
+    expect(models.length).toBeGreaterThan(0)
+    expect(models.some((m) => m.id === "claude-sonnet-4-5")).toBe(true)
   })
 })
 
@@ -332,13 +339,12 @@ describe("cache", () => {
     expect(svc.getAllCachedModels()).toEqual([])
   })
 
-  it("does not cache empty results", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({}, 401))
-
+  it("does not cache empty results for providers without static catalogue", async () => {
+    // google-ai-studio has no static fallback and needs apiKey (not accessToken)
     const svc = new ModelDiscoveryService()
-    await svc.discoverModels("anthropic", { apiKey: "bad" })
+    await svc.discoverModels("google-ai-studio", { accessToken: "tok" })
 
-    expect(svc.getCachedModels("anthropic")).toEqual([])
+    expect(svc.getCachedModels("google-ai-studio")).toEqual([])
   })
 })
 
@@ -368,5 +374,101 @@ describe("getAllCachedModels", () => {
     const gemini = all.find((m) => m.id === "gemini-2.5-pro")
     expect(gemini).toBeDefined()
     expect(gemini!.providers).toEqual(["google-antigravity"])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Static catalogue fallback
+// ---------------------------------------------------------------------------
+
+describe("discoverModels — static catalogue fallback", () => {
+  it("falls back to static catalogue when google-antigravity API returns 404", async () => {
+    // Both endpoints return 404
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({}, 404))
+      .mockResolvedValueOnce(jsonResponse({}, 404))
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("google-antigravity", { accessToken: "tok" })
+
+    expect(models.length).toBeGreaterThan(0)
+    expect(models.some((m) => m.id === "gemini-3-flash")).toBe(true)
+    expect(models.every((m) => m.providers.includes("google-antigravity"))).toBe(true)
+
+    // Warning should have been logged
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("static model catalogue"))
+
+    warnSpy.mockRestore()
+  })
+
+  it("falls back to static catalogue when anthropic API fails", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 500))
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("anthropic", { apiKey: "bad-key" })
+
+    expect(models.length).toBeGreaterThan(0)
+    expect(models.some((m) => m.id === "claude-sonnet-4-5")).toBe(true)
+    expect(models.every((m) => m.providers.includes("anthropic"))).toBe(true)
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("static model catalogue"))
+
+    warnSpy.mockRestore()
+  })
+
+  it("falls back to static catalogue when openai-codex API fails", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 403))
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("openai-codex", { apiKey: "bad" })
+
+    expect(models.length).toBeGreaterThan(0)
+    expect(models.some((m) => m.id === "gpt-5")).toBe(true)
+
+    warnSpy.mockRestore()
+  })
+
+  it("does NOT fall back when dynamic discovery succeeds", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [{ id: "claude-sonnet-4-6" }] }))
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("anthropic", { apiKey: "sk-good" })
+
+    expect(models).toHaveLength(1)
+    expect(models[0]!.id).toBe("claude-sonnet-4-6")
+
+    // No fallback warning
+    expect(warnSpy).not.toHaveBeenCalled()
+
+    warnSpy.mockRestore()
+  })
+
+  it("does NOT fall back for providers without static catalogue", async () => {
+    const svc = new ModelDiscoveryService()
+    const models = await svc.discoverModels("some-unknown", { apiKey: "key" })
+    expect(models).toEqual([])
+  })
+
+  it("caches fallback results", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({}, 404))
+      .mockResolvedValueOnce(jsonResponse({}, 404))
+
+    vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    const svc = new ModelDiscoveryService()
+    await svc.discoverModels("google-antigravity", { accessToken: "tok" })
+
+    const cached = svc.getCachedModels("google-antigravity")
+    expect(cached.length).toBeGreaterThan(0)
+    expect(cached.some((m) => m.id === "gemini-3-flash")).toBe(true)
   })
 })

--- a/packages/control-plane/src/auth/model-catalogue.ts
+++ b/packages/control-plane/src/auth/model-catalogue.ts
@@ -1,0 +1,57 @@
+/**
+ * Static model catalogue — fallback for providers whose API does not expose
+ * a models listing endpoint (e.g. Google Antigravity returns 404 on /v1/models).
+ *
+ * Keep this file easy to update: one entry per provider, alphabetical model IDs.
+ */
+
+import type { ModelInfo } from "../observability/model-providers.js"
+
+// ---------------------------------------------------------------------------
+// Per-provider static model lists
+// ---------------------------------------------------------------------------
+
+function models(ids: string[], provider: string): ModelInfo[] {
+  return ids.map((id) => ({
+    id,
+    label: id
+      .split("-")
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join(" "),
+    providers: [provider],
+  }))
+}
+
+const STATIC_CATALOGUE: Record<string, ModelInfo[]> = {
+  "google-antigravity": models(
+    [
+      "claude-opus-4-5-thinking",
+      "claude-opus-4-6-thinking",
+      "claude-sonnet-4-5",
+      "claude-sonnet-4-5-thinking",
+      "gemini-3-flash",
+      "gemini-3-flash-preview",
+      "gemini-3-pro-high",
+      "gemini-3-pro-low",
+      "gemini-3-pro-preview",
+      "gemini-3.1-pro-preview",
+    ],
+    "google-antigravity",
+  ),
+
+  anthropic: models(["claude-haiku-3.5", "claude-opus-4", "claude-sonnet-4-5"], "anthropic"),
+
+  "openai-codex": models(["gpt-5", "gpt-5-mini", "gpt-5.2"], "openai-codex"),
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the static model list for `providerId`, or `undefined` if no
+ * static catalogue exists for that provider.
+ */
+export function getStaticModels(providerId: string): ModelInfo[] | undefined {
+  return STATIC_CATALOGUE[providerId]
+}

--- a/packages/control-plane/src/auth/model-discovery.ts
+++ b/packages/control-plane/src/auth/model-discovery.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ModelInfo } from "../observability/model-providers.js"
+import { getStaticModels } from "./model-catalogue.js"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -241,6 +242,17 @@ export class ModelDiscoveryService {
         break
       default:
         models = []
+    }
+
+    // Fall back to static catalogue when dynamic discovery returns empty
+    if (models.length === 0) {
+      const fallback = getStaticModels(providerId)
+      if (fallback) {
+        console.warn(
+          `[model-discovery] Dynamic discovery returned empty for "${providerId}" — using static model catalogue`,
+        )
+        models = fallback
+      }
     }
 
     if (models.length > 0) {


### PR DESCRIPTION
## Summary
- Creates `packages/control-plane/src/auth/model-catalogue.ts` with static model lists for google-antigravity, anthropic, and openai-codex
- Modifies `discoverModels()` to fall back to the static catalogue when dynamic API discovery returns empty
- Logs `console.warn` when fallback is used so operators know discovery failed
- Adds 6 new tests for the fallback path; updates 3 existing tests to account for fallback behavior

Closes #684

## Test plan
- [x] `pnpm -C packages/control-plane run build` — passes
- [x] `pnpm -C packages/control-plane run test` — 1982 tests pass (118 files)
- [x] `pnpm format` — clean
- [ ] After deploy: connect google-antigravity → `GET /models` returns static model list
- [ ] Dashboard model dropdown shows Antigravity models after connecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic fallback to a static catalogue of models when dynamic model discovery APIs fail or are unavailable, ensuring continued access to models during API outages.

* **Tests**
  * Expanded test coverage for static catalogue fallback behavior across multiple providers and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->