### PR TITLE
fix(auth): use correct verification endpoint for OpenAI Codex OAuth

### DIFF
--- a/packages/control-plane/src/__tests__/auth-connect-callback.test.ts
+++ b/packages/control-plane/src/__tests__/auth-connect-callback.test.ts
@@ -328,3 +328,119 @@ describe("GET /auth/connect/callback/:provider", () => {
     expect(res.headers.location).toBe("http://localhost:3100/settings?error=connect_failed")
   })
 })
+
+describe("POST /auth/connect/:provider/exchange — verification failure path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetCodePasteProvider.mockImplementation((provider: string) => {
+      if (provider === "openai-codex") {
+        return {
+          id: "openai-codex",
+          name: "OpenAI Codex",
+          clientId: "test-codex-id",
+          clientSecret: "test-codex-secret",
+          authUrl: "https://auth.openai.com/oauth/authorize",
+          tokenUrl: "https://auth.openai.com/oauth/token",
+          redirectUri: "http://localhost:1455/auth/callback",
+          scopes: ["openid", "profile", "email", "offline_access"],
+          usePkce: true,
+        }
+      }
+      if (provider === "google-antigravity") {
+        return {
+          id: "google-antigravity",
+          clientId: "test-client-id",
+          clientSecret: "test-client-secret",
+          authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+          tokenUrl: "https://oauth2.googleapis.com/token",
+          redirectUri: "http://localhost:51121/oauth-callback",
+          scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+          usePkce: true,
+        }
+      }
+      return undefined
+    })
+    mockExchangeCode.mockResolvedValue({
+      access_token: "codex-access-token",
+      refresh_token: null,
+      expires_in: 3600,
+      token_type: "Bearer",
+      scope: "openid profile email offline_access",
+    })
+  })
+
+  it("returns ok:false with verification details when openai-codex verify fails (regression #740)", async () => {
+    const { app, credentialService } = await buildTestApp()
+    ;(
+      credentialService.storeOAuthCredential as {
+        mockResolvedValueOnce: (v: unknown) => unknown
+      }
+    ).mockResolvedValueOnce({
+      id: "cred-codex-1",
+      provider: "openai-codex",
+      credentialType: "oauth",
+      status: "active",
+    })
+    ;(
+      credentialService.testCredential as { mockResolvedValueOnce: (v: unknown) => unknown }
+    ).mockResolvedValueOnce({
+      status: "auth_failed",
+      message: "Authentication failed (HTTP 403)",
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/auth/connect/openai-codex/exchange",
+      headers: { ...withSession(), "content-type": "application/json" },
+      payload: JSON.stringify({
+        pastedUrl: "http://localhost:1455/auth/callback?code=test-code&state=test-state",
+        codeVerifier: "test-verifier",
+        state: "test-state",
+      }),
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body) as Record<string, unknown>
+    expect(body.ok).toBe(false)
+    expect(body.provider).toBe("OpenAI Codex")
+    const verification = body.verification as Record<string, unknown>
+    expect(verification.status).toBe("auth_failed")
+    expect(verification.message).toContain("403")
+  })
+
+  it("returns ok:true when openai-codex verification succeeds", async () => {
+    const { app, credentialService } = await buildTestApp()
+    ;(
+      credentialService.storeOAuthCredential as {
+        mockResolvedValueOnce: (v: unknown) => unknown
+      }
+    ).mockResolvedValueOnce({
+      id: "cred-codex-2",
+      provider: "openai-codex",
+      credentialType: "oauth",
+      status: "active",
+    })
+    ;(
+      credentialService.testCredential as { mockResolvedValueOnce: (v: unknown) => unknown }
+    ).mockResolvedValueOnce({
+      status: "connected",
+      message: "Connection successful",
+    })
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/auth/connect/openai-codex/exchange",
+      headers: { ...withSession(), "content-type": "application/json" },
+      payload: JSON.stringify({
+        pastedUrl: "http://localhost:1455/auth/callback?code=good-code&state=test-state",
+        codeVerifier: "test-verifier",
+        state: "test-state",
+      }),
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body) as Record<string, unknown>
+    expect(body.ok).toBe(true)
+    expect(body.provider).toBe("OpenAI Codex")
+  })
+})

--- a/packages/control-plane/src/__tests__/credential-service.test.ts
+++ b/packages/control-plane/src/__tests__/credential-service.test.ts
@@ -914,7 +914,7 @@ describe("getConfiguredProviders", () => {
 })
 
 describe("CredentialService.testCredential", () => {
-  it("verifies OpenAI Codex OAuth credentials against the ChatGPT Codex models endpoint", async () => {
+  it("verifies OpenAI Codex OAuth credentials against the /v1/me endpoint", async () => {
     const oauthToken = "codex-oauth-token"
     const cred = makeCredRow({
       provider: "openai-codex",
@@ -936,7 +936,7 @@ describe("CredentialService.testCredential", () => {
 
     expect(result.status).toBe("connected")
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://chatgpt.com/backend-api/codex/models")
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.openai.com/v1/me")
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
       method: "GET",
       headers: {
@@ -976,5 +976,87 @@ describe("CredentialService.testCredential", () => {
       "anthropic-version": "2023-06-01",
     })
     expect((init.headers as Record<string, string>)["x-api-key"]).toBeUndefined()
+  })
+
+  it("verifies OpenAI Codex OAuth via /v1/me instead of /v1/models", async () => {
+    const oauthToken = "codex-oauth-token"
+    const cred = makeCredRow({
+      provider: "openai-codex",
+      credential_type: "oauth",
+      api_key_enc: null,
+      access_token_enc: encryptCredential(oauthToken, USER_KEY),
+      refresh_token_enc: null,
+    })
+    const { db } = buildMockDb({ existingCred: cred, updatedCred: cred })
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const service = new CredentialService(db, AUTH_CONFIG)
+    const result = await service.testCredential(ADMIN_USER_ID, CRED_ID)
+
+    expect(result.status).toBe("connected")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.openai.com/v1/me")
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer " + oauthToken)
+  })
+
+  it("marks credential as error when openai-codex verification returns 403", async () => {
+    const oauthToken = "codex-oauth-token-bad"
+    const cred = makeCredRow({
+      provider: "openai-codex",
+      credential_type: "oauth",
+      api_key_enc: null,
+      access_token_enc: encryptCredential(oauthToken, USER_KEY),
+      refresh_token_enc: null,
+    })
+    const { db } = buildMockDb({ existingCred: cred, updatedCred: { ...cred, status: "error" } })
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const service = new CredentialService(db, AUTH_CONFIG)
+    const result = await service.testCredential(ADMIN_USER_ID, CRED_ID)
+
+    expect(result.status).toBe("auth_failed")
+    expect(result.message).toContain("403")
+
+    // Credential status must be updated to "error" in the DB
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(db.updateTable).toHaveBeenCalled()
+  })
+
+  it("verifies GitHub Copilot OAuth via /user endpoint", async () => {
+    const oauthToken = "copilot-oauth-token"
+    const cred = makeCredRow({
+      provider: "github-copilot",
+      credential_type: "oauth",
+      api_key_enc: null,
+      access_token_enc: encryptCredential(oauthToken, USER_KEY),
+      refresh_token_enc: null,
+    })
+    const { db } = buildMockDb({ existingCred: cred, updatedCred: cred })
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const service = new CredentialService(db, AUTH_CONFIG)
+    const result = await service.testCredential(ADMIN_USER_ID, CRED_ID)
+
+    expect(result.status).toBe("connected")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.github.com/user")
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer " + oauthToken)
   })
 })

--- a/packages/control-plane/src/auth/credential-service.ts
+++ b/packages/control-plane/src/auth/credential-service.ts
@@ -43,7 +43,6 @@ export interface AuditContext {
 }
 
 const OPENAI_MODELS_URL = "https://api.openai.com/v1/models"
-const OPENAI_CODEX_MODELS_URL = "https://chatgpt.com/backend-api/codex/models"
 
 /** Provider metadata for the "Connected Providers" UI. */
 export interface ProviderInfo {
@@ -1056,7 +1055,7 @@ export class CredentialService {
         })
         .where("id", "=", credentialId)
         .execute()
-    } else if (result.status === "auth_failed") {
+    } else if (result.status === "auth_failed" || result.status === "error") {
       await this.db
         .updateTable("provider_credential")
         .set({
@@ -1108,13 +1107,6 @@ export class CredentialService {
         return { status: "connected", message: "Connection successful" }
       }
       if (res.status === 401 || res.status === 403) {
-        if (provider === "openai-codex" && res.status === 403) {
-          return {
-            status: "auth_failed",
-            message:
-              "OpenAI Codex OAuth token is not authorized for the /v1/models verification endpoint (HTTP 403). Callback succeeded, but credential is not operational for this provider check.",
-          }
-        }
         return { status: "auth_failed", message: `Authentication failed (HTTP ${res.status})` }
       }
       if (res.status === 429) {
@@ -1142,8 +1134,11 @@ export class CredentialService {
           init: { method: "GET", headers: { Authorization: `Bearer ${token}` } },
         }
       case "openai-codex":
+        // Codex OAuth tokens carry OIDC scopes (openid, profile, email) and
+        // cannot access the /v1/models API endpoint (HTTP 403). Verify via
+        // the OIDC userinfo endpoint that the token is valid instead.
         return {
-          url: OPENAI_CODEX_MODELS_URL,
+          url: "https://api.openai.com/v1/me",
           init: { method: "GET", headers: { Authorization: `Bearer ${token}` } },
         }
       case "anthropic": {
@@ -1167,6 +1162,7 @@ export class CredentialService {
           init: { method: "GET" },
         }
       case "google-antigravity":
+      case "google-gemini-cli":
         return {
           url: "https://www.googleapis.com/oauth2/v1/tokeninfo",
           init: { method: "GET", headers: { Authorization: `Bearer ${token}` } },
@@ -1177,6 +1173,7 @@ export class CredentialService {
           init: { method: "GET", headers: { Authorization: `Bearer ${token}` } },
         }
       case "github-user":
+      case "github-copilot":
         return {
           url: "https://api.github.com/user",
           init: {


### PR DESCRIPTION
## Summary
- **Fix**: OpenAI Codex OAuth tokens carry OIDC scopes (`openid`, `profile`, `email`, `offline_access`) and cannot access `/v1/models` (HTTP 403). Switched verification to `/v1/me` which the OIDC token can access.
- **Fix**: Credential status now correctly updates to `"error"` on generic ping failures (not just `auth_failed`), preventing stale `"active"` status after failed verification.
- **Hardening**: Added explicit ping endpoints for `github-copilot` (`/user`) and `google-gemini-cli` (`tokeninfo`) instead of falling through to the httpbin default.

## Test plan
- [x] New test: OpenAI Codex OAuth verifies via `/v1/me` instead of `/v1/models`
- [x] New test: Credential marked as `error` when Codex verification returns 403
- [x] New test: GitHub Copilot OAuth verifies via `/user` endpoint
- [x] New test: Code-paste exchange returns `ok:false` with verification details on Codex failure (regression #740)
- [x] New test: Code-paste exchange returns `ok:true` when Codex verification succeeds
- [x] All existing tests pass (50 credential-service, 10 auth-connect-callback)
- [x] Lint, typecheck, and build pass

Fixes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More consistent authentication failure handling and clearer error reporting for credential checks; failed verifications now properly mark credentials as errored.

* **New Features**
  * Added verification support for OpenAI Codex, GitHub Copilot, and Google Gemini CLI.

* **Tests**
  * Added/expanded tests covering OAuth token exchange and credential verification success and failure scenarios for the above providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->