### PR TITLE
fix(runtime): account llm limiter by logical turn

### DIFF
--- a/packages/control-plane/src/__tests__/agent-execute-circuit-breaker.test.ts
+++ b/packages/control-plane/src/__tests__/agent-execute-circuit-breaker.test.ts
@@ -460,6 +460,111 @@ describe("agent-execute circuit breaker wiring", () => {
     )
   })
 
+  it("accounts llm rate limiting by logical turn, not streamed text chunks", async () => {
+    const db = makeMockDb({
+      agent: {
+        id: "agent-1",
+        name: "TestAgent",
+        slug: "test-agent",
+        role: "developer",
+        description: null,
+        status: "ACTIVE",
+        model_config: {},
+        skill_config: {},
+        resource_limits: {
+          circuitBreaker: {
+            llmCallRateLimit: { maxCalls: 2, windowSeconds: 300 },
+          },
+        },
+        config: null,
+      },
+      recentJobs: [],
+    })
+
+    const events: OutputEvent[] = [
+      { type: "text", timestamp: new Date().toISOString(), content: "chunk 1" },
+      { type: "text", timestamp: new Date().toISOString(), content: "chunk 2" },
+      { type: "tool_use", timestamp: new Date().toISOString(), toolName: "grep", toolInput: {} },
+      {
+        type: "tool_result",
+        timestamp: new Date().toISOString(),
+        toolName: "grep",
+        output: "done",
+        isError: false,
+      },
+      { type: "text", timestamp: new Date().toISOString(), content: "chunk 3" },
+      { type: "text", timestamp: new Date().toISOString(), content: "chunk 4" },
+    ]
+
+    const handle = createMockHandle(createMockResult(), events)
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    expect((handle as unknown as { _cancelReason?: string })._cancelReason).toBeUndefined()
+  })
+
+  it("cancels execution when logical llm turns exceed the rate limit", async () => {
+    const db = makeMockDb({
+      agent: {
+        id: "agent-1",
+        name: "TestAgent",
+        slug: "test-agent",
+        role: "developer",
+        description: null,
+        status: "ACTIVE",
+        model_config: {},
+        skill_config: {},
+        resource_limits: {
+          circuitBreaker: {
+            llmCallRateLimit: { maxCalls: 2, windowSeconds: 300 },
+          },
+        },
+        config: null,
+      },
+      recentJobs: [],
+    })
+
+    const events: OutputEvent[] = [
+      { type: "text", timestamp: new Date().toISOString(), content: "turn 1 chunk 1" },
+      { type: "tool_use", timestamp: new Date().toISOString(), toolName: "grep", toolInput: {} },
+      {
+        type: "tool_result",
+        timestamp: new Date().toISOString(),
+        toolName: "grep",
+        output: "done",
+        isError: false,
+      },
+      { type: "text", timestamp: new Date().toISOString(), content: "turn 2 chunk 1" },
+      { type: "tool_use", timestamp: new Date().toISOString(), toolName: "read", toolInput: {} },
+      {
+        type: "tool_result",
+        timestamp: new Date().toISOString(),
+        toolName: "read",
+        output: "done",
+        isError: false,
+      },
+      { type: "text", timestamp: new Date().toISOString(), content: "turn 3 chunk 1" },
+    ]
+
+    const handle = createMockHandle(createMockResult(), events)
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    expect((handle as unknown as { _cancelReason: string })._cancelReason).toBe(
+      "llm_call_rate_exceeded",
+    )
+  })
+
   it("records tool errors from tool_result events", async () => {
     const db = makeMockDb({
       agent: {

--- a/packages/control-plane/src/lifecycle/__tests__/agent-circuit-breaker.test.ts
+++ b/packages/control-plane/src/lifecycle/__tests__/agent-circuit-breaker.test.ts
@@ -213,12 +213,12 @@ describe("AgentCircuitBreaker", () => {
   // LLM call rate limiting
   // -------------------------------------------------------------------------
 
-  describe("recordLlmCall", () => {
+  describe("recordLlmTurn", () => {
     it("allows calls within the rate limit", () => {
       const cb = new AgentCircuitBreaker("agent-1")
       const now = Date.now()
       for (let i = 0; i < DEFAULT_AGENT_CIRCUIT_BREAKER_CONFIG.llmCallRateLimit.maxCalls; i++) {
-        expect(cb.recordLlmCall(now + i)).toBe(true)
+        expect(cb.recordLlmTurn(now + i)).toBe(true)
       }
     })
 
@@ -226,9 +226,9 @@ describe("AgentCircuitBreaker", () => {
       const cb = new AgentCircuitBreaker("agent-1")
       const now = Date.now()
       for (let i = 0; i < DEFAULT_AGENT_CIRCUIT_BREAKER_CONFIG.llmCallRateLimit.maxCalls; i++) {
-        cb.recordLlmCall(now)
+        cb.recordLlmTurn(now)
       }
-      expect(cb.recordLlmCall(now)).toBe(false)
+      expect(cb.recordLlmTurn(now)).toBe(false)
     })
 
     it("allows calls after the window expires", () => {
@@ -236,10 +236,10 @@ describe("AgentCircuitBreaker", () => {
         llmCallRateLimit: { maxCalls: 2, windowSeconds: 5 },
       })
       const now = Date.now()
-      cb.recordLlmCall(now)
-      cb.recordLlmCall(now)
-      expect(cb.recordLlmCall(now)).toBe(false)
-      expect(cb.recordLlmCall(now + 6_000)).toBe(true)
+      cb.recordLlmTurn(now)
+      cb.recordLlmTurn(now)
+      expect(cb.recordLlmTurn(now)).toBe(false)
+      expect(cb.recordLlmTurn(now + 6_000)).toBe(true)
     })
   })
 

--- a/packages/control-plane/src/lifecycle/agent-circuit-breaker.ts
+++ b/packages/control-plane/src/lifecycle/agent-circuit-breaker.ts
@@ -112,10 +112,10 @@ export class AgentCircuitBreaker {
   }
 
   /**
-   * Record an LLM call. Returns `false` if the sliding-window rate limit
-   * has been exceeded.
+   * Record a logical LLM turn. Returns `false` if the sliding-window rate
+   * limit has been exceeded.
    */
-  recordLlmCall(now: number = Date.now()): boolean {
+  recordLlmTurn(now: number = Date.now()): boolean {
     this.pruneWindow(this.state.llmCallTimestamps, this.config.llmCallRateLimit.windowSeconds, now)
     if (this.state.llmCallTimestamps.length >= this.config.llmCallRateLimit.maxCalls) {
       return false

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -628,8 +628,9 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
           // ── Step 9: Stream events ──
           const cancelChecker = startCancelChecker(db, jobId, handle)
 
-          // Track LLM turn count (each text event = 1 turn)
+          // Track LLM turn count for steer acknowledgements and limiter accounting.
           let turnCount = 0
+          let llmTurnOpen = false
 
           // Register steer listener so mid-execution steers are consumed
           const unsubSteer = lifecycleManager
@@ -677,9 +678,14 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                 streamManager.broadcast(agent.id, "agent:output", ssePayload)
               }
 
-              // Track LLM turns (text events from the model)
-              if (event.type === "text") {
+              const startsLlmTurn = event.type === "text" || event.type === "tool_use"
+              const openedLlmTurn = startsLlmTurn && !llmTurnOpen
+              if (openedLlmTurn) {
+                llmTurnOpen = true
                 turnCount++
+              }
+              if (event.type === "tool_result" || event.type === "complete") {
+                llmTurnOpen = false
               }
 
               // ── Circuit breaker: mid-execution monitoring ──
@@ -694,10 +700,8 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                   void handle.cancel("tool_call_rate_exceeded")
                 }
               }
-              if (event.type === "text") {
-                if (!agentCB.recordLlmCall()) {
-                  void handle.cancel("llm_call_rate_exceeded")
-                }
+              if (openedLlmTurn && !agentCB.recordLlmTurn()) {
+                void handle.cancel("llm_call_rate_exceeded")
               }
               if (event.type === "tool_result" && event.isError) {
                 agentCB.recordToolError()


### PR DESCRIPTION
## Summary
- switch LLM limiter accounting in agent execution from per streamed text chunk to per logical model turn
- rename circuit-breaker API from `recordLlmCall` to `recordLlmTurn` to reflect semantics
- add regression coverage for chunk-heavy single turns and genuine over-limit multi-turn execution

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build

Closes #703


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases validating LLM rate limiting behavior at tool-use/tool-result boundaries
  * Verified execution cancellation when logical turn counts exceed configured limits

* **Bug Fixes**
  * LLM rate limiting now counts logical turns instead of individual text events, preventing false rate-limit triggers during multi-chunk streaming within a single tool cycle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->