### PR TITLE
Fix Anthropic OAuth auth header handling to prevent false 401 failures

### DIFF
--- a/packages/control-plane/src/__tests__/credential-injection.test.ts
+++ b/packages/control-plane/src/__tests__/credential-injection.test.ts
@@ -190,7 +190,7 @@ describe("LLM credential injection", () => {
     await handle.cancel("test")
   })
 
-  it("uses x-api-key (apiKey) for Anthropic OAuth credentials (not Bearer)", async () => {
+  it("uses Bearer auth (authToken) for Anthropic OAuth credentials", async () => {
     const backend = new HttpLlmBackend()
     await backend.start({ provider: "anthropic", apiKey: "global-key" })
 
@@ -209,7 +209,7 @@ describe("LLM credential injection", () => {
     const handle = await backend.executeTask(task)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
     const useAuthToken = (handle as any).useAuthToken
-    expect(useAuthToken).toBe(false)
+    expect(useAuthToken).toBe(true)
     await handle.cancel("test")
   })
 

--- a/packages/control-plane/src/__tests__/credential-service.test.ts
+++ b/packages/control-plane/src/__tests__/credential-service.test.ts
@@ -945,7 +945,7 @@ describe("CredentialService.testCredential", () => {
     })
   })
 
-  it("verifies Anthropic OAuth credentials with x-api-key instead of Bearer", async () => {
+  it("verifies Anthropic OAuth credentials with Bearer auth", async () => {
     const oauthToken = "anthropic-oauth-token"
     const cred = makeCredRow({
       provider: "anthropic",
@@ -972,9 +972,9 @@ describe("CredentialService.testCredential", () => {
     expect(init.method).toBe("GET")
     expect(init.signal).toBeInstanceOf(AbortSignal)
     expect(init.headers).toMatchObject({
-      "x-api-key": oauthToken,
+      Authorization: `Bearer ${oauthToken}`,
       "anthropic-version": "2023-06-01",
     })
-    expect((init.headers as Record<string, string>).Authorization).toBeUndefined()
+    expect((init.headers as Record<string, string>)["x-api-key"]).toBeUndefined()
   })
 })

--- a/packages/control-plane/src/auth/credential-service.ts
+++ b/packages/control-plane/src/auth/credential-service.ts
@@ -1041,7 +1041,7 @@ export class CredentialService {
     }
 
     // Make a lightweight provider-specific health check
-    const result = await this.pingProvider(cred.provider, token)
+    const result = await this.pingProvider(cred.provider, token, cred.credential_type)
 
     // Update credential status based on test result
     if (result.status === "connected") {
@@ -1094,9 +1094,10 @@ export class CredentialService {
   private async pingProvider(
     provider: string,
     token: string,
+    credentialType?: "oauth" | "api_key",
   ): Promise<{ status: "connected" | "auth_failed" | "rate_limited" | "error"; message: string }> {
     try {
-      const { url, init } = this.buildProviderPing(provider, token)
+      const { url, init } = this.buildProviderPing(provider, token, credentialType)
       const controller = new AbortController()
       const timeout = setTimeout(() => controller.abort(), 10_000)
 
@@ -1129,7 +1130,11 @@ export class CredentialService {
     }
   }
 
-  private buildProviderPing(provider: string, token: string): { url: string; init: RequestInit } {
+  private buildProviderPing(
+    provider: string,
+    token: string,
+    credentialType?: "oauth" | "api_key",
+  ): { url: string; init: RequestInit } {
     switch (provider) {
       case "openai":
         return {
@@ -1141,20 +1146,21 @@ export class CredentialService {
           url: OPENAI_CODEX_MODELS_URL,
           init: { method: "GET", headers: { Authorization: `Bearer ${token}` } },
         }
-      case "anthropic":
+      case "anthropic": {
+        const headers: Record<string, string> = {
+          "anthropic-version": "2023-06-01",
+          ...(credentialType === "oauth"
+            ? { Authorization: `Bearer ${token}` }
+            : { "x-api-key": token }),
+        }
         return {
           url: "https://api.anthropic.com/v1/models",
           init: {
             method: "GET",
-            headers: {
-              // Anthropic expects the token on x-api-key for /v1/models even
-              // when the credential came from OAuth. Bearer auth here yields a
-              // false-negative 401 during post-connect verification.
-              "x-api-key": token,
-              "anthropic-version": "2023-06-01",
-            },
+            headers,
           },
         }
+      }
       case "google-ai-studio":
         return {
           url: `https://generativelanguage.googleapis.com/v1beta/models?key=${token}`,

--- a/packages/control-plane/src/backends/http-llm.ts
+++ b/packages/control-plane/src/backends/http-llm.ts
@@ -231,10 +231,8 @@ export class HttpLlmBackend implements ExecutionBackend {
 
       const credProvider = mapCredentialProvider(cred.provider)
       if (credProvider === "anthropic") {
-        // Anthropic OAuth: x-api-key header (Anthropic requires it, NOT Bearer)
-        // Other OAuth: Bearer auth
-        const isAnthropicOAuth = cred.provider === "anthropic" && cred.credentialType === "oauth"
-        const useBearer = cred.credentialType === "oauth" && !isAnthropicOAuth
+        // OAuth credentials use bearer auth tokens; API keys use x-api-key.
+        const useBearer = cred.credentialType === "oauth"
 
         const clientBaseUrl = baseUrl
 


### PR DESCRIPTION
## Summary
- use Bearer auth for Anthropic OAuth credentials during provider verification
- keep x-api-key for Anthropic API key credentials
- align runtime LLM credential injection so Anthropic OAuth uses SDK authToken
- update regression tests for verification and credential injection behavior

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

Closes #741
