### PR TITLE
Fix #689: persist/surface structured failureReason for failed jobs

### DIFF
--- a/packages/control-plane/src/__tests__/dashboard-routes.test.ts
+++ b/packages/control-plane/src/__tests__/dashboard-routes.test.ts
@@ -227,7 +227,12 @@ describe("dashboard routes", () => {
 
   it("returns job detail with failureReason and attempt info", async () => {
     const { app } = await buildTestApp({
-      error: { message: "context budget exceeded", category: "CONTEXT_BUDGET_EXCEEDED" },
+      error: {
+        message: "context budget exceeded",
+        category: "CONTEXT_BUDGET_EXCEEDED",
+        provider: "google-antigravity",
+        model: "claude-sonnet-4-6",
+      },
       attempt: 2,
       max_attempts: 3,
     })
@@ -240,9 +245,38 @@ describe("dashboard routes", () => {
       failureReason: {
         message: "context budget exceeded",
         category: "CONTEXT_BUDGET_EXCEEDED",
+        provider: "google-antigravity",
+        model: "claude-sonnet-4-6",
       },
       attempt: 2,
       maxAttempts: 3,
+    })
+  })
+
+  it("falls back to result.error when job.error is missing", async () => {
+    const { app } = await buildTestApp({
+      error: null,
+      result: {
+        taskId: JOB_UUID,
+        status: "failed",
+        error: {
+          message: "Provider endpoint/model mismatch",
+          category: "PERMANENT",
+          provider: "google-antigravity",
+          model: "claude-sonnet-4-6-20250514",
+        },
+      },
+    })
+
+    const detail = await app.inject({ method: "GET", url: `/jobs/${JOB_UUID}` })
+    expect(detail.statusCode).toBe(200)
+    expect(detail.json()).toMatchObject({
+      failureReason: {
+        message: "Provider endpoint/model mismatch",
+        category: "PERMANENT",
+        provider: "google-antigravity",
+        model: "claude-sonnet-4-6-20250514",
+      },
     })
   })
 

--- a/packages/control-plane/src/routes/dashboard.ts
+++ b/packages/control-plane/src/routes/dashboard.ts
@@ -510,13 +510,37 @@ export function dashboardRoutes(deps: DashboardRouteDeps) {
             ? Math.max(0, completedAtMs - startedAtMs)
             : undefined
 
-        // Build structured failure reason from job.error
+        // Build structured failure reason from job.error, with fallback to result.error
         const rawErr = job.error
-        const failureReason =
+        const resultObj = job.result && typeof job.result === "object" ? job.result : undefined
+        const resultErr = resultObj && "error" in resultObj ? resultObj.error : undefined
+
+        const sourceErr: Record<string, unknown> | undefined =
           rawErr && typeof rawErr === "object"
+            ? rawErr
+            : resultErr && typeof resultErr === "object"
+              ? (resultErr as Record<string, unknown>)
+              : undefined
+
+        const message =
+          sourceErr && typeof sourceErr.message === "string"
+            ? sourceErr.message
+            : sourceErr && typeof sourceErr.summary === "string"
+              ? sourceErr.summary
+              : undefined
+        const category =
+          sourceErr && typeof sourceErr.category === "string" ? sourceErr.category : undefined
+        const provider =
+          sourceErr && typeof sourceErr.provider === "string" ? sourceErr.provider : undefined
+        const model = sourceErr && typeof sourceErr.model === "string" ? sourceErr.model : undefined
+
+        const failureReason =
+          sourceErr && (message || category || provider || model)
             ? {
-                message: typeof rawErr.message === "string" ? rawErr.message : "Unknown error",
-                category: typeof rawErr.category === "string" ? rawErr.category : undefined,
+                message: message ?? "Unknown error",
+                category,
+                provider,
+                model,
               }
             : undefined
 

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -863,12 +863,15 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
           // during execution; only status, result, and tool_call_count written here.
           const jobStatus = mapExecutionStatus(result.status)
 
+          const jobError = executionErrorToJobError(result, task)
+
           await db
             .updateTable("job")
             .set({
               status: jobStatus,
               completed_at: new Date(),
               result: executionResultToJson(result),
+              error: jobError,
               tool_call_count: toolCallCount,
             })
             .where("id", "=", jobId)
@@ -1286,6 +1289,51 @@ function executionResultToJson(result: ExecutionResult): Record<string, unknown>
     artifacts: result.artifacts,
     durationMs: result.durationMs,
     error: result.error ?? null,
+  }
+}
+
+function executionErrorToJobError(
+  result: ExecutionResult,
+  task: ExecutionTask,
+): Record<string, unknown> | null {
+  if (result.status === "completed") return null
+
+  const provider = task.constraints.llmCredential?.provider
+  const model = task.constraints.model
+
+  if (result.error) {
+    const category =
+      result.error.classification === "permanent"
+        ? "PERMANENT"
+        : result.error.classification === "transient"
+          ? "TRANSIENT"
+          : result.error.classification === "resource"
+            ? "RESOURCE"
+            : result.error.classification === "timeout"
+              ? "TIMEOUT"
+              : "UNKNOWN"
+
+    return {
+      category,
+      message: result.error.message,
+      provider,
+      model,
+    }
+  }
+
+  return {
+    category:
+      result.status === "timed_out"
+        ? "TIMEOUT"
+        : result.status === "cancelled"
+          ? "RESOURCE"
+          : "UNKNOWN",
+    message:
+      result.status === "cancelled"
+        ? "Execution cancelled"
+        : result.summary || result.stderr || "Execution failed",
+    provider,
+    model,
   }
 }
 


### PR DESCRIPTION
## Summary
- persist structured `job.error` metadata for non-completed executions in `agent-execute`
- include provider/model context in persisted failure payloads
- add dashboard fallback to `result.error` when legacy rows lack `job.error`
- extend dashboard route tests for provider/model and fallback behavior

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build

Closes #689


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error reporting now includes additional provider and model field information.
  * Implemented fallback mechanism to ensure error details are captured and displayed when primary error data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->