### PR TITLE
test(runtime): guard LLM limiter against streamed chunk inflation

### DIFF
--- a/packages/control-plane/src/__tests__/agent-execute-circuit-breaker.test.ts
+++ b/packages/control-plane/src/__tests__/agent-execute-circuit-breaker.test.ts
@@ -460,6 +460,47 @@ describe("agent-execute circuit breaker wiring", () => {
     )
   })
 
+  it("does not count streamed text chunks as separate llm calls", async () => {
+    const db = makeMockDb({
+      agent: {
+        id: "agent-1",
+        name: "TestAgent",
+        slug: "test-agent",
+        role: "developer",
+        description: null,
+        status: "ACTIVE",
+        model_config: {},
+        skill_config: {},
+        resource_limits: {
+          circuitBreaker: {
+            llmCallRateLimit: { maxCalls: 1, windowSeconds: 300 },
+          },
+        },
+        config: null,
+      },
+      recentJobs: [],
+    })
+
+    const events: OutputEvent[] = [
+      { type: "text", timestamp: new Date().toISOString(), content: "chunk 1" },
+      { type: "text", timestamp: new Date().toISOString(), content: "chunk 2" },
+      { type: "text", timestamp: new Date().toISOString(), content: "chunk 3" },
+      { type: "text", timestamp: new Date().toISOString(), content: "chunk 4" },
+      { type: "text", timestamp: new Date().toISOString(), content: "chunk 5" },
+    ]
+
+    const handle = createMockHandle(createMockResult(), events)
+    const registry = makeMockRegistry(handle)
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    expect((handle as unknown as { _cancelReason?: string })._cancelReason).toBeUndefined()
+  })
+
   it("accounts llm rate limiting by logical turn, not streamed text chunks", async () => {
     const db = makeMockDb({
       agent: {


### PR DESCRIPTION
Closes #725

## Summary
- add a focused regression test ensuring many streamed `text` chunks in a single turn do not trigger `llm_call_rate_exceeded`
- keep existing logical-turn coverage (turns separated by tool round-trips) to confirm limiter still trips under sustained multi-turn load

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
