### PR TITLE
fix: resolve Google Antigravity 404 by rewriting /v1/messages to Cloud Code endpoint

### DIFF
--- a/packages/control-plane/src/__tests__/agent-execute-credential-wiring.test.ts
+++ b/packages/control-plane/src/__tests__/agent-execute-credential-wiring.test.ts
@@ -62,7 +62,7 @@ function createMockHandle(
     async result() {
       return result
     },
-    // eslint-disable-next-line @typescript-eslint/require-await
+
     async cancel() {
       // no-op
     },
@@ -336,7 +336,7 @@ describe("agent-execute credential wiring (#444)", () => {
     await task({ jobId: "job-1" }, makeMockHelpers() as never)
 
     // Verify the credential binding query included a provider filter
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+
     const selectCalls = (db.selectFrom as ReturnType<typeof vi.fn>).mock.calls
     const credBindingCall = selectCalls.find((c: string[]) => c[0] === "agent_credential_binding")
     expect(credBindingCall).toBeDefined()

--- a/packages/control-plane/src/__tests__/http-llm.test.ts
+++ b/packages/control-plane/src/__tests__/http-llm.test.ts
@@ -1,7 +1,7 @@
 import type { ExecutionTask, OutputEvent } from "@cortex/shared/backends"
 import { describe, expect, it, vi } from "vitest"
 
-import { HttpLlmBackend, type McpDeps, createAntigravityFetch } from "../backends/http-llm.js"
+import { createAntigravityFetch, HttpLlmBackend, type McpDeps } from "../backends/http-llm.js"
 import type { McpToolRouter } from "../mcp/tool-router.js"
 
 // ---------------------------------------------------------------------------
@@ -1568,7 +1568,11 @@ describe("HttpLlmBackend — credential provider routing", () => {
     const handle = await backend.executeTask(task)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    const client = (handle as any).client as { baseURL: string; authToken: string | null; fetch: unknown }
+    const client = (handle as any).client as {
+      baseURL: string
+      authToken: string | null
+      fetch: unknown
+    }
     expect(client.baseURL).toBe("https://cloudcode-pa.googleapis.com")
     expect(client.authToken).toBe(
       JSON.stringify({ token: "gcp-oauth-token", projectId: "my-project-42" }),
@@ -1590,20 +1594,19 @@ describe("createAntigravityFetch — URL rewriting", () => {
     const originalFetch = globalThis.fetch
 
     let capturedUrl = ""
-    globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
-      capturedUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    globalThis.fetch = vi.fn((input: string | URL | Request) => {
+      capturedUrl =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
       return new Response("{}", { status: 200 })
     }) as typeof globalThis.fetch
 
     try {
-      await antigravityFetch(
-        "https://cloudcode-pa.googleapis.com/v1/messages",
-        { method: "POST", body: JSON.stringify({ model: "claude-3", messages: [] }) },
-      )
+      await antigravityFetch("https://cloudcode-pa.googleapis.com/v1/messages", {
+        method: "POST",
+        body: JSON.stringify({ model: "claude-3", messages: [] }),
+      })
 
-      expect(capturedUrl).toBe(
-        "https://cloudcode-pa.googleapis.com/v1internal:streamCodeAssist",
-      )
+      expect(capturedUrl).toBe("https://cloudcode-pa.googleapis.com/v1internal:streamCodeAssist")
     } finally {
       globalThis.fetch = originalFetch
     }
@@ -1614,16 +1617,17 @@ describe("createAntigravityFetch — URL rewriting", () => {
     const originalFetch = globalThis.fetch
 
     let capturedUrl = ""
-    globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
-      capturedUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    globalThis.fetch = vi.fn((input: string | URL | Request) => {
+      capturedUrl =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
       return new Response("{}", { status: 200 })
     }) as typeof globalThis.fetch
 
     try {
-      await antigravityFetch(
-        "https://daily-cloudcode-pa.sandbox.googleapis.com/v1/messages",
-        { method: "POST", body: "{}" },
-      )
+      await antigravityFetch("https://daily-cloudcode-pa.sandbox.googleapis.com/v1/messages", {
+        method: "POST",
+        body: "{}",
+      })
 
       expect(capturedUrl).toBe(
         "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:streamCodeAssist",
@@ -1638,8 +1642,9 @@ describe("createAntigravityFetch — URL rewriting", () => {
     const originalFetch = globalThis.fetch
 
     let capturedUrl = ""
-    globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
-      capturedUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    globalThis.fetch = vi.fn((input: string | URL | Request) => {
+      capturedUrl =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
       return new Response("{}", { status: 200 })
     }) as typeof globalThis.fetch
 
@@ -1659,22 +1664,20 @@ describe("createAntigravityFetch — URL rewriting", () => {
     const originalFetch = globalThis.fetch
 
     let capturedInit: RequestInit | undefined
-    globalThis.fetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+    globalThis.fetch = vi.fn((_input: string | URL | Request, init?: RequestInit) => {
       capturedInit = init
       return new Response("{}", { status: 200 })
     }) as typeof globalThis.fetch
 
     try {
-      await antigravityFetch(
-        "https://cloudcode-pa.googleapis.com/v1/messages",
-        { method: "POST", body: "{}" },
-      )
+      await antigravityFetch("https://cloudcode-pa.googleapis.com/v1/messages", {
+        method: "POST",
+        body: "{}",
+      })
 
       const headers = new Headers(capturedInit?.headers)
       expect(headers.get("User-Agent")).toBe("google-api-nodejs-client/9.15.1")
-      expect(headers.get("X-Goog-Api-Client")).toBe(
-        "google-cloud-sdk vscode_cloudshelleditor/0.1",
-      )
+      expect(headers.get("X-Goog-Api-Client")).toBe("google-cloud-sdk vscode_cloudshelleditor/0.1")
       expect(headers.get("Client-Metadata")).toContain("GEMINI")
     } finally {
       globalThis.fetch = originalFetch
@@ -1686,17 +1689,17 @@ describe("createAntigravityFetch — URL rewriting", () => {
     const originalFetch = globalThis.fetch
 
     let capturedBody = ""
-    globalThis.fetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+    globalThis.fetch = vi.fn((_input: string | URL | Request, init?: RequestInit) => {
       capturedBody = (init?.body as string) ?? ""
       return new Response("{}", { status: 200 })
     }) as typeof globalThis.fetch
 
     try {
       const originalBody = { model: "claude-3", messages: [{ role: "user", content: "hello" }] }
-      await antigravityFetch(
-        "https://cloudcode-pa.googleapis.com/v1/messages",
-        { method: "POST", body: JSON.stringify(originalBody) },
-      )
+      await antigravityFetch("https://cloudcode-pa.googleapis.com/v1/messages", {
+        method: "POST",
+        body: JSON.stringify(originalBody),
+      })
 
       const parsedBody = JSON.parse(capturedBody) as Record<string, unknown>
       // Original fields preserved
@@ -1718,8 +1721,9 @@ describe("createAntigravityFetch — URL rewriting", () => {
     const originalFetch = globalThis.fetch
 
     let capturedUrl = ""
-    globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
-      capturedUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    globalThis.fetch = vi.fn((input: string | URL | Request) => {
+      capturedUrl =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
       return new Response("{}", { status: 200 })
     }) as typeof globalThis.fetch
 

--- a/packages/control-plane/src/backends/http-llm.ts
+++ b/packages/control-plane/src/backends/http-llm.ts
@@ -478,10 +478,7 @@ const ANTIGRAVITY_CLIENT_METADATA = {
  * Non-messages requests pass through unchanged.
  */
 export function createAntigravityFetch(): typeof globalThis.fetch {
-  return async (
-    input: string | URL | Request,
-    init?: RequestInit,
-  ): Promise<Response> => {
+  return async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
     let url: string
     let requestInit = init
 


### PR DESCRIPTION
The Anthropic SDK appends `/v1/messages` to the baseURL, but Google's Cloud Code backend serves at `/v1internal:streamCodeAssist` — causing a 404. 

Add a custom fetch override (`createAntigravityFetch`) that intercepts requests to `/v1/messages` and rewrites the path, adds Google-specific headers (`User-Agent`, `X-Goog-Api-Client`, `Client-Metadata`), and wraps the request body with Cloud Code metadata. Applied to all three Antigravity client creation sites: initial, 401 retry, and endpoint fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Antigravity integration with custom request routing and metadata to improve code assist behavior.
* **Tests**
  * Added and updated test coverage to verify Antigravity request overrides, URL handling, header/body transformations, and non-rewriting paths.
* **Style**
  * Small formatting adjustments in tests for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->