### PR TITLE
fix(dashboard): make credential warnings source-aware and state-accurate

### DIFF
--- a/packages/dashboard/src/__tests__/use-notifications.test.ts
+++ b/packages/dashboard/src/__tests__/use-notifications.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest"
+
+import { buildCredentialWarningNotification } from "@/hooks/use-notifications"
+import type { Credential } from "@/lib/api-client"
+
+function makeCredential(overrides: Partial<Credential>): Credential {
+  return {
+    id: "cred-1",
+    provider: "anthropic",
+    credentialType: "oauth",
+    credentialClass: "llm_provider",
+    toolName: null,
+    displayLabel: "Primary",
+    maskedKey: null,
+    status: "active",
+    accountId: null,
+    scopes: null,
+    tokenExpiresAt: null,
+    lastUsedAt: null,
+    lastRefreshAt: null,
+    errorCount: 0,
+    lastError: null,
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("buildCredentialWarningNotification", () => {
+  it("returns null when no credential is in a warning/error state", () => {
+    const now = new Date("2026-03-21T00:00:00.000Z")
+    const creds: Credential[] = [
+      makeCredential({
+        status: "active",
+        credentialType: "oauth",
+        tokenExpiresAt: "2026-03-21T02:00:00.000Z",
+      }),
+    ]
+
+    const notification = buildCredentialWarningNotification(creds, now)
+    expect(notification).toBeNull()
+  })
+
+  it("identifies a single affected provider/credential with reason", () => {
+    const now = new Date("2026-03-21T00:00:00.000Z")
+    const creds: Credential[] = [
+      makeCredential({
+        provider: "openai",
+        displayLabel: "Production Key",
+        credentialType: "api_key",
+        tokenExpiresAt: "2026-03-21T06:00:00.000Z",
+      }),
+    ]
+
+    const notification = buildCredentialWarningNotification(creds, now)
+    expect(notification).not.toBeNull()
+    expect(notification?.label).toContain("openai · Production Key")
+    expect(notification?.label).toContain("expires in 6h")
+  })
+
+  it("uses status-based warning when credential is already unhealthy", () => {
+    const now = new Date("2026-03-21T00:00:00.000Z")
+    const creds: Credential[] = [
+      makeCredential({
+        provider: "anthropic",
+        displayLabel: "Anthropic OAuth",
+        status: "expired",
+        tokenExpiresAt: "2026-03-20T23:00:00.000Z",
+      }),
+    ]
+
+    const notification = buildCredentialWarningNotification(creds, now)
+    expect(notification?.label).toContain("anthropic · Anthropic OAuth")
+    expect(notification?.label).toContain("status: expired")
+  })
+
+  it("summarizes multiple warnings while naming a concrete source", () => {
+    const now = new Date("2026-03-21T00:00:00.000Z")
+    const creds: Credential[] = [
+      makeCredential({
+        provider: "openai",
+        displayLabel: "OpenAI Prod",
+        credentialType: "api_key",
+        tokenExpiresAt: "2026-03-21T02:00:00.000Z",
+      }),
+      makeCredential({
+        id: "cred-2",
+        provider: "anthropic",
+        displayLabel: "Anthropic Team",
+        status: "error",
+      }),
+    ]
+
+    const notification = buildCredentialWarningNotification(creds, now)
+    expect(notification?.label).toContain("openai · OpenAI Prod")
+    expect(notification?.label).toContain("+1 more")
+  })
+})

--- a/packages/dashboard/src/hooks/use-notifications.ts
+++ b/packages/dashboard/src/hooks/use-notifications.ts
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from "react"
 
-import { getDashboardSummary, listCredentials, listJobs } from "@/lib/api-client"
+import { type Credential, getDashboardSummary, listCredentials, listJobs } from "@/lib/api-client"
+import { tokenExpiry } from "@/lib/credential-health"
 
 export interface NotificationItem {
   id: string
@@ -19,13 +20,64 @@ export interface Notifications {
 }
 
 const POLL_INTERVAL_MS = 30_000
-const CREDENTIAL_EXPIRY_WARN_DAYS = 7
 
-function isExpiringSoon(tokenExpiresAt: string | null | undefined): boolean {
-  if (!tokenExpiresAt) return false
-  const expiresMs = new Date(tokenExpiresAt).getTime()
-  const warnMs = Date.now() + CREDENTIAL_EXPIRY_WARN_DAYS * 86_400_000
-  return expiresMs > 0 && expiresMs < warnMs
+function credentialSourceLabel(credential: Credential): string {
+  if (credential.displayLabel && credential.displayLabel !== credential.provider) {
+    return `${credential.provider} · ${credential.displayLabel}`
+  }
+  return credential.provider
+}
+
+function credentialWarningReason(credential: Credential, now: Date): string | null {
+  if (
+    credential.status === "expired" ||
+    credential.status === "error" ||
+    credential.status === "revoked"
+  ) {
+    return `status: ${credential.status}`
+  }
+
+  const expiry = tokenExpiry(credential, now)
+  if (!expiry) return null
+  if (expiry.severity === "warning" || expiry.severity === "danger") {
+    return expiry.label.toLowerCase()
+  }
+  return null
+}
+
+export function buildCredentialWarningNotification(
+  credentials: Credential[] | null | undefined,
+  now: Date = new Date(),
+): NotificationItem | null {
+  const warned =
+    credentials
+      ?.map((credential) => {
+        const reason = credentialWarningReason(credential, now)
+        if (!reason) return null
+        return {
+          source: credentialSourceLabel(credential),
+          reason,
+        }
+      })
+      .filter((value): value is { source: string; reason: string } => value !== null) ?? []
+
+  if (warned.length === 0) return null
+
+  const [first] = warned
+  if (!first) return null
+
+  const label =
+    warned.length === 1
+      ? `Credential warning: ${first.source} (${first.reason})`
+      : `Credential warnings: ${first.source} (${first.reason}) +${warned.length - 1} more`
+
+  return {
+    id: "expiring-creds",
+    icon: "key_off",
+    label,
+    href: "/settings",
+    severity: "warning",
+  }
 }
 
 export function useNotifications(): Notifications {
@@ -69,16 +121,10 @@ export function useNotifications(): Notifications {
         })
       }
 
-      // Expiring credentials
-      const expiring = creds?.credentials?.filter((c) => isExpiringSoon(c.tokenExpiresAt)) ?? []
-      if (expiring.length > 0) {
-        next.push({
-          id: "expiring-creds",
-          icon: "key_off",
-          label: `${expiring.length} credential${expiring.length > 1 ? "s" : ""} expiring soon`,
-          href: "/settings",
-          severity: "warning",
-        })
+      // Credential health / expiration warnings
+      const credentialWarning = buildCredentialWarningNotification(creds?.credentials)
+      if (credentialWarning) {
+        next.push(credentialWarning)
       }
 
       setItems(next)


### PR DESCRIPTION
## Summary
- replace opaque credential-expiry notification count with source-aware warning text
- align warnings with real credential state by surfacing unhealthy statuses (expired, error, revoked) and only showing expiry countdowns when health is actually warning/danger
- keep active auto-renewing OAuth credentials from being misreported as expiring warnings
- add unit tests for warning construction and state/expiry behavior

Fixes #720

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated credential warning notifications to display health-based status information alongside credential sources, replacing simple expiration date checks.
  * Multiple affected credentials are now consolidated into a single notification with a '+N more' indicator.

* **Tests**
  * Added test suite for credential warning notification generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->