### PR TITLE
Align extensibility verification audit with issue #727

### DIFF
--- a/docs/audits/extensibility-verification-matrix-2026-03-21.md
+++ b/docs/audits/extensibility-verification-matrix-2026-03-21.md
@@ -1,4 +1,4 @@
-# Extensibility Verification Matrix — Browser Tooling + MCP (Issue #706)
+# Extensibility Verification Matrix — Browser Tooling + MCP (Issue #727)
 
 _Date:_ 2026-03-21  
 _Scope:_ Runtime/extensibility checks so schema/contract parity is not confused with execution readiness.

--- a/packages/dashboard/src/__tests__/extensibility-verification-matrix.test.ts
+++ b/packages/dashboard/src/__tests__/extensibility-verification-matrix.test.ts
@@ -10,8 +10,8 @@ describe("extensibility verification matrix artifact", () => {
   )
   const matrix = readFileSync(matrixPath, "utf8")
 
-  it("links to issue #706 and scope", () => {
-    expect(matrix).toContain("Issue #706")
+  it("links to issue #727 and scope", () => {
+    expect(matrix).toContain("Issue #727")
     expect(matrix).toContain("Browser tooling")
     expect(matrix).toContain("MCP")
   })
@@ -21,5 +21,12 @@ describe("extensibility verification matrix artifact", () => {
     expect(matrix).toContain("#711")
     expect(matrix).toContain("#712")
     expect(matrix).toContain("#713")
+  })
+
+  it("captures acceptance checklist for browser and MCP end-to-end status", () => {
+    expect(matrix).toContain("Browser tooling happy-path verified end-to-end")
+    expect(matrix).toContain("Browser tooling failure paths verified with actionable errors")
+    expect(matrix).toContain("MCP happy-path verified end-to-end")
+    expect(matrix).toContain("MCP failure paths verified with actionable errors")
   })
 })


### PR DESCRIPTION
## Summary\n- retarget the extensibility verification audit artifact to issue #727\n- update the dashboard artifact test to assert issue #727 linkage\n- add acceptance-checklist assertions so browser/MCP end-to-end status lines stay present\n\n## Validation\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n- pnpm build\n\nCloses #727