### PR TITLE
fix(ui): prevent authenticated dashboard crash when localStorage is unavailable (#742)

### DIFF
--- a/packages/dashboard/src/__tests__/nav-shell-storage.test.ts
+++ b/packages/dashboard/src/__tests__/nav-shell-storage.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  readSidebarCollapsedPreference,
+  writeSidebarCollapsedPreference,
+} from "@/components/layout/nav-shell"
+
+describe("nav shell sidebar storage guards", () => {
+  const originalWindow = globalThis.window
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window
+    } else {
+      ;(globalThis as { window?: unknown }).window = originalWindow
+    }
+  })
+
+  it("returns false instead of throwing when localStorage.getItem throws", () => {
+    ;(globalThis as { window?: unknown }).window = {
+      localStorage: {
+        getItem: () => {
+          throw new Error("SecurityError")
+        },
+      },
+    }
+
+    expect(readSidebarCollapsedPreference()).toBe(false)
+  })
+
+  it("does not throw when localStorage.setItem throws", () => {
+    ;(globalThis as { window?: unknown }).window = {
+      localStorage: {
+        setItem: () => {
+          throw new Error("SecurityError")
+        },
+      },
+    }
+
+    expect(() => writeSidebarCollapsedPreference(true)).not.toThrow()
+  })
+})

--- a/packages/dashboard/src/components/layout/nav-shell.tsx
+++ b/packages/dashboard/src/components/layout/nav-shell.tsx
@@ -170,19 +170,38 @@ function BottomTabs() {
 
 const SIDEBAR_KEY = "cortex-plane:sidebar-collapsed"
 
+export function readSidebarCollapsedPreference(): boolean {
+  if (typeof window === "undefined") return false
+
+  try {
+    return window.localStorage.getItem(SIDEBAR_KEY) === "true"
+  } catch {
+    // Mobile browsers (e.g. private mode / embedded webviews) can throw
+    // SecurityError when storage is unavailable. Fall back safely.
+    return false
+  }
+}
+
+export function writeSidebarCollapsedPreference(collapsed: boolean): void {
+  if (typeof window === "undefined") return
+
+  try {
+    window.localStorage.setItem(SIDEBAR_KEY, String(collapsed))
+  } catch {
+    // Best effort only; never crash render path due to storage policy.
+  }
+}
+
 /* ── Shell ────────────────────────────────────────────── */
 export function NavShell({ children }: { children: React.ReactNode }) {
   const router = useRouter()
-  const [collapsed, setCollapsed] = useState(() => {
-    if (typeof window === "undefined") return false
-    return localStorage.getItem(SIDEBAR_KEY) === "true"
-  })
+  const [collapsed, setCollapsed] = useState(readSidebarCollapsedPreference)
   const guardState = useAuthGuard()
 
   const toggleSidebar = useCallback(() => {
     setCollapsed((prev) => {
       const next = !prev
-      localStorage.setItem(SIDEBAR_KEY, String(next))
+      writeSidebarCollapsedPreference(next)
       return next
     })
   }, [])


### PR DESCRIPTION
## Summary
- guard sidebar preference reads/writes in NavShell with try/catch wrappers
- prevent mobile/private-mode localStorage access errors from crashing authenticated app routes
- add regression tests covering getItem/setItem storage failures

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

Closes #742.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sidebar preference persistence with improved error handling, ensuring the sidebar collapsed state reliably persists across sessions and browser environments, even when storage access is restricted or unavailable.

* **Tests**
  * Added comprehensive test suite to validate sidebar preference storage and error handling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->