### PR TITLE
fix: truthful runtime capability disclosure for agent execution

### DIFF
--- a/packages/control-plane/src/__tests__/agent-execute-credential-wiring.test.ts
+++ b/packages/control-plane/src/__tests__/agent-execute-credential-wiring.test.ts
@@ -18,6 +18,7 @@ import type {
 import { describe, expect, it, vi } from "vitest"
 
 import type { CredentialService } from "../auth/credential-service.js"
+import { ToolRegistry } from "../backends/tool-executor.js"
 import { type AgentExecuteDeps, createAgentExecuteTask } from "../worker/tasks/agent-execute.js"
 
 // ---------------------------------------------------------------------------
@@ -168,6 +169,39 @@ function makeMockRegistry(handle: ExecutionHandle = createMockHandle()) {
       routeTask: vi.fn().mockReturnValue({
         backend: {
           backendId: "mock-backend",
+          executeTask: executeTaskSpy,
+        },
+        providerId: "mock-provider",
+      }),
+      acquirePermit: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      recordOutcome: vi.fn(),
+    } as unknown as BackendRegistry,
+    executeTaskSpy,
+  }
+}
+
+function makeMockRegistryWithAgentRegistry(handle: ExecutionHandle = createMockHandle()) {
+  const executeTaskSpy = vi.fn().mockResolvedValue(handle)
+  const agentRegistry = new ToolRegistry()
+  agentRegistry.register({
+    name: "web_search",
+    description: "search",
+    inputSchema: { type: "object" },
+    execute: vi.fn().mockResolvedValue("ok"),
+  })
+  agentRegistry.register({
+    name: "mcp:filesystem:read_file",
+    description: "read",
+    inputSchema: { type: "object" },
+    execute: vi.fn().mockResolvedValue("ok"),
+  })
+
+  return {
+    registry: {
+      routeTask: vi.fn().mockReturnValue({
+        backend: {
+          backendId: "mock-backend",
+          createAgentRegistry: vi.fn().mockResolvedValue(agentRegistry),
           executeTask: executeTaskSpy,
         },
         providerId: "mock-provider",
@@ -409,7 +443,55 @@ describe("agent-execute credential wiring (#444)", () => {
 
     // Task should be dispatched, just without llmCredential
     expect(executeTaskSpy).toHaveBeenCalled()
-    const executedTask = executeTaskSpy.mock.calls[0][0] as ExecutionTask
+    const executedTask = executeTaskSpy.mock.calls[0]![0] as ExecutionTask
     expect(executedTask.constraints.llmCredential).toBeUndefined()
+  })
+
+  it("injects truthful runtime capability disclosure into the execution system prompt", async () => {
+    const db = makeMockDb()
+    const { registry, executeTaskSpy } = makeMockRegistry()
+
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    const executedTask = executeTaskSpy.mock.calls[0]![0] as ExecutionTask
+    expect(executedTask.context.systemPrompt).toContain("Runtime capability disclosure:")
+    expect(executedTask.context.systemPrompt).toContain("Workspace root: /workspace.")
+    expect(executedTask.context.systemPrompt).toContain(
+      "Filesystem scope: this run is configured with /workspace as its workspace root.",
+    )
+    expect(executedTask.context.systemPrompt).toContain(
+      "MCP tools exposed by Cortex: unavailable for this run.",
+    )
+    expect(executedTask.context.systemPrompt).toContain(
+      "OS command availability: unknown until verified in this runtime.",
+    )
+  })
+
+  it("uses the actual resolved registry to disclose MCP availability", async () => {
+    const db = makeMockDb()
+    const { registry, executeTaskSpy } = makeMockRegistryWithAgentRegistry()
+
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    const executedTask = executeTaskSpy.mock.calls[0]![0] as ExecutionTask
+    expect(executedTask.context.systemPrompt).toContain(
+      "MCP tools exposed by Cortex: available (mcp:filesystem:read_file).",
+    )
+    expect(executedTask.context.systemPrompt).toContain(
+      "Browser tools exposed by Cortex: unavailable for this run.",
+    )
+    expect(executedTask.context.systemPrompt).toContain(
+      "Exposed tool names: mcp:filesystem:read_file, web_search.",
+    )
   })
 })

--- a/packages/control-plane/src/__tests__/runtime-capability-disclosure.test.ts
+++ b/packages/control-plane/src/__tests__/runtime-capability-disclosure.test.ts
@@ -1,0 +1,90 @@
+import type { ExecutionTask } from "@cortex/shared/backends"
+import { describe, expect, it } from "vitest"
+
+import { buildRuntimeCapabilityDisclosure } from "../worker/runtime-capability-disclosure.js"
+
+function makeTask(overrides?: Partial<ExecutionTask>): ExecutionTask {
+  return {
+    id: "task-1",
+    jobId: "job-1",
+    agentId: "agent-1",
+    instruction: {
+      prompt: "test",
+      goalType: "research",
+    },
+    context: {
+      workspacePath: "/workspace/project",
+      systemPrompt: "You are a test agent.",
+      memories: [],
+      relevantFiles: {},
+      environment: {},
+    },
+    constraints: {
+      timeoutMs: 30_000,
+      maxTokens: 4096,
+      model: "claude-sonnet-4-5",
+      allowedTools: [],
+      deniedTools: [],
+      maxTurns: 1,
+      networkAccess: true,
+      shellAccess: true,
+    },
+    ...overrides,
+  }
+}
+
+describe("runtime capability disclosure", () => {
+  it("reports actual MCP and browser tools when runtime tool names are known", () => {
+    const disclosure = buildRuntimeCapabilityDisclosure({
+      task: makeTask(),
+      actualToolNames: ["mcp:filesystem:read_file", "playwright_navigate", "web_search"],
+    })
+
+    expect(disclosure).toContain("Workspace root: /workspace/project.")
+    expect(disclosure).toContain(
+      "Filesystem scope: this run is configured with /workspace/project as its workspace root.",
+    )
+    expect(disclosure).toContain(
+      "MCP tools exposed by Cortex: available (mcp:filesystem:read_file).",
+    )
+    expect(disclosure).toContain(
+      "Browser tools exposed by Cortex: available (playwright_navigate).",
+    )
+    expect(disclosure).toContain("OS command availability: unknown until verified in this runtime.")
+  })
+
+  it("surfaces unknown states when the worker has no runtime tool evidence", () => {
+    const disclosure = buildRuntimeCapabilityDisclosure({
+      task: makeTask(),
+    })
+
+    expect(disclosure).toContain("MCP tools exposed by Cortex: unknown.")
+    expect(disclosure).toContain("Browser tools exposed by Cortex: unknown.")
+    expect(disclosure).toContain("Exposed tool names: unknown.")
+    expect(disclosure).toContain("If a capability is unknown, say it is unknown")
+  })
+
+  it("does not bluff about curl or installation when shell access is disabled", () => {
+    const disclosure = buildRuntimeCapabilityDisclosure({
+      task: makeTask({
+        constraints: {
+          ...makeTask().constraints,
+          shellAccess: false,
+          networkAccess: false,
+        },
+      }),
+      actualToolNames: [],
+    })
+
+    expect(disclosure).toContain("Network access: unavailable.")
+    expect(disclosure).toContain("Shell execution: unavailable.")
+    expect(disclosure).toContain("MCP tools exposed by Cortex: unavailable for this run.")
+    expect(disclosure).toContain("Browser tools exposed by Cortex: unavailable for this run.")
+    expect(disclosure).toContain(
+      "OS command availability: unavailable because shell execution is disabled.",
+    )
+    expect(disclosure).toContain(
+      "Do not claim curl, package installation, or arbitrary command access.",
+    )
+  })
+})

--- a/packages/control-plane/src/backends/tool-executor.ts
+++ b/packages/control-plane/src/backends/tool-executor.ts
@@ -37,6 +37,10 @@ export class ToolRegistry {
     return this.tools.get(name)
   }
 
+  list(): ToolDefinition[] {
+    return [...this.tools.values()]
+  }
+
   /**
    * Return tool definitions filtered by the task's allowed/denied lists.
    * Per the TaskConstraints contract, an empty allowedTools array means

--- a/packages/control-plane/src/worker/runtime-capability-disclosure.ts
+++ b/packages/control-plane/src/worker/runtime-capability-disclosure.ts
@@ -1,0 +1,117 @@
+import type { ExecutionTask } from "@cortex/shared/backends"
+
+type CapabilityState = "available" | "unavailable" | "unknown"
+
+const BROWSER_TOOL_PATTERN = /(browser|playwright|chrome|chromium|cdp)/i
+
+export interface RuntimeCapabilityDisclosureInput {
+  task: ExecutionTask
+  actualToolNames?: string[]
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b))
+}
+
+function summarizeToolNames(names: string[]): string {
+  if (names.length === 0) return "none"
+  const shown = names.slice(0, 5)
+  const suffix = names.length > shown.length ? ` (+${names.length - shown.length} more)` : ""
+  return `${shown.join(", ")}${suffix}`
+}
+
+function classifyToolState(
+  actualToolNames: string[] | undefined,
+  predicate: (toolName: string) => boolean,
+): { state: CapabilityState; matchingTools: string[] } {
+  if (!actualToolNames) {
+    return { state: "unknown", matchingTools: [] }
+  }
+
+  const matchingTools = actualToolNames.filter(predicate)
+  if (matchingTools.length > 0) {
+    return { state: "available", matchingTools: uniqueSorted(matchingTools) }
+  }
+
+  return { state: "unavailable", matchingTools: [] }
+}
+
+function buildMcpLine(actualToolNames: string[] | undefined): string {
+  const mcp = classifyToolState(actualToolNames, (toolName) => toolName.startsWith("mcp:"))
+  if (mcp.state === "available") {
+    return `- MCP tools exposed by Cortex: available (${summarizeToolNames(mcp.matchingTools)}).`
+  }
+  if (mcp.state === "unavailable") {
+    return "- MCP tools exposed by Cortex: unavailable for this run."
+  }
+  return "- MCP tools exposed by Cortex: unknown."
+}
+
+function buildBrowserLine(actualToolNames: string[] | undefined): string {
+  const browser = classifyToolState(actualToolNames, (toolName) =>
+    BROWSER_TOOL_PATTERN.test(toolName),
+  )
+  if (browser.state === "available") {
+    return `- Browser tools exposed by Cortex: available (${summarizeToolNames(browser.matchingTools)}).`
+  }
+  if (browser.state === "unavailable") {
+    return "- Browser tools exposed by Cortex: unavailable for this run."
+  }
+  return "- Browser tools exposed by Cortex: unknown."
+}
+
+function buildCommandAvailabilityLine(shellAccess: boolean): string {
+  if (!shellAccess) {
+    return (
+      "- OS command availability: unavailable because shell execution is disabled. " +
+      "Do not claim curl, package installation, or arbitrary command access."
+    )
+  }
+
+  return (
+    "- OS command availability: unknown until verified in this runtime. " +
+    "Do not claim curl, package installation, or arbitrary filesystem access without evidence."
+  )
+}
+
+export function listToolNamesFromRegistryLike(registry: {
+  list: () => Array<{ name: string }>
+}): string[] {
+  return uniqueSorted(registry.list().map((tool) => tool.name))
+}
+
+export function buildRuntimeCapabilityDisclosure(input: RuntimeCapabilityDisclosureInput): string {
+  const actualToolNames = input.actualToolNames ? uniqueSorted(input.actualToolNames) : undefined
+  const { task } = input
+
+  const lines = [
+    "Runtime capability disclosure:",
+    `- Workspace root: ${task.context.workspacePath}.`,
+    `- Filesystem scope: this run is configured with ${task.context.workspacePath} as its workspace root. Access outside that workspace is unknown unless verified during execution.`,
+    `- Network access: ${task.constraints.networkAccess ? "available" : "unavailable"}.`,
+    `- Shell execution: ${task.constraints.shellAccess ? "available" : "unavailable"}.`,
+    buildMcpLine(actualToolNames),
+    buildBrowserLine(actualToolNames),
+    buildCommandAvailabilityLine(task.constraints.shellAccess),
+  ]
+
+  if (actualToolNames) {
+    lines.push(`- Exposed tool names: ${summarizeToolNames(actualToolNames)}.`)
+  } else {
+    lines.push("- Exposed tool names: unknown.")
+  }
+
+  lines.push("- If a capability is unknown, say it is unknown and verify before claiming it.")
+
+  return lines.join("\n")
+}
+
+export function appendRuntimeCapabilityDisclosure(
+  systemPrompt: string,
+  input: RuntimeCapabilityDisclosureInput,
+): string {
+  const disclosure = buildRuntimeCapabilityDisclosure(input)
+  return systemPrompt.includes("Runtime capability disclosure:")
+    ? systemPrompt
+    : `${systemPrompt}\n\n${disclosure}`
+}

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -52,6 +52,10 @@ import { classifyError, isConfigErrorCategory } from "../error-classifier.js"
 import { startHeartbeat } from "../heartbeat.js"
 import { createMemoryScheduler } from "../memory-scheduler.js"
 import { calculateRunAt } from "../retry.js"
+import {
+  appendRuntimeCapabilityDisclosure,
+  listToolNamesFromRegistryLike,
+} from "../runtime-capability-disclosure.js"
 
 export interface AgentExecutePayload {
   jobId: string
@@ -522,6 +526,13 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
               jobId: job.id,
               userId,
             })
+            task.context.systemPrompt = appendRuntimeCapabilityDisclosure(
+              task.context.systemPrompt,
+              {
+                task,
+                actualToolNames: effectiveTools.map((tool) => tool.toolRef),
+              },
+            )
 
             handle = await (
               backend as {
@@ -559,6 +570,21 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                 createAgentRegistry: (c: Record<string, unknown>, m?: unknown) => Promise<unknown>
               }
             ).createAgentRegistry(agent.config ?? {}, mcpDeps)
+            task.context.systemPrompt = appendRuntimeCapabilityDisclosure(
+              task.context.systemPrompt,
+              {
+                task,
+                actualToolNames:
+                  typeof agentRegistry === "object" &&
+                  agentRegistry !== null &&
+                  "list" in agentRegistry &&
+                  typeof agentRegistry.list === "function"
+                    ? listToolNamesFromRegistryLike(
+                        agentRegistry as { list: () => Array<{ name: string }> },
+                      )
+                    : undefined,
+              },
+            )
             handle = await (
               backend as {
                 executeTask: (
@@ -569,6 +595,13 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
               }
             ).executeTask(task, agentRegistry, tokenRefresher)
           } else {
+            task.context.systemPrompt = appendRuntimeCapabilityDisclosure(
+              task.context.systemPrompt,
+              {
+                task,
+                actualToolNames: task.constraints.allowedTools,
+              },
+            )
             handle = await backend.executeTask(task)
           }
 

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,7 @@
     }
   },
   "globalEnv": [
+    "CAPABILITY_MODEL_V2",
     "TELEGRAM_BOT_TOKEN",
     "TELEGRAM_ALLOWED_USERS",
     "DISCORD_BOT_TOKEN",


### PR DESCRIPTION
## Summary\n- add runtime capability disclosure builder that reports workspace scope and capability states as available/unavailable/unknown based on runtime evidence\n- inject disclosure into execution system prompts for capability-v2, legacy createAgentRegistry, and direct executeTask backends\n- expose ToolRegistry.list() so resolved registry tool names can be disclosed accurately\n- add focused tests for disclosure logic and worker integration paths\n\nCloses #719\n\n## Validation\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now receive runtime capability disclosure, transparently detailing available tools, access permissions for filesystem and network operations, shell execution capabilities, and runtime constraints.

* **Tests**
  * Added comprehensive test coverage validating runtime capability disclosure across different runtime configurations and agent execution paths with varying tool availability scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->