### PR TITLE
Fix steering API contract mismatch in dashboard (#701)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -715,7 +715,7 @@ components:
             type: https://cortex-plane.dev/errors/bad-request
             title: Bad Request
             status: 400
-            detail: "body/message must NOT have fewer than 1 characters"
+            detail: "body/instruction must NOT have fewer than 1 characters"
             instance: /agents/550e8400-e29b-41d4-a716-446655440000/steer
 
     Unauthorized:

--- a/packages/control-plane/src/__tests__/stream-routes.test.ts
+++ b/packages/control-plane/src/__tests__/stream-routes.test.ts
@@ -370,6 +370,22 @@ describe("POST /agents/:agentId/steer", () => {
     expect(msg.id).toBeDefined()
   })
 
+  it("rejects the legacy dashboard steer payload shape", async () => {
+    const { app } = await buildTestApp({})
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/steer",
+      headers: {
+        authorization: "Bearer session-123",
+        "content-type": "application/json",
+      },
+      payload: { message: "focus on tests", priority: "high" },
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+
   it("returns 409 if lifecycle.steerAsync throws", async () => {
     const steerAsyncFn = vi.fn().mockRejectedValue(new Error("Agent not in EXECUTING state"))
     const lifecycle = mockLifecycleManager({

--- a/packages/control-plane/src/routes/stream.ts
+++ b/packages/control-plane/src/routes/stream.ts
@@ -33,6 +33,12 @@ interface SteerBody {
   priority?: "normal" | "urgent"
 }
 
+interface SteerResponse {
+  steerEventId: string
+  acknowledged: boolean
+  incorporatedAtTurn?: number
+}
+
 // ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
@@ -138,6 +144,19 @@ export function streamRoutes(deps: StreamRouteDeps) {
               priority: { type: "string", enum: ["normal", "urgent"] },
             },
             required: ["instruction"],
+            additionalProperties: false,
+          },
+          response: {
+            200: {
+              type: "object",
+              properties: {
+                steerEventId: { type: "string" },
+                acknowledged: { type: "boolean" },
+                incorporatedAtTurn: { type: "integer", minimum: 1 },
+              },
+              required: ["steerEventId", "acknowledged"],
+              additionalProperties: false,
+            },
           },
         },
       },
@@ -205,11 +224,12 @@ export function streamRoutes(deps: StreamRouteDeps) {
               })
             }
 
-            return reply.status(200).send({
+            const response: SteerResponse = {
               steerEventId,
               acknowledged: ack.acknowledged,
               incorporatedAtTurn: ack.turnNumber,
-            })
+            }
+            return reply.status(200).send(response)
           } catch (error) {
             return reply.status(409).send({
               error: "conflict",
@@ -220,10 +240,11 @@ export function streamRoutes(deps: StreamRouteDeps) {
         }
 
         // No lifecycle manager — accept without acknowledgment
-        return reply.status(200).send({
+        const response: SteerResponse = {
           steerEventId,
           acknowledged: false,
-        })
+        }
+        return reply.status(200).send(response)
       },
     )
   }

--- a/packages/dashboard/fixtures/api-responses/action-responses.json
+++ b/packages/dashboard/fixtures/api-responses/action-responses.json
@@ -1,9 +1,8 @@
 {
   "steer": {
-    "steer_message_id": "steer-001",
-    "status": "accepted",
-    "agent_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    "priority": "high"
+    "steerEventId": "steer-001",
+    "acknowledged": true,
+    "incorporatedAtTurn": 7
   },
   "pause": {
     "agent_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",

--- a/packages/dashboard/src/__tests__/api-client.test.ts
+++ b/packages/dashboard/src/__tests__/api-client.test.ts
@@ -175,19 +175,18 @@ describe("API Client", () => {
 
     it("steerAgent sends POST with body", async () => {
       mockFetchResponse({
-        steer_message_id: "sm-1",
-        status: "accepted",
-        agent_id: "agent-1",
-        priority: "high",
+        steerEventId: "sm-1",
+        acknowledged: true,
+        incorporatedAtTurn: 3,
       })
 
-      await steerAgent("agent-1", { message: "focus on tests", priority: "high" })
+      await steerAgent("agent-1", { instruction: "focus on tests", priority: "urgent" })
 
       const [, opts] = vi.mocked(fetch).mock.calls[0]!
       expect(opts!.method).toBe("POST")
       expect(JSON.parse(opts!.body as string)).toEqual({
-        message: "focus on tests",
-        priority: "high",
+        instruction: "focus on tests",
+        priority: "urgent",
       })
     })
 
@@ -412,7 +411,7 @@ describe("API Client", () => {
       mockFetchResponse(problem, 409)
 
       try {
-        await steerAgent("a1", { message: "test" })
+        await steerAgent("a1", { instruction: "test" })
         expect.fail("should have thrown")
       } catch (err) {
         const apiErr = err as ApiError

--- a/packages/dashboard/src/__tests__/error-handling-audit.test.ts
+++ b/packages/dashboard/src/__tests__/error-handling-audit.test.ts
@@ -88,12 +88,12 @@ describe("Agent lifecycle API error propagation", () => {
   describe("steerAgent", () => {
     it("throws on server error", async () => {
       mockFetchResponse({ error: "Agent unavailable" }, 503)
-      await expect(steerAgent("agent-1", { message: "do something" })).rejects.toThrow()
+      await expect(steerAgent("agent-1", { instruction: "do something" })).rejects.toThrow()
     })
 
     it("throws on network failure", async () => {
       mockFetchRejection("fetch failed")
-      await expect(steerAgent("agent-1", { message: "do something" })).rejects.toThrow()
+      await expect(steerAgent("agent-1", { instruction: "do something" })).rejects.toThrow()
     })
   })
 })

--- a/packages/dashboard/src/__tests__/schema-contract.test.ts
+++ b/packages/dashboard/src/__tests__/schema-contract.test.ts
@@ -604,8 +604,8 @@ describe("API-Dashboard contract tests", () => {
   describe("POST /agents/:agentId/steer — SteerResponseSchema", () => {
     it("parses the fixture successfully", () => {
       const result = SteerResponseSchema.parse(actionResponsesFixture.steer)
-      expect(result.status).toBe("accepted")
-      expect(result.priority).toBe("high")
+      expect(result.acknowledged).toBe(true)
+      expect(result.incorporatedAtTurn).toBe(7)
     })
 
     it("does not silently drop fields", () => {

--- a/packages/dashboard/src/app/agents/[agentId]/page.tsx
+++ b/packages/dashboard/src/app/agents/[agentId]/page.tsx
@@ -659,7 +659,7 @@ function MobileSteerBar({ agentId }: { agentId: string }): React.JSX.Element {
     setSending(true)
     try {
       const { steerAgent: steer } = await import("@/lib/api-client")
-      await steer(agentId, { message: message.trim() })
+      await steer(agentId, { instruction: message.trim() })
       setMessage("")
     } catch {
       addToast("Failed to send steering instruction", "error")

--- a/packages/dashboard/src/components/agents/steer-input.tsx
+++ b/packages/dashboard/src/components/agents/steer-input.tsx
@@ -10,8 +10,8 @@ interface SteerInputProps {
 }
 
 export function SteerInput({ agentId, onStop }: SteerInputProps): React.JSX.Element {
-  const [message, setMessage] = useState("")
-  const [priority, setPriority] = useState<"normal" | "high">("normal")
+  const [instruction, setInstruction] = useState("")
+  const [priority, setPriority] = useState<"normal" | "urgent">("normal")
   const [sending, setSending] = useState(false)
   const [confirmation, setConfirmation] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -19,16 +19,18 @@ export function SteerInput({ agentId, onStop }: SteerInputProps): React.JSX.Elem
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault()
-      if (!message.trim() || sending) return
+      if (!instruction.trim() || sending) return
 
       setSending(true)
       setError(null)
       setConfirmation(null)
 
       try {
-        const res = await steerAgent(agentId, { message: message.trim(), priority })
-        setConfirmation(`Instruction accepted (${res.steer_message_id.slice(0, 8)})`)
-        setMessage("")
+        const res = await steerAgent(agentId, { instruction: instruction.trim(), priority })
+        setConfirmation(
+          `${res.acknowledged ? "Instruction incorporated" : "Instruction queued"} (${res.steerEventId.slice(0, 8)})`,
+        )
+        setInstruction("")
         setTimeout(() => setConfirmation(null), 4000)
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to send instruction")
@@ -36,7 +38,7 @@ export function SteerInput({ agentId, onStop }: SteerInputProps): React.JSX.Elem
         setSending(false)
       }
     },
-    [agentId, message, priority, sending],
+    [agentId, instruction, priority, sending],
   )
 
   return (
@@ -56,8 +58,8 @@ export function SteerInput({ agentId, onStop }: SteerInputProps): React.JSX.Elem
             Override Instruction
           </label>
           <textarea
-            value={message}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setMessage(e.target.value)}
+            value={instruction}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setInstruction(e.target.value)}
             placeholder="Enter steering instruction for the agent..."
             rows={4}
             disabled={sending}
@@ -69,20 +71,20 @@ export function SteerInput({ agentId, onStop }: SteerInputProps): React.JSX.Elem
         <label className="flex items-center gap-2 text-xs text-text-muted">
           <input
             type="checkbox"
-            checked={priority === "high"}
+            checked={priority === "urgent"}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setPriority(e.target.checked ? "high" : "normal")
+              setPriority(e.target.checked ? "urgent" : "normal")
             }
             className="rounded border-surface-border"
           />
-          <span className="font-medium">High Priority</span>
+          <span className="font-medium">Urgent Priority</span>
         </label>
 
         {/* Buttons */}
         <div className="flex gap-2">
           <button
             type="submit"
-            disabled={sending || !message.trim()}
+            disabled={sending || !instruction.trim()}
             className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-bold text-white shadow-lg shadow-primary/20 transition-all hover:bg-primary/90 disabled:opacity-50"
           >
             <span className="material-symbols-outlined text-[18px]">send</span>

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -149,8 +149,8 @@ export type {
 // ---------------------------------------------------------------------------
 
 export interface SteerRequest {
-  message: string
-  priority?: "normal" | "high"
+  instruction: string
+  priority?: "normal" | "urgent"
 }
 
 /** RFC 7807 Problem Details error body. */

--- a/packages/dashboard/src/lib/schemas/actions.ts
+++ b/packages/dashboard/src/lib/schemas/actions.ts
@@ -5,10 +5,9 @@ import { z } from "zod"
 // ---------------------------------------------------------------------------
 
 export const SteerResponseSchema = z.object({
-  steer_message_id: z.string(),
-  status: z.literal("accepted"),
-  agent_id: z.string(),
-  priority: z.enum(["normal", "high"]),
+  steerEventId: z.string(),
+  acknowledged: z.boolean(),
+  incorporatedAtTurn: z.number().int().min(1).optional(),
 })
 
 export const PauseResponseSchema = z.object({


### PR DESCRIPTION
Closes #701

## Summary
- Align dashboard steerAgent request payload with backend contract (`instruction`, `priority: normal|urgent`)
- Align dashboard steer response schema with backend response (`steerEventId`, `acknowledged`, optional `incorporatedAtTurn`)
- Update steering UI and mobile quick-steer path to send canonical request and render canonical acknowledgment
- Tighten control-plane route schema (no extra properties) and add explicit 200 response schema for steer endpoint
- Update tests and fixtures to cover the new shape and reject legacy payloads
- Refresh OpenAPI validation detail text for `instruction`

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the steering action request and response structures with refined field names and organization.
  * Changed steering priority option from "high" to "urgent" for improved clarity.
  * Response now includes acknowledgment status and event tracking information.

* **Documentation**
  * Updated API specification to reflect current validation error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->