### PR TITLE
test(extensibility): add browser+MCP verification matrix (#706)

### DIFF
--- a/docs/audits/extensibility-verification-matrix-2026-03-21.md
+++ b/docs/audits/extensibility-verification-matrix-2026-03-21.md
@@ -24,28 +24,28 @@ pnpm --filter @cortex/control-plane test -- --runInBand \
 
 ### Browser tooling
 
-| Check | Result | Evidence |
-|---|---|---|
-| Steering/action endpoint contract + runtime execution | ✅ PASS | `stream-routes.test.ts`, `schema-contract.test.ts` (`SteerResponseSchema`) |
-| Auth handoff behavior | ✅ PASS | `streaming/types.ts` (`browser:auth:handoff`), `oauth-popup.test.ts` |
-| Trace/event propagation to UI | ⚠️ PARTIAL | Trace flow validated; screenshot/event history endpoints remain stub-empty in `dashboard-feature-audit.test.ts` |
-| Failure paths (auth, invalid action, timeout) | ✅ PASS | `stream-routes.test.ts`, `api-client.test.ts`, `error-handling-audit.test.ts` |
+| Check                                                 | Result     | Evidence                                                                                                        |
+| ----------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------- |
+| Steering/action endpoint contract + runtime execution | ✅ PASS    | `stream-routes.test.ts`, `schema-contract.test.ts` (`SteerResponseSchema`)                                      |
+| Auth handoff behavior                                 | ✅ PASS    | `streaming/types.ts` (`browser:auth:handoff`), `oauth-popup.test.ts`                                            |
+| Trace/event propagation to UI                         | ⚠️ PARTIAL | Trace flow validated; screenshot/event history endpoints remain stub-empty in `dashboard-feature-audit.test.ts` |
+| Failure paths (auth, invalid action, timeout)         | ✅ PASS    | `stream-routes.test.ts`, `api-client.test.ts`, `error-handling-audit.test.ts`                                   |
 
 ### MCP
 
-| Check | Result | Evidence |
-|---|---|---|
-| MCP server binding + credential resolution | ✅ PASS | dashboard bindings + `mcp-tool-router.test.ts` |
-| Tool invocation from agent execution path | ⚠️ PARTIAL | Router-level execution proven; missing full integrated worker-path assertion |
-| Result propagation to job/session output | ⚠️ PARTIAL | Stream contracts covered; needs explicit integrated MCP output assertion |
-| Failure paths (missing creds, denied tool, timeout) | ✅ PASS (layered), ⚠️ PARTIAL (full e2e) | unit/layer coverage exists, full worker→UI propagation test pending |
+| Check                                               | Result                                   | Evidence                                                                     |
+| --------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| MCP server binding + credential resolution          | ✅ PASS                                  | dashboard bindings + `mcp-tool-router.test.ts`                               |
+| Tool invocation from agent execution path           | ⚠️ PARTIAL                               | Router-level execution proven; missing full integrated worker-path assertion |
+| Result propagation to job/session output            | ⚠️ PARTIAL                               | Stream contracts covered; needs explicit integrated MCP output assertion     |
+| Failure paths (missing creds, denied tool, timeout) | ✅ PASS (layered), ⚠️ PARTIAL (full e2e) | unit/layer coverage exists, full worker→UI propagation test pending          |
 
 ### Operator surface
 
-| Check | Result | Evidence |
-|---|---|---|
-| UI shows actionable errors | ✅ PASS | `error-handling-audit.test.ts` |
-| Endpoint responses match dashboard schemas | ✅ PASS | `schema-contract.test.ts` |
+| Check                                      | Result  | Evidence                       |
+| ------------------------------------------ | ------- | ------------------------------ |
+| UI shows actionable errors                 | ✅ PASS | `error-handling-audit.test.ts` |
+| Endpoint responses match dashboard schemas | ✅ PASS | `schema-contract.test.ts`      |
 
 ## Gap Tickets
 

--- a/packages/dashboard/src/__tests__/extensibility-verification-matrix.test.ts
+++ b/packages/dashboard/src/__tests__/extensibility-verification-matrix.test.ts
@@ -4,7 +4,10 @@ import { resolve } from "node:path"
 import { describe, expect, it } from "vitest"
 
 describe("extensibility verification matrix artifact", () => {
-  const matrixPath = resolve(process.cwd(), "../../docs/audits/extensibility-verification-matrix-2026-03-21.md")
+  const matrixPath = resolve(
+    process.cwd(),
+    "../../docs/audits/extensibility-verification-matrix-2026-03-21.md",
+  )
   const matrix = readFileSync(matrixPath, "utf8")
 
   it("links to issue #706 and scope", () => {


### PR DESCRIPTION
## Summary
Implements #706 by adding an explicit in-repo extensibility verification matrix that distinguishes API/schema alignment from runtime end-to-end readiness for browser tooling and MCP surfaces.

## What changed
- Added `docs/audits/extensibility-verification-matrix-2026-03-21.md` with:
  - pass/partial matrix across browser, MCP, and operator surface checks
  - reproducible verification commands
  - evidence references to existing tests/routes
  - explicit follow-up gaps linked as tickets
- Added `packages/dashboard/src/__tests__/extensibility-verification-matrix.test.ts` to guard the matrix artifact and follow-up issue linkage.
- Filed follow-up tickets for partial checks:
  - #711 browser screenshot/event runtime persistence
  - #712 MCP full execution-path integration test
  - #713 MCP failure-path propagation integration test

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

All commands passed.

Fixes #706


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an extensibility verification matrix documenting browser tooling, MCP runtime checks, verification statuses, evidence references, gap tickets, and an acceptance checklist.

* **Tests**
  * Added tests to assert the new audit document includes key headings, PASS/PARTIAL markers, and referenced follow-up tickets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->