### PR TITLE
fix: close provider parity gap for issue #693

### DIFF
--- a/packages/control-plane/src/__tests__/preflight.test.ts
+++ b/packages/control-plane/src/__tests__/preflight.test.ts
@@ -300,4 +300,32 @@ describe("mapJobErrorToUserMessage", () => {
     })
     expect(msg).toContain("Something went wrong")
   })
+
+  it("returns typed model_unavailable message from job error fields", () => {
+    const msg = mapJobErrorToUserMessage({
+      category: "PERMANENT",
+      code: "model_unavailable",
+      provider: "openai-codex",
+      model: "claude-sonnet-4-5",
+      message: "Model 'claude-sonnet-4-5' is unavailable for provider 'openai-codex'",
+    })
+    expect(msg).toContain("unavailable for this provider")
+    expect(msg).toContain("claude-sonnet-4-5 / openai-codex")
+  })
+
+  it("returns typed model_unavailable message from nested execution error", () => {
+    const msg = mapJobErrorToUserMessage({
+      taskId: "task-1",
+      status: "failed",
+      error: {
+        classification: "permanent",
+        code: "model_unavailable",
+        message: "Model 'claude-sonnet-4-5' is unavailable for provider 'openai-codex'",
+      },
+      provider: "openai-codex",
+      model: "claude-sonnet-4-5",
+    })
+    expect(msg).toContain("unavailable for this provider")
+    expect(msg).toContain("claude-sonnet-4-5 / openai-codex")
+  })
 })

--- a/packages/control-plane/src/auth/__tests__/model-discovery.test.ts
+++ b/packages/control-plane/src/auth/__tests__/model-discovery.test.ts
@@ -52,14 +52,15 @@ describe("discoverModels — anthropic", () => {
     expect((init.headers as Record<string, string>)["anthropic-version"]).toBe("2023-06-01")
   })
 
-  it("uses Bearer auth when accessToken provided", async () => {
+  it("uses x-api-key auth when accessToken provided", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ data: [{ id: "claude-haiku-4-5" }] }))
 
     const svc = new ModelDiscoveryService()
     await svc.discoverModels("anthropic", { accessToken: "oauth-tok" })
 
     const [, init] = fetchMock.mock.calls[0]! as [string, RequestInit]
-    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer oauth-tok")
+    expect((init.headers as Record<string, string>)["x-api-key"]).toBe("oauth-tok")
+    expect((init.headers as Record<string, string>)["Authorization"]).toBeUndefined()
   })
 
   it("falls back to static catalogue on API failure", async () => {

--- a/packages/control-plane/src/auth/model-discovery.ts
+++ b/packages/control-plane/src/auth/model-discovery.ts
@@ -65,7 +65,9 @@ async function discoverAnthropic(cred: ProviderCredential): Promise<ModelInfo[]>
   if (cred.apiKey) {
     headers["x-api-key"] = cred.apiKey
   } else if (cred.accessToken) {
-    headers["Authorization"] = `Bearer ${cred.accessToken}`
+    // Anthropic model discovery follows the same x-api-key contract used by
+    // the runtime path, even when the credential originated from OAuth.
+    headers["x-api-key"] = cred.accessToken
   } else {
     return []
   }

--- a/packages/control-plane/src/channels/preflight.ts
+++ b/packages/control-plane/src/channels/preflight.ts
@@ -132,16 +132,31 @@ export function mapJobErrorToUserMessage(
 
   // Top-level fields from the job `error` column (exception path)
   const category = typeof error.category === "string" ? error.category : ""
+  const code = typeof error.code === "string" ? error.code : ""
   const message = typeof error.message === "string" ? error.message : ""
+  const provider = typeof error.provider === "string" ? error.provider : ""
+  const model = typeof error.model === "string" ? error.model : ""
 
   // Nested error from the execution `result` column (execution-result path)
   const nested = error.error as Record<string, unknown> | undefined
+  const nestedCode = typeof nested?.code === "string" ? nested.code : ""
   const nestedClassification =
     typeof nested?.classification === "string" ? nested.classification : ""
   const nestedMessage = typeof nested?.message === "string" ? nested.message : ""
+  const nestedProvider = typeof nested?.provider === "string" ? nested.provider : ""
+  const nestedModel = typeof nested?.model === "string" ? nested.model : ""
 
   // Combine for matching
   const allMessages = [message, nestedMessage].join(" ")
+  const resolvedProvider = provider || nestedProvider
+  const resolvedModel = model || nestedModel
+
+  if (code === "model_unavailable" || nestedCode === "model_unavailable") {
+    const details = [resolvedModel, resolvedProvider].filter(Boolean).join(" / ")
+    return details
+      ? `The configured AI model is unavailable for this provider (${details}). An operator needs to update the agent's model configuration.`
+      : "The configured AI model is unavailable for this provider. An operator needs to update the agent's model configuration."
+  }
 
   // Quarantine
   if (category === "QUARANTINED" || allMessages.includes("QUARANTINED")) {


### PR DESCRIPTION
## Summary
- align Anthropic model discovery auth with the runtime provider contract so OAuth and API-key paths behave the same
- map typed model_unavailable failures to deterministic user-facing chat/Telegram messaging instead of the generic fallback
- add regression coverage for both parity fixes

Closes #693

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Improved error messages when AI models are unavailable, now displaying specific model and provider information alongside guidance for users to contact an operator to update the agent's model configuration.

* **Improvements**
  - Updated Anthropic integration to correctly handle OAuth-based authentication.

* **Tests**
  - Added test coverage for model unavailability scenarios and authentication verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->