### PR TITLE
fix: align session clear/reset semantics across API/UI/tests (#702)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2230,7 +2230,7 @@ paths:
 
     delete:
       operationId: clearSession
-      summary: Clear a session (delete messages, mark as ended)
+      summary: Clear a session (remove all messages, mark as ended)
       tags:
         - Sessions
       parameters:
@@ -2243,6 +2243,21 @@ paths:
       responses:
         "200":
           description: Session cleared.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, status, action]
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  status:
+                    type: string
+                    enum: [ended]
+                  action:
+                    type: string
+                    enum: [cleared]
         "404":
           description: Session not found.
 

--- a/packages/control-plane/src/__tests__/chat-session-crud.test.ts
+++ b/packages/control-plane/src/__tests__/chat-session-crud.test.ts
@@ -424,6 +424,7 @@ describe("Delete session → messages cleared, status ended", () => {
     expect(res.statusCode).toBe(200)
     expect(res.json().id).toBe(SESSION_ID)
     expect(res.json().status).toBe("ended")
+    expect(res.json().action).toBe("cleared")
 
     // Verify session_message rows were deleted
     expect(deleteFromFn).toHaveBeenCalledWith("session_message")

--- a/packages/control-plane/src/__tests__/session-routes.test.ts
+++ b/packages/control-plane/src/__tests__/session-routes.test.ts
@@ -232,6 +232,8 @@ describe("DELETE /sessions/:id", () => {
     const body = res.json()
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(body.status).toBe("ended")
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(body.action).toBe("cleared")
 
     // Should have deleted session messages
     // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/packages/control-plane/src/routes/sessions.ts
+++ b/packages/control-plane/src/routes/sessions.ts
@@ -197,7 +197,7 @@ export function sessionRoutes(deps: SessionRouteDeps) {
           return reply.status(404).send({ error: "not_found", message: "Session not found" })
         }
 
-        // Delete all messages (cascade) and mark session as ended
+        // Clear all messages and mark session as ended
         await db.deleteFrom("session_message").where("session_id", "=", sessionId).execute()
 
         await db
@@ -206,7 +206,7 @@ export function sessionRoutes(deps: SessionRouteDeps) {
           .where("id", "=", sessionId)
           .execute()
 
-        return reply.status(200).send({ id: sessionId, status: "ended" })
+        return reply.status(200).send({ id: sessionId, status: "ended", action: "cleared" })
       },
     )
   }

--- a/packages/dashboard/fixtures/api-responses/session-delete.json
+++ b/packages/dashboard/fixtures/api-responses/session-delete.json
@@ -1,4 +1,5 @@
 {
   "id": "sess-001",
-  "status": "ended"
+  "status": "ended",
+  "action": "cleared"
 }

--- a/packages/dashboard/src/__tests__/chat.test.ts
+++ b/packages/dashboard/src/__tests__/chat.test.ts
@@ -307,7 +307,7 @@ describe("Chat & Session API Client", () => {
 
   describe("deleteSession", () => {
     it("deletes a session", async () => {
-      mockFetchResponse({ id: "sess-1", status: "ended" })
+      mockFetchResponse({ id: "sess-1", status: "ended", action: "cleared" })
 
       const result = await deleteSession("sess-1")
 
@@ -329,7 +329,7 @@ import {
   type ChatMessageStatus,
   ChatResponseSchema,
   MessageListResponseSchema,
-  SessionDeleteResponseSchema,
+  SessionClearResponseSchema,
   SessionListResponseSchema,
   SessionMessageSchema,
   SessionSchema,
@@ -543,18 +543,19 @@ describe("Chat schemas", () => {
     })
   })
 
-  describe("SessionDeleteResponseSchema", () => {
+  describe("SessionClearResponseSchema", () => {
     it("parses delete response", () => {
-      const result = SessionDeleteResponseSchema.parse({
+      const result = SessionClearResponseSchema.parse({
         id: "sess-1",
         status: "ended",
+        action: "cleared",
       })
       expect(result.status).toBe("ended")
     })
 
     it("rejects wrong status", () => {
       expect(() =>
-        SessionDeleteResponseSchema.parse({
+        SessionClearResponseSchema.parse({
           id: "sess-1",
           status: "active",
         }),

--- a/packages/dashboard/src/__tests__/schema-contract.test.ts
+++ b/packages/dashboard/src/__tests__/schema-contract.test.ts
@@ -90,7 +90,7 @@ import {
 import {
   ChatResponseSchema,
   MessageListResponseSchema,
-  SessionDeleteResponseSchema,
+  SessionClearResponseSchema,
   SessionListResponseSchema,
   SessionMessageSchema,
   SessionSchema,
@@ -480,15 +480,15 @@ describe("API-Dashboard contract tests", () => {
     })
   })
 
-  describe("DELETE /sessions/:id — SessionDeleteResponseSchema", () => {
+  describe("DELETE /sessions/:id — SessionClearResponseSchema", () => {
     it("parses the fixture successfully", () => {
-      const result = SessionDeleteResponseSchema.parse(sessionDeleteFixture)
+      const result = SessionClearResponseSchema.parse(sessionDeleteFixture)
       expect(result.id).toBe("sess-001")
       expect(result.status).toBe("ended")
     })
 
     it("does not silently drop fields", () => {
-      assertContractMatch(SessionDeleteResponseSchema, sessionDeleteFixture, "SessionDelete")
+      assertContractMatch(SessionClearResponseSchema, sessionDeleteFixture, "SessionClear")
     })
   })
 

--- a/packages/dashboard/src/components/agents/chat-panel.tsx
+++ b/packages/dashboard/src/components/agents/chat-panel.tsx
@@ -8,7 +8,7 @@ import { useToast } from "@/components/layout/toast"
 import { useApiQuery } from "@/hooks/use-api"
 import type { ChatMessage } from "@/hooks/use-chat-api"
 import { useChatApi } from "@/hooks/use-chat-api"
-import { deleteSession, listAgentSessions, type Session } from "@/lib/api-client"
+import { clearSession, listAgentSessions, type Session } from "@/lib/api-client"
 import type { ChatMessageStatus } from "@/lib/schemas/chat"
 
 // ---------------------------------------------------------------------------
@@ -23,7 +23,7 @@ export function ChatPanel({ agentId }: ChatPanelProps): React.JSX.Element {
   const { addToast } = useToast()
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
   const [showSessions, setShowSessions] = useState(false)
-  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [clearError, setClearError] = useState<string | null>(null)
 
   // Fetch sessions
   const {
@@ -59,19 +59,19 @@ export function ChatPanel({ agentId }: ChatPanelProps): React.JSX.Element {
     [refetchSessions],
   )
 
-  const handleDeleteSession = useCallback(
+  const handleClearSession = useCallback(
     async (sessionId: string) => {
-      setDeleteError(null)
+      setClearError(null)
       try {
-        await deleteSession(sessionId)
+        await clearSession(sessionId)
         if (activeSessionId === sessionId) {
           setActiveSessionId(null)
         }
-        addToast("Session deleted", "success")
+        addToast("Session cleared", "success")
         void refetchSessions()
       } catch (err) {
-        const msg = err instanceof Error ? err.message : "Failed to delete session"
-        setDeleteError(msg)
+        const msg = err instanceof Error ? err.message : "Failed to clear session"
+        setClearError(msg)
         addToast(msg, "error")
       }
     },
@@ -111,12 +111,12 @@ export function ChatPanel({ agentId }: ChatPanelProps): React.JSX.Element {
 
       {/* Quarantine banner */}
       <QuarantineBanner agentId={agentId} />
-      {/* Delete error banner */}
-      {deleteError && (
+      {/* Clear error banner */}
+      {clearError && (
         <div className="flex items-center justify-between border-b border-red-200 bg-red-50 px-4 py-2 dark:border-red-800 dark:bg-red-900/20">
-          <span className="text-xs text-red-600 dark:text-red-400">{deleteError}</span>
+          <span className="text-xs text-red-600 dark:text-red-400">{clearError}</span>
           <button
-            onClick={() => setDeleteError(null)}
+            onClick={() => setClearError(null)}
             className="ml-2 text-xs font-medium text-red-500 hover:text-red-700 dark:hover:text-red-300"
           >
             Dismiss
@@ -131,7 +131,7 @@ export function ChatPanel({ agentId }: ChatPanelProps): React.JSX.Element {
           activeSessionId={activeSessionId}
           loading={sessionsLoading}
           onSelect={handleSelectSession}
-          onDelete={(id) => void handleDeleteSession(id)}
+          onClear={(id) => void handleClearSession(id)}
         />
       )}
 
@@ -156,15 +156,15 @@ function SessionList({
   activeSessionId,
   loading,
   onSelect,
-  onDelete,
+  onClear,
 }: {
   sessions: Session[]
   activeSessionId: string | null
   loading: boolean
   onSelect: (id: string) => void
-  onDelete: (id: string) => void
+  onClear: (id: string) => void
 }): React.JSX.Element {
-  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
+  const [confirmClearId, setConfirmClearId] = useState<string | null>(null)
 
   if (loading) {
     return (
@@ -206,19 +206,19 @@ function SessionList({
               {new Date(session.updated_at).toLocaleDateString()}
             </span>
           </button>
-          {confirmDeleteId === session.id ? (
+          {confirmClearId === session.id ? (
             <div className="flex items-center gap-1">
               <button
                 onClick={() => {
-                  onDelete(session.id)
-                  setConfirmDeleteId(null)
+                  onClear(session.id)
+                  setConfirmClearId(null)
                 }}
-                className="rounded px-1.5 py-0.5 text-[10px] font-medium text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20"
+                className="rounded px-1.5 py-0.5 text-[10px] font-medium text-amber-600 hover:bg-amber-50 dark:hover:bg-amber-900/20"
               >
-                Confirm
+                Clear
               </button>
               <button
-                onClick={() => setConfirmDeleteId(null)}
+                onClick={() => setConfirmClearId(null)}
                 className="rounded px-1.5 py-0.5 text-[10px] font-medium text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800"
               >
                 Cancel
@@ -226,10 +226,12 @@ function SessionList({
             </div>
           ) : (
             <button
-              onClick={() => setConfirmDeleteId(session.id)}
-              className="rounded p-1 text-slate-400 transition-colors hover:text-red-500"
+              onClick={() => setConfirmClearId(session.id)}
+              className="rounded p-1 text-slate-400 transition-colors hover:text-amber-500"
+              title="Clear session history"
+              aria-label="Clear session history"
             >
-              <span className="material-symbols-outlined text-sm">delete</span>
+              <span className="material-symbols-outlined text-sm">restart_alt</span>
             </button>
           )}
         </div>

--- a/packages/dashboard/src/components/agents/copilot-chat-panel.tsx
+++ b/packages/dashboard/src/components/agents/copilot-chat-panel.tsx
@@ -9,12 +9,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { QuarantineBanner } from "@/components/agents/quarantine-banner"
 import { useToast } from "@/components/layout/toast"
 import { useApiQuery } from "@/hooks/use-api"
-import {
-  deleteSession,
-  getSessionMessages,
-  listAgentSessions,
-  type Session,
-} from "@/lib/api-client"
+import { clearSession, getSessionMessages, listAgentSessions, type Session } from "@/lib/api-client"
 
 // ---------------------------------------------------------------------------
 // CopilotChatPanel — CopilotKit-powered chat UI for the agent detail page
@@ -28,7 +23,7 @@ export function CopilotChatPanel({ agentId }: CopilotChatPanelProps): React.JSX.
   const { addToast } = useToast()
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
   const [showSessions, setShowSessions] = useState(false)
-  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [clearError, setClearError] = useState<string | null>(null)
 
   // Fetch sessions
   const {
@@ -56,19 +51,19 @@ export function CopilotChatPanel({ agentId }: CopilotChatPanelProps): React.JSX.
     setShowSessions(false)
   }, [])
 
-  const handleDeleteSession = useCallback(
+  const handleClearSession = useCallback(
     async (sessionId: string) => {
-      setDeleteError(null)
+      setClearError(null)
       try {
-        await deleteSession(sessionId)
+        await clearSession(sessionId)
         if (activeSessionId === sessionId) {
           setActiveSessionId(null)
         }
-        addToast("Session deleted", "success")
+        addToast("Session cleared", "success")
         void refetchSessions()
       } catch (err) {
-        const msg = err instanceof Error ? err.message : "Failed to delete session"
-        setDeleteError(msg)
+        const msg = err instanceof Error ? err.message : "Failed to clear session"
+        setClearError(msg)
         addToast(msg, "error")
       }
     },
@@ -141,12 +136,12 @@ export function CopilotChatPanel({ agentId }: CopilotChatPanelProps): React.JSX.
       {/* Quarantine banner */}
       <QuarantineBanner agentId={agentId} />
 
-      {/* Delete error banner */}
-      {deleteError && (
+      {/* Clear error banner */}
+      {clearError && (
         <div className="flex items-center justify-between border-b border-red-200 bg-red-50 px-4 py-2 dark:border-red-800 dark:bg-red-900/20">
-          <span className="text-xs text-red-600 dark:text-red-400">{deleteError}</span>
+          <span className="text-xs text-red-600 dark:text-red-400">{clearError}</span>
           <button
-            onClick={() => setDeleteError(null)}
+            onClick={() => setClearError(null)}
             className="ml-2 text-xs font-medium text-red-500 hover:text-red-700 dark:hover:text-red-300"
           >
             Dismiss
@@ -161,7 +156,7 @@ export function CopilotChatPanel({ agentId }: CopilotChatPanelProps): React.JSX.
           activeSessionId={activeSessionId}
           loading={sessionsLoading}
           onSelect={handleSelectSession}
-          onDelete={(id) => void handleDeleteSession(id)}
+          onClear={(id) => void handleClearSession(id)}
         />
       )}
 
@@ -198,15 +193,15 @@ function SessionList({
   activeSessionId,
   loading,
   onSelect,
-  onDelete,
+  onClear,
 }: {
   sessions: Session[]
   activeSessionId: string | null
   loading: boolean
   onSelect: (id: string) => void
-  onDelete: (id: string) => void
+  onClear: (id: string) => void
 }): React.JSX.Element {
-  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
+  const [confirmClearId, setConfirmClearId] = useState<string | null>(null)
 
   if (loading) {
     return (
@@ -248,19 +243,19 @@ function SessionList({
               {new Date(session.updated_at).toLocaleDateString()}
             </span>
           </button>
-          {confirmDeleteId === session.id ? (
+          {confirmClearId === session.id ? (
             <div className="flex items-center gap-1">
               <button
                 onClick={() => {
-                  onDelete(session.id)
-                  setConfirmDeleteId(null)
+                  onClear(session.id)
+                  setConfirmClearId(null)
                 }}
-                className="rounded px-1.5 py-0.5 text-[10px] font-medium text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20"
+                className="rounded px-1.5 py-0.5 text-[10px] font-medium text-amber-600 hover:bg-amber-50 dark:hover:bg-amber-900/20"
               >
-                Confirm
+                Clear
               </button>
               <button
-                onClick={() => setConfirmDeleteId(null)}
+                onClick={() => setConfirmClearId(null)}
                 className="rounded px-1.5 py-0.5 text-[10px] font-medium text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800"
               >
                 Cancel
@@ -268,10 +263,12 @@ function SessionList({
             </div>
           ) : (
             <button
-              onClick={() => setConfirmDeleteId(session.id)}
-              className="rounded p-1 text-slate-400 transition-colors hover:text-red-500"
+              onClick={() => setConfirmClearId(session.id)}
+              className="rounded p-1 text-slate-400 transition-colors hover:text-amber-500"
+              title="Clear session history"
+              aria-label="Clear session history"
             >
-              <span className="material-symbols-outlined text-sm">delete</span>
+              <span className="material-symbols-outlined text-sm">restart_alt</span>
             </button>
           )}
         </div>

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -1124,7 +1124,7 @@ export async function getPendingCounts(): Promise<import("./schemas/users").Pend
 import {
   ChatResponseSchema,
   MessageListResponseSchema,
-  SessionDeleteResponseSchema,
+  SessionClearResponseSchema,
   SessionListResponseSchema,
 } from "./schemas/chat"
 
@@ -1179,12 +1179,17 @@ export async function sendChatMessage(
   })
 }
 
-export async function deleteSession(sessionId: string): Promise<{ id: string; status: "ended" }> {
+export async function clearSession(
+  sessionId: string,
+): Promise<{ id: string; status: "ended"; action: "cleared" }> {
   return apiFetch(`/sessions/${sessionId}`, {
     method: "DELETE",
-    schema: SessionDeleteResponseSchema,
+    schema: SessionClearResponseSchema,
   })
 }
+
+/** @deprecated Use clearSession() — endpoint semantics are clear/reset, not hard delete. */
+export const deleteSession = clearSession
 
 /**
  * Poll the status of a chat job. Used for non-blocking chat flow where the

--- a/packages/dashboard/src/lib/schemas/chat.ts
+++ b/packages/dashboard/src/lib/schemas/chat.ts
@@ -82,7 +82,11 @@ export const ChatResponseSchema = z.object({
 
 export type ChatResponse = z.infer<typeof ChatResponseSchema>
 
-export const SessionDeleteResponseSchema = z.object({
+export const SessionClearResponseSchema = z.object({
   id: z.string(),
   status: z.literal("ended"),
+  action: z.literal("cleared"),
 })
+
+// Backward-compatible alias (deprecated name)
+export const SessionDeleteResponseSchema = SessionClearResponseSchema


### PR DESCRIPTION
## Summary
Fixes #702 by standardizing DELETE /sessions/:id as **clear/reset** (not hard delete) semantics across backend, API contract, dashboard UI, and tests.

## What changed
- Backend route now returns explicit clear action payload: `{ id, status: "ended", action: "cleared" }`.
- OpenAPI docs updated to describe clear/reset semantics and response schema.
- Dashboard API client now uses `clearSession()` (with deprecated alias `deleteSession`).
- Dashboard schema updated to `SessionClearResponseSchema` (with backward alias).
- Chat and Copilot chat panels updated copy/actions from delete wording to clear wording.
- Fixtures + contract/unit/integration tests updated accordingly.

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build

All passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **User Interface**
  * Updated session management terminology from "delete" to "clear" throughout the app.
  * Changed action button icon and styling to reflect clearing rather than deletion.
  * Updated confirmation messages and success notifications from "Session deleted" to "Session cleared."

* **Documentation**
  * Updated API documentation to clarify session clearing behavior and response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->