### PR TITLE
fix(dashboard): guard theme-provider localStorage for mobile (#742)

### DIFF
--- a/packages/dashboard/src/__tests__/theme-provider-storage.test.ts
+++ b/packages/dashboard/src/__tests__/theme-provider-storage.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import { readThemePreference, writeThemePreference } from "@/components/theme-provider"
+
+describe("theme provider storage guards", () => {
+  const originalWindow = globalThis.window
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window
+    } else {
+      ;(globalThis as { window?: unknown }).window = originalWindow
+    }
+  })
+
+  it("returns 'dark' instead of throwing when localStorage.getItem throws", () => {
+    ;(globalThis as { window?: unknown }).window = {
+      localStorage: {
+        getItem: () => {
+          throw new Error("SecurityError")
+        },
+      },
+    }
+
+    expect(readThemePreference()).toBe("dark")
+  })
+
+  it("does not throw when localStorage.setItem throws", () => {
+    ;(globalThis as { window?: unknown }).window = {
+      localStorage: {
+        setItem: () => {
+          throw new Error("SecurityError")
+        },
+      },
+    }
+
+    expect(() => writeThemePreference("light")).not.toThrow()
+  })
+
+  it("returns stored theme when localStorage works", () => {
+    ;(globalThis as { window?: unknown }).window = {
+      localStorage: {
+        getItem: () => "light",
+      },
+    }
+
+    expect(readThemePreference()).toBe("light")
+  })
+
+  it("returns 'dark' for invalid stored value", () => {
+    ;(globalThis as { window?: unknown }).window = {
+      localStorage: {
+        getItem: () => "invalid-value",
+      },
+    }
+
+    expect(readThemePreference()).toBe("dark")
+  })
+})

--- a/packages/dashboard/src/components/theme-provider.tsx
+++ b/packages/dashboard/src/components/theme-provider.tsx
@@ -4,6 +4,8 @@ import { createContext, useCallback, useContext, useEffect, useState } from "rea
 
 type Theme = "light" | "dark"
 
+const THEME_KEY = "cortex-theme"
+
 const ThemeContext = createContext<{
   theme: Theme
   toggle: () => void
@@ -13,21 +15,43 @@ export function useTheme() {
   return useContext(ThemeContext)
 }
 
+export function readThemePreference(): Theme {
+  if (typeof window === "undefined") return "dark"
+
+  try {
+    const stored = window.localStorage.getItem(THEME_KEY)
+    if (stored === "light" || stored === "dark") return stored
+    return "dark"
+  } catch {
+    // Mobile browsers (e.g. private mode / embedded webviews) can throw
+    // SecurityError when storage is unavailable. Fall back safely.
+    return "dark"
+  }
+}
+
+export function writeThemePreference(theme: Theme): void {
+  if (typeof window === "undefined") return
+
+  try {
+    window.localStorage.setItem(THEME_KEY, theme)
+  } catch {
+    // Best effort only; never crash render path due to storage policy.
+  }
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>("dark")
 
   useEffect(() => {
-    const stored = localStorage.getItem("cortex-theme") as Theme | null
-    if (stored === "light" || stored === "dark") {
-      setTheme(stored)
-      document.documentElement.classList.toggle("dark", stored === "dark")
-    }
+    const stored = readThemePreference()
+    setTheme(stored)
+    document.documentElement.classList.toggle("dark", stored === "dark")
   }, [])
 
   const toggle = useCallback(() => {
     setTheme((prev) => {
       const next = prev === "dark" ? "light" : "dark"
-      localStorage.setItem("cortex-theme", next)
+      writeThemePreference(next)
       document.documentElement.classList.toggle("dark", next === "dark")
       return next
     })


### PR DESCRIPTION
## Summary
- Wraps `localStorage.getItem`/`setItem` in `theme-provider.tsx` with try-catch guards, mirroring the safe pattern from nav-shell (#746)
- Extracts `readThemePreference()` / `writeThemePreference()` helpers that catch `SecurityError` and fall back to defaults
- Adds 4 tests covering: getItem throwing, setItem throwing, valid stored theme, invalid stored value

## Why this fixes the mobile crash
PR #746 fixed the nav-shell sidebar localStorage crash but `theme-provider.tsx` still accessed `localStorage` directly. On mobile browsers in private mode or embedded webviews, `localStorage.getItem()` throws a `SecurityError`, which propagated as an unhandled Next.js client-side exception on page load — crashing the entire dashboard UI.

The fix catches these errors and falls back to the default dark theme, keeping the app functional even when storage is unavailable.

## Verification steps
1. Open dashboard in mobile Safari private mode (or Chrome with storage blocked via DevTools → Application → Storage → block cookies)
2. Confirm page loads without client-side crash
3. Toggle theme — should work; preference won't persist (expected when storage is blocked)
4. Open in normal mode — theme preference persists as before

## Test plan
- [x] `npx vitest run src/__tests__/theme-provider-storage.test.ts` — 4/4 pass
- [x] ESLint clean on changed files
- [ ] Manual verification on mobile private mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme persistence reliability with graceful error handling for storage access failures
  * Theme now safely defaults to dark mode when storage is unavailable or contains invalid values

* **Tests**
  * Added comprehensive test suite for theme preference storage, covering error handling and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->