### PR TITLE
fix(dashboard): prevent bg crash on resilient lifecycle states

### DIFF
--- a/packages/dashboard/src/__tests__/agent-status-badge.test.ts
+++ b/packages/dashboard/src/__tests__/agent-status-badge.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+
+import { getAgentStateStyle } from "@/components/agents/agent-status-badge"
+
+describe("AgentStatusBadge style resolver", () => {
+  it("returns mapped style for QUARANTINED state", () => {
+    const style = getAgentStateStyle("QUARANTINED")
+    expect(style.bg).toContain("bg-red-500/10")
+  })
+
+  it("returns mapped style for DEGRADED state", () => {
+    const style = getAgentStateStyle("DEGRADED")
+    expect(style.bg).toContain("bg-amber-500/10")
+  })
+
+  it("falls back safely for unknown state (prevents reading .bg crash)", () => {
+    const style = getAgentStateStyle("UNKNOWN_STATE")
+    expect(style).toMatchObject({
+      bg: "bg-slate-500/10",
+      text: "text-slate-500 dark:text-slate-400",
+      border: "border-slate-500/20",
+    })
+  })
+})

--- a/packages/dashboard/src/__tests__/schemas.test.ts
+++ b/packages/dashboard/src/__tests__/schemas.test.ts
@@ -79,6 +79,26 @@ describe("AgentSummarySchema", () => {
     expect(() => AgentSummarySchema.parse({ ...validAgent, lifecycle_state: "RUNNING" })).toThrow()
   })
 
+  it("accepts all valid lifecycle states", () => {
+    const lifecycleStates = [
+      "BOOTING",
+      "HYDRATING",
+      "READY",
+      "EXECUTING",
+      "DRAINING",
+      "TERMINATED",
+      "DEGRADED",
+      "QUARANTINED",
+      "SAFE_MODE",
+    ]
+
+    for (const lifecycle_state of lifecycleStates) {
+      expect(AgentSummarySchema.parse({ ...validAgent, lifecycle_state }).lifecycle_state).toBe(
+        lifecycle_state,
+      )
+    }
+  })
+
   it("accepts all valid statuses including QUARANTINED", () => {
     for (const status of ["ACTIVE", "DISABLED", "ARCHIVED", "QUARANTINED"]) {
       expect(AgentSummarySchema.parse({ ...validAgent, status }).status).toBe(status)

--- a/packages/dashboard/src/components/agents/agent-status-badge.tsx
+++ b/packages/dashboard/src/components/agents/agent-status-badge.tsx
@@ -1,9 +1,15 @@
 import type { AgentLifecycleState } from "@/lib/api-client"
 
-const stateStyles: Record<
-  AgentLifecycleState,
-  { dot: string; bg: string; text: string; border: string }
-> = {
+type StatusStyle = { dot: string; bg: string; text: string; border: string }
+
+const fallbackStyle: StatusStyle = {
+  dot: "bg-slate-400",
+  bg: "bg-slate-500/10",
+  text: "text-slate-500 dark:text-slate-400",
+  border: "border-slate-500/20",
+}
+
+const stateStyles: Partial<Record<AgentLifecycleState, StatusStyle>> = {
   BOOTING: {
     dot: "bg-yellow-400",
     bg: "bg-yellow-500/10",
@@ -40,6 +46,24 @@ const stateStyles: Record<
     text: "text-slate-500",
     border: "border-slate-500/20",
   },
+  DEGRADED: {
+    dot: "bg-amber-400",
+    bg: "bg-amber-500/10",
+    text: "text-amber-500 dark:text-amber-400",
+    border: "border-amber-500/20",
+  },
+  QUARANTINED: {
+    dot: "bg-red-500",
+    bg: "bg-red-500/10",
+    text: "text-red-500 dark:text-red-400",
+    border: "border-red-500/20",
+  },
+  SAFE_MODE: {
+    dot: "bg-purple-400",
+    bg: "bg-purple-500/10",
+    text: "text-purple-500 dark:text-purple-400",
+    border: "border-purple-500/20",
+  },
 }
 
 /** Extra state for ERROR display (not in AgentLifecycleState enum but shown in UI). */
@@ -55,9 +79,15 @@ interface AgentStatusBadgeProps {
   hasError?: boolean
 }
 
+export function getAgentStateStyle(state: string | undefined, hasError = false): StatusStyle {
+  if (hasError) return errorStyle
+  if (!state) return stateStyles.READY ?? fallbackStyle
+  return stateStyles[state as AgentLifecycleState] ?? fallbackStyle
+}
+
 export function AgentStatusBadge({ state, hasError }: AgentStatusBadgeProps): React.JSX.Element {
   const resolvedState = state ?? "READY"
-  const style = hasError ? errorStyle : stateStyles[resolvedState]
+  const style = getAgentStateStyle(resolvedState, hasError)
   const label = hasError ? "ERROR" : resolvedState
 
   return (

--- a/packages/dashboard/src/components/agents/lifecycle-timeline.tsx
+++ b/packages/dashboard/src/components/agents/lifecycle-timeline.tsx
@@ -15,8 +15,11 @@ interface LifecycleTimelineProps {
 const LIFECYCLE_ORDER: AgentLifecycleState[] = [
   "BOOTING",
   "HYDRATING",
+  "SAFE_MODE",
   "READY",
   "EXECUTING",
+  "DEGRADED",
+  "QUARANTINED",
   "DRAINING",
   "TERMINATED",
 ]
@@ -24,8 +27,11 @@ const LIFECYCLE_ORDER: AgentLifecycleState[] = [
 const stepIcons: Record<AgentLifecycleState, string> = {
   BOOTING: "rocket_launch",
   HYDRATING: "database",
+  SAFE_MODE: "safety_check",
   READY: "check_circle",
   EXECUTING: "bolt",
+  DEGRADED: "warning",
+  QUARANTINED: "shield",
   DRAINING: "water_drop",
   TERMINATED: "flag",
 }

--- a/packages/dashboard/src/lib/schemas/agents.ts
+++ b/packages/dashboard/src/lib/schemas/agents.ts
@@ -11,6 +11,9 @@ export const AgentLifecycleStateSchema = z.enum([
   "EXECUTING",
   "DRAINING",
   "TERMINATED",
+  "DEGRADED",
+  "QUARANTINED",
+  "SAFE_MODE",
 ])
 
 export const CheckpointSchema = z.object({


### PR DESCRIPTION
## Summary
- expand dashboard lifecycle schema to include DEGRADED, QUARANTINED, and SAFE_MODE
- harden AgentStatusBadge with explicit mappings for resilient states plus a safe fallback style to prevent undefined.bg access
- update lifecycle timeline icon/state coverage for the expanded lifecycle set
- add regression tests for state-style resolution and expanded lifecycle schema acceptance

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build

Fixes #750


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new agent lifecycle states: SAFE_MODE, DEGRADED, and QUARANTINED.
  * Agent status timeline now displays the new states with appropriate icons.

* **Bug Fixes**
  * Improved agent status badge styling to gracefully handle unknown states with fallback styling.

* **Tests**
  * Added comprehensive test coverage for agent status displays and lifecycle state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->