### PR TITLE
Fix #695: typed RESOURCE cancellation reasons + channel/dashboard propagation

### DIFF
--- a/packages/control-plane/src/__tests__/dashboard-routes.test.ts
+++ b/packages/control-plane/src/__tests__/dashboard-routes.test.ts
@@ -230,6 +230,7 @@ describe("dashboard routes", () => {
       error: {
         message: "context budget exceeded",
         category: "CONTEXT_BUDGET_EXCEEDED",
+        code: "resource_guard",
         provider: "google-antigravity",
         model: "claude-sonnet-4-6",
       },
@@ -245,6 +246,7 @@ describe("dashboard routes", () => {
       failureReason: {
         message: "context budget exceeded",
         category: "CONTEXT_BUDGET_EXCEEDED",
+        code: "resource_guard",
         provider: "google-antigravity",
         model: "claude-sonnet-4-6",
       },
@@ -262,6 +264,7 @@ describe("dashboard routes", () => {
         error: {
           message: "Provider endpoint/model mismatch",
           category: "PERMANENT",
+          code: "model_unavailable",
           provider: "google-antigravity",
           model: "claude-sonnet-4-6-20250514",
         },
@@ -274,6 +277,7 @@ describe("dashboard routes", () => {
       failureReason: {
         message: "Provider endpoint/model mismatch",
         category: "PERMANENT",
+        code: "model_unavailable",
         provider: "google-antigravity",
         model: "claude-sonnet-4-6-20250514",
       },

--- a/packages/control-plane/src/__tests__/preflight.test.ts
+++ b/packages/control-plane/src/__tests__/preflight.test.ts
@@ -328,4 +328,22 @@ describe("mapJobErrorToUserMessage", () => {
     expect(msg).toContain("unavailable for this provider")
     expect(msg).toContain("claude-sonnet-4-5 / openai-codex")
   })
+
+  it("returns typed quota_exceeded message", () => {
+    const msg = mapJobErrorToUserMessage({
+      category: "RESOURCE",
+      code: "quota_exceeded",
+      message: "Provider quota exceeded",
+    })
+    expect(msg).toContain("quota has been exceeded")
+  })
+
+  it("returns typed upstream_cancelled message", () => {
+    const msg = mapJobErrorToUserMessage({
+      category: "RESOURCE",
+      code: "upstream_cancelled",
+      message: "Execution cancelled",
+    })
+    expect(msg).toContain("cancelled by the upstream provider")
+  })
 })

--- a/packages/control-plane/src/channels/preflight.ts
+++ b/packages/control-plane/src/channels/preflight.ts
@@ -158,6 +158,26 @@ export function mapJobErrorToUserMessage(
       : "The configured AI model is unavailable for this provider. An operator needs to update the agent's model configuration."
   }
 
+  const resourceCode = code || nestedCode
+  if (resourceCode === "rate_limit") {
+    return "The AI provider is currently rate-limiting requests. Please try again in a few minutes."
+  }
+  if (resourceCode === "quota_exceeded") {
+    return "The AI provider quota has been exceeded. An operator needs to increase quota or switch credentials."
+  }
+  if (resourceCode === "upstream_cancelled") {
+    return "The AI request was cancelled by the upstream provider. Please try again."
+  }
+  if (resourceCode === "resource_guard") {
+    return (
+      "Execution was stopped by a local resource safety guard (budget/rate limits). " +
+      "Please retry with a smaller request or ask an operator to adjust limits."
+    )
+  }
+  if (resourceCode === "timeout") {
+    return "The request timed out. Please try again."
+  }
+
   // Quarantine
   if (category === "QUARANTINED" || allMessages.includes("QUARANTINED")) {
     return (

--- a/packages/control-plane/src/routes/dashboard.ts
+++ b/packages/control-plane/src/routes/dashboard.ts
@@ -530,15 +530,17 @@ export function dashboardRoutes(deps: DashboardRouteDeps) {
               : undefined
         const category =
           sourceErr && typeof sourceErr.category === "string" ? sourceErr.category : undefined
+        const code = sourceErr && typeof sourceErr.code === "string" ? sourceErr.code : undefined
         const provider =
           sourceErr && typeof sourceErr.provider === "string" ? sourceErr.provider : undefined
         const model = sourceErr && typeof sourceErr.model === "string" ? sourceErr.model : undefined
 
         const failureReason =
-          sourceErr && (message || category || provider || model)
+          sourceErr && (message || category || code || provider || model)
             ? {
                 message: message ?? "Unknown error",
                 category,
+                code,
                 provider,
                 model,
               }

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -1292,6 +1292,41 @@ function executionResultToJson(result: ExecutionResult): Record<string, unknown>
   }
 }
 
+function inferResourceFailureCode(text: string): string | undefined {
+  const lower = text.toLowerCase()
+
+  if (
+    lower.includes("429") ||
+    lower.includes("rate limit") ||
+    lower.includes("too many requests")
+  ) {
+    return "rate_limit"
+  }
+
+  if (lower.includes("quota") || lower.includes("insufficient_quota")) {
+    return "quota_exceeded"
+  }
+
+  if (lower.includes("timeout") || lower.includes("deadline") || lower.includes("timed out")) {
+    return "timeout"
+  }
+
+  if (
+    lower.includes("circuit breaker") ||
+    lower.includes("resource guard") ||
+    lower.includes("token budget") ||
+    lower.includes("tool call rate")
+  ) {
+    return "resource_guard"
+  }
+
+  if (lower.includes("cancel") || lower.includes("abort")) {
+    return "upstream_cancelled"
+  }
+
+  return undefined
+}
+
 function executionErrorToJobError(
   result: ExecutionResult,
   task: ExecutionTask,
@@ -1313,14 +1348,31 @@ function executionErrorToJobError(
               ? "TIMEOUT"
               : "UNKNOWN"
 
+    const inferredCode =
+      category === "RESOURCE" ? inferResourceFailureCode(result.error.message) : undefined
+
     return {
       category,
-      ...(result.error.code ? { code: result.error.code } : {}),
+      ...(result.error.code
+        ? { code: result.error.code }
+        : inferredCode
+          ? { code: inferredCode }
+          : {}),
       message: result.error.message,
       provider,
       model,
     }
   }
+
+  const message =
+    result.status === "cancelled"
+      ? result.summary || result.stderr || "Execution cancelled"
+      : result.summary || result.stderr || "Execution failed"
+
+  const inferredCode =
+    result.status === "cancelled"
+      ? (inferResourceFailureCode(message) ?? "upstream_cancelled")
+      : undefined
 
   return {
     category:
@@ -1329,10 +1381,8 @@ function executionErrorToJobError(
         : result.status === "cancelled"
           ? "RESOURCE"
           : "UNKNOWN",
-    message:
-      result.status === "cancelled"
-        ? "Execution cancelled"
-        : result.summary || result.stderr || "Execution failed",
+    ...(inferredCode ? { code: inferredCode } : {}),
+    message,
     provider,
     model,
   }


### PR DESCRIPTION
## Summary
- classify resource/cancellation failures into typed `code` values in worker job error mapping (`rate_limit`, `quota_exceeded`, `upstream_cancelled`, `timeout`, `resource_guard`)
- propagate `code` through dashboard job detail `failureReason`
- update channel preflight/user-message mapping to prefer typed reason text over generic fallbacks
- add regression tests for preflight and dashboard typed error propagation

Closes #695

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error messages for job failures with more specific codes for quota limits, rate limiting, timeouts, and upstream cancellations.
  * Improved dashboard display of job failure details with additional diagnostic codes to better identify failure causes and troubleshoot issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->