### PR TITLE
fix: verify OpenAI Codex OAuth against ChatGPT Codex backend

### DIFF
--- a/packages/control-plane/src/__tests__/credential-service.test.ts
+++ b/packages/control-plane/src/__tests__/credential-service.test.ts
@@ -914,6 +914,37 @@ describe("getConfiguredProviders", () => {
 })
 
 describe("CredentialService.testCredential", () => {
+  it("verifies OpenAI Codex OAuth credentials against the ChatGPT Codex models endpoint", async () => {
+    const oauthToken = "codex-oauth-token"
+    const cred = makeCredRow({
+      provider: "openai-codex",
+      credential_type: "oauth",
+      api_key_enc: null,
+      access_token_enc: encryptCredential(oauthToken, USER_KEY),
+      refresh_token_enc: null,
+    })
+    const { db } = buildMockDb({ existingCred: cred, updatedCred: cred })
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const service = new CredentialService(db, AUTH_CONFIG)
+    const result = await service.testCredential(ADMIN_USER_ID, CRED_ID)
+
+    expect(result.status).toBe("connected")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://chatgpt.com/backend-api/codex/models")
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${oauthToken}`,
+      },
+    })
+  })
+
   it("verifies Anthropic OAuth credentials with x-api-key instead of Bearer", async () => {
     const oauthToken = "anthropic-oauth-token"
     const cred = makeCredRow({

--- a/packages/control-plane/src/auth/__tests__/model-discovery.test.ts
+++ b/packages/control-plane/src/auth/__tests__/model-discovery.test.ts
@@ -128,11 +128,13 @@ describe("discoverModels — openai", () => {
   })
 
   it("openai-codex tags models with openai-codex provider", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [{ id: "gpt-4o" }] }))
+    fetchMock.mockResolvedValueOnce(jsonResponse({ models: [{ slug: "gpt-5" }] }))
 
     const svc = new ModelDiscoveryService()
     const models = await svc.discoverModels("openai-codex", { accessToken: "tok" })
 
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://chatgpt.com/backend-api/codex/models")
+    expect(models[0]!.id).toBe("gpt-5")
     expect(models[0]!.providers).toEqual(["openai-codex"])
   })
 

--- a/packages/control-plane/src/auth/credential-service.ts
+++ b/packages/control-plane/src/auth/credential-service.ts
@@ -42,6 +42,9 @@ export interface AuditContext {
   toolName?: string
 }
 
+const OPENAI_MODELS_URL = "https://api.openai.com/v1/models"
+const OPENAI_CODEX_MODELS_URL = "https://chatgpt.com/backend-api/codex/models"
+
 /** Provider metadata for the "Connected Providers" UI. */
 export interface ProviderInfo {
   id: string
@@ -1129,9 +1132,13 @@ export class CredentialService {
   private buildProviderPing(provider: string, token: string): { url: string; init: RequestInit } {
     switch (provider) {
       case "openai":
+        return {
+          url: OPENAI_MODELS_URL,
+          init: { method: "GET", headers: { Authorization: `Bearer ${token}` } },
+        }
       case "openai-codex":
         return {
-          url: "https://api.openai.com/v1/models",
+          url: OPENAI_CODEX_MODELS_URL,
           init: { method: "GET", headers: { Authorization: `Bearer ${token}` } },
         }
       case "anthropic":

--- a/packages/control-plane/src/auth/model-discovery.ts
+++ b/packages/control-plane/src/auth/model-discovery.ts
@@ -28,6 +28,8 @@ interface CacheEntry {
 // ---------------------------------------------------------------------------
 
 const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour
+const OPENAI_MODELS_URL = "https://api.openai.com/v1/models"
+const OPENAI_CODEX_MODELS_URL = "https://chatgpt.com/backend-api/codex/models"
 
 /** Chat-model filter for OpenAI: keep only models whose id matches these. */
 const OPENAI_CHAT_RE = /gpt|o1|o3|o4/i
@@ -88,17 +90,24 @@ async function discoverAnthropic(cred: ProviderCredential): Promise<ModelInfo[]>
 async function discoverOpenAI(
   cred: ProviderCredential,
   providerIds: string[],
+  url = OPENAI_MODELS_URL,
 ): Promise<ModelInfo[]> {
   const token = cred.accessToken ?? cred.apiKey
   if (!token) return []
 
-  const data = (await fetchJson("https://api.openai.com/v1/models", {
+  const data = (await fetchJson(url, {
     method: "GET",
     headers: { Authorization: `Bearer ${token}` },
-  })) as { data?: { id: string }[] } | null
-  if (!data?.data) return []
+  })) as { data?: { id: string }[]; models?: { id?: string; slug?: string }[] } | null
+  const items =
+    data?.data ??
+    data?.models?.flatMap((model) => {
+      const id = model.id ?? model.slug
+      return id ? [{ id }] : []
+    })
+  if (!items) return []
 
-  return data.data
+  return items
     .filter((m) => OPENAI_CHAT_RE.test(m.id))
     .map((m) => ({
       id: m.id,
@@ -228,7 +237,7 @@ export class ModelDiscoveryService {
         models = await discoverOpenAI(credential, ["openai"])
         break
       case "openai-codex":
-        models = await discoverOpenAI(credential, ["openai-codex"])
+        models = await discoverOpenAI(credential, ["openai-codex"], OPENAI_CODEX_MODELS_URL)
         break
       case "google-ai-studio":
         models = await discoverGoogleAIStudio(credential)


### PR DESCRIPTION
Fixes #740

## Summary
- verify `openai-codex` OAuth credentials against `https://chatgpt.com/backend-api/codex/models` instead of `https://api.openai.com/v1/models`
- align Codex model discovery with the ChatGPT Codex backend and accept the backend's `models` response shape
- add regression tests for Codex verification and model discovery endpoint selection

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI Codex provider support for credential verification and OAuth authentication.
  * Enabled model discovery integration for OpenAI Codex with flexible endpoint configuration.
  * Enhanced model discovery to support multiple API response payload formats for improved compatibility.

* **Tests**
  * Added comprehensive test coverage for OpenAI Codex credential verification.
  * Updated model discovery tests for OpenAI Codex provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->