### PR TITLE
fix(auth): verify Anthropic OAuth connections correctly (#722)

### DIFF
--- a/docs/AUTH-PROVIDERS.md
+++ b/docs/AUTH-PROVIDERS.md
@@ -69,6 +69,13 @@ Current behavior:
 - Credential status is marked as failing (`status=error` with `last_error`) so the UI
   does not present it as healthy/connected.
 
+### Anthropic OAuth verification note (Issue #722)
+
+Anthropic's `GET /v1/models` verification path expects the OAuth-issued token on
+`x-api-key`, matching the runtime and model-discovery contract. Sending the same
+token as `Authorization: Bearer ...` produces HTTP 401 and can make a callback-
+complete credential look connected until verification failure is surfaced.
+
 ## LLM Providers — API Key
 
 | Provider         | How to Add                    | Storage         |

--- a/packages/control-plane/src/__tests__/credential-service.test.ts
+++ b/packages/control-plane/src/__tests__/credential-service.test.ts
@@ -7,7 +7,7 @@ vi.hoisted(() => {
 })
 
 import type { Kysely } from "kysely"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   deriveMasterKey,
@@ -68,6 +68,11 @@ function makeCredRow(overrides: Partial<ProviderCredential> = {}): ProviderCrede
 const AUTH_CONFIG = {
   credentialMasterKey: MASTER_PASSPHRASE,
 } as Parameters<typeof CredentialService.prototype.constructor>[1]
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
 
 /**
  * Build a chainable Kysely mock.
@@ -905,5 +910,40 @@ describe("getConfiguredProviders", () => {
 
   it("returns empty array when authConfig is undefined", () => {
     expect(getConfiguredProviders(undefined)).toEqual([])
+  })
+})
+
+describe("CredentialService.testCredential", () => {
+  it("verifies Anthropic OAuth credentials with x-api-key instead of Bearer", async () => {
+    const oauthToken = "anthropic-oauth-token"
+    const cred = makeCredRow({
+      provider: "anthropic",
+      credential_type: "oauth",
+      api_key_enc: null,
+      access_token_enc: encryptCredential(oauthToken, USER_KEY),
+      refresh_token_enc: null,
+    })
+    const { db } = buildMockDb({ existingCred: cred, updatedCred: cred })
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const service = new CredentialService(db, AUTH_CONFIG)
+    const result = await service.testCredential(ADMIN_USER_ID, CRED_ID)
+
+    expect(result.status).toBe("connected")
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.anthropic.com/v1/models")
+    expect(init.method).toBe("GET")
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+    expect(init.headers).toMatchObject({
+      "x-api-key": oauthToken,
+      "anthropic-version": "2023-06-01",
+    })
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined()
   })
 })

--- a/packages/control-plane/src/auth/credential-service.ts
+++ b/packages/control-plane/src/auth/credential-service.ts
@@ -1038,7 +1038,7 @@ export class CredentialService {
     }
 
     // Make a lightweight provider-specific health check
-    const result = await this.pingProvider(cred.provider, token, cred.credential_type)
+    const result = await this.pingProvider(cred.provider, token)
 
     // Update credential status based on test result
     if (result.status === "connected") {
@@ -1091,10 +1091,9 @@ export class CredentialService {
   private async pingProvider(
     provider: string,
     token: string,
-    credentialType: string,
   ): Promise<{ status: "connected" | "auth_failed" | "rate_limited" | "error"; message: string }> {
     try {
-      const { url, init } = this.buildProviderPing(provider, token, credentialType)
+      const { url, init } = this.buildProviderPing(provider, token)
       const controller = new AbortController()
       const timeout = setTimeout(() => controller.abort(), 10_000)
 
@@ -1127,11 +1126,7 @@ export class CredentialService {
     }
   }
 
-  private buildProviderPing(
-    provider: string,
-    token: string,
-    credentialType: string,
-  ): { url: string; init: RequestInit } {
+  private buildProviderPing(provider: string, token: string): { url: string; init: RequestInit } {
     switch (provider) {
       case "openai":
       case "openai-codex":
@@ -1145,9 +1140,10 @@ export class CredentialService {
           init: {
             method: "GET",
             headers: {
-              ...(credentialType === "api_key"
-                ? { "x-api-key": token }
-                : { Authorization: `Bearer ${token}` }),
+              // Anthropic expects the token on x-api-key for /v1/models even
+              // when the credential came from OAuth. Bearer auth here yields a
+              // false-negative 401 during post-connect verification.
+              "x-api-key": token,
               "anthropic-version": "2023-06-01",
             },
           },

--- a/packages/dashboard/src/__tests__/api-client.test.ts
+++ b/packages/dashboard/src/__tests__/api-client.test.ts
@@ -669,7 +669,7 @@ describe("API Client", () => {
     })
 
     it("exchangeOAuthConnect sends POST with body", async () => {
-      mockFetchResponse({ success: true })
+      mockFetchResponse({ ok: true, provider: "Anthropic", accountId: null })
 
       await exchangeOAuthConnect("anthropic", {
         pastedUrl: "http://localhost:3100/callback?code=abc",

--- a/packages/dashboard/src/__tests__/settings-providers.test.ts
+++ b/packages/dashboard/src/__tests__/settings-providers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest"
 
 import type { Credential, ProviderInfo } from "@/lib/api-client"
+import {
+  formatConnectErrorMessage,
+  formatVerificationFailureMessage,
+  isVerificationFailureResult,
+} from "@/lib/oauth-connect-feedback"
 
 /**
  * Tests for provider-driven OAuth flow selection used in the settings page.
@@ -204,5 +209,35 @@ describe("settings page LLM provider filter", () => {
   it("returns correct count", () => {
     const result = filterLlmProviders(ALL_PROVIDERS)
     expect(result).toHaveLength(3)
+  })
+})
+
+describe("OAuth connect feedback", () => {
+  it("formats connect_unverified with provider-specific reason", () => {
+    expect(
+      formatConnectErrorMessage({
+        error: "connect_unverified",
+        provider: "anthropic",
+        reason: "Authentication failed (HTTP 401)",
+        providers: STUB_PROVIDERS,
+      }),
+    ).toBe("Anthropic connection failed verification: Authentication failed (HTTP 401)")
+  })
+
+  it("detects code-paste exchange verification failures", () => {
+    const result = {
+      ok: false as const,
+      provider: "Anthropic",
+      accountId: null,
+      verification: {
+        status: "auth_failed" as const,
+        message: "Authentication failed (HTTP 401)",
+      },
+    }
+
+    expect(isVerificationFailureResult(result)).toBe(true)
+    expect(formatVerificationFailureMessage(result.provider, result.verification)).toBe(
+      "Anthropic connection failed verification: Authentication failed (HTTP 401)",
+    )
   })
 })

--- a/packages/dashboard/src/app/settings/page.tsx
+++ b/packages/dashboard/src/app/settings/page.tsx
@@ -20,6 +20,11 @@ import {
   testCredential as apiTestCredential,
 } from "@/lib/api-client"
 import { errorSummary, refreshStatus, tokenExpiry } from "@/lib/credential-health"
+import {
+  formatConnectErrorMessage,
+  formatVerificationFailureMessage,
+  isVerificationFailureResult,
+} from "@/lib/oauth-connect-feedback"
 
 /** Find a human-readable label for a credential (provider name or display label). */
 function credentialLabel(cred: Credential, providers: ProviderInfo[]): string {
@@ -152,9 +157,17 @@ function SettingsInner() {
 
   const connected = searchParams.get("connected")
   const paramError = searchParams.get("error")
+  const errorProvider = searchParams.get("provider")
+  const errorReason = searchParams.get("reason")
   const popupProviderInfo = popupProvider
     ? (providers.find((provider) => provider.id === popupProvider) ?? null)
     : null
+  const connectErrorMessage = formatConnectErrorMessage({
+    error: paramError,
+    provider: errorProvider,
+    reason: errorReason,
+    providers,
+  })
 
   // Fetch providers and credentials
   const fetchData = useCallback(async () => {
@@ -206,11 +219,22 @@ function SettingsInner() {
     setCodePasteError(null)
 
     try {
-      await exchangeOAuthConnect(popupProvider, {
+      const result = await exchangeOAuthConnect(popupProvider, {
         pastedUrl: codePastePastedUrl,
         codeVerifier: popup.fallbackContext.codeVerifier,
         state: popup.fallbackContext.state,
       })
+
+      if (isVerificationFailureResult(result)) {
+        const message = formatVerificationFailureMessage(result.provider, result.verification)
+        popup.cancel()
+        setPopupProvider(null)
+        setCodePastePastedUrl("")
+        setCodePasteError(message)
+        addToast(message, "error")
+        void fetchData()
+        return
+      }
 
       popup.cancel()
       setPopupProvider(null)
@@ -384,9 +408,9 @@ function SettingsInner() {
           Successfully connected {connected}. Your credentials are encrypted and stored securely.
         </div>
       )}
-      {paramError && (
+      {connectErrorMessage && (
         <div className="rounded-lg border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
-          Connection error: {paramError}
+          {connectErrorMessage}
         </div>
       )}
       {(codePasteError ?? popup.error) && popup.status === "idle" && (

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -47,6 +47,7 @@ import { ContentListResponseSchema } from "./schemas/content"
 import {
   CredentialListResponseSchema,
   CredentialTestResultSchema,
+  OAuthConnectExchangeResultSchema,
   OAuthInitResultSchema,
   ProviderListResponseSchema,
 } from "./schemas/credentials"
@@ -800,6 +801,7 @@ export async function listModels(opts?: { credentialAware?: boolean }): Promise<
 export type {
   Credential,
   CredentialTestResult,
+  OAuthConnectExchangeResult,
   OAuthInitResult,
   ProviderInfo,
 } from "./schemas/credentials"
@@ -825,11 +827,11 @@ export async function initOAuthConnect(
 export async function exchangeOAuthConnect(
   provider: string,
   body: { pastedUrl: string; codeVerifier: string; state: string },
-): Promise<unknown> {
+): Promise<import("./schemas/credentials").OAuthConnectExchangeResult> {
   return apiFetch(`/auth/connect/${provider}/exchange`, {
     method: "POST",
     body,
-    schema: z.unknown(),
+    schema: OAuthConnectExchangeResultSchema,
   })
 }
 

--- a/packages/dashboard/src/lib/oauth-connect-feedback.ts
+++ b/packages/dashboard/src/lib/oauth-connect-feedback.ts
@@ -1,0 +1,41 @@
+import type {
+  CredentialTestResult,
+  OAuthConnectExchangeResult,
+  ProviderInfo,
+} from "@/lib/api-client"
+
+function providerLabel(providerId: string | null, providers: ProviderInfo[]): string | null {
+  if (!providerId) return null
+  return providers.find((provider) => provider.id === providerId)?.name ?? providerId
+}
+
+export function isVerificationFailureResult(
+  result: OAuthConnectExchangeResult,
+): result is Extract<OAuthConnectExchangeResult, { ok: false }> {
+  return result.ok === false
+}
+
+export function formatConnectErrorMessage(params: {
+  error: string | null
+  provider: string | null
+  reason: string | null
+  providers: ProviderInfo[]
+}): string | null {
+  const { error, provider, reason, providers } = params
+  if (!error) return null
+
+  if (error === "connect_unverified") {
+    const label = providerLabel(provider, providers) ?? "Provider"
+    const suffix = reason ? `: ${reason}` : "."
+    return `${label} connection failed verification${suffix}`
+  }
+
+  return `Connection error: ${error}`
+}
+
+export function formatVerificationFailureMessage(
+  provider: string,
+  verification: CredentialTestResult,
+): string {
+  return `${provider} connection failed verification: ${verification.message}`
+}

--- a/packages/dashboard/src/lib/schemas/credentials.ts
+++ b/packages/dashboard/src/lib/schemas/credentials.ts
@@ -56,7 +56,22 @@ export const CredentialTestResultSchema = z.object({
   lastUsedAt: z.string().nullable().optional(),
 })
 
+export const OAuthConnectExchangeResultSchema = z.union([
+  z.object({
+    ok: z.literal(true),
+    provider: z.string(),
+    accountId: z.string().nullable(),
+  }),
+  z.object({
+    ok: z.literal(false),
+    provider: z.string(),
+    accountId: z.string().nullable(),
+    verification: CredentialTestResultSchema,
+  }),
+])
+
 export type ProviderInfo = z.infer<typeof ProviderInfoSchema>
 export type Credential = z.infer<typeof CredentialSchema>
 export type OAuthInitResult = z.infer<typeof OAuthInitResultSchema>
 export type CredentialTestResult = z.infer<typeof CredentialTestResultSchema>
+export type OAuthConnectExchangeResult = z.infer<typeof OAuthConnectExchangeResultSchema>


### PR DESCRIPTION
## Summary
- verify Anthropic credentials with the OAuth token on \ during post-connect health checks
- type the code-paste exchange response and surface verification failures in the dashboard settings flow
- add regression coverage and document the Anthropic verification contract

Closes #722.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Anthropic OAuth verification to correctly use the `x-api-key` header instead of `Authorization` header, ensuring proper credential validation.

* **New Features**
  * Enhanced OAuth connection error handling with detailed feedback messages for verification failures.

* **Documentation**
  * Added clarification on Anthropic's OAuth verification requirements and expected header format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->