### PR TITLE
fix: propagate dashboard auth to browser observation routes (#754)

### DIFF
--- a/packages/control-plane/src/__tests__/observation-routes.test.ts
+++ b/packages/control-plane/src/__tests__/observation-routes.test.ts
@@ -4,6 +4,7 @@ import type { Runner } from "graphile-worker"
 import type { Kysely } from "kysely"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import type { SessionData, SessionService } from "../auth/session-service.js"
 import type { Database } from "../db/types.js"
 import type { AgentLifecycleManager } from "../lifecycle/manager.js"
 import type { AgentLifecycleState } from "../lifecycle/state-machine.js"
@@ -120,6 +121,26 @@ const VALID_SESSION = {
   status: "active",
 }
 
+const VALID_DASHBOARD_SESSION: SessionData = {
+  session: {
+    id: "dash-session-1",
+    user_account_id: "dash-user-1",
+    csrf_token: "csrf-tok",
+    expires_at: new Date(Date.now() + 86400_000),
+    created_at: new Date(),
+    updated_at: new Date(),
+    refresh_token_hash: null,
+    refresh_expires_at: null,
+  },
+  user: {
+    userId: "dash-user-1",
+    email: "user@example.com",
+    displayName: "Dashboard User",
+    avatarUrl: null,
+    role: "admin",
+  },
+}
+
 const AUTH_HEADER = { authorization: "Bearer session-123" }
 
 const AUTH_HEADERS = {
@@ -127,10 +148,23 @@ const AUTH_HEADERS = {
   "content-type": "application/json",
 }
 
+function mockSessionService(sessionData: SessionData | null = null): SessionService {
+  return {
+    validateSession: vi.fn().mockResolvedValue(sessionData),
+    createSession: vi.fn(),
+    destroySession: vi.fn(),
+    cleanupExpired: vi.fn(),
+    validateCsrf: vi.fn(),
+    serializeCookie: vi.fn(),
+    serializeClearCookie: vi.fn(),
+  } as unknown as SessionService
+}
+
 async function buildTestApp(options: {
   session?: Record<string, unknown> | null
   lifecycleManager?: AgentLifecycleManager
   observationService?: BrowserObservationService
+  sessionService?: SessionService
 }) {
   const app = Fastify({ logger: false })
   const db = mockDb("session" in options ? options.session : VALID_SESSION)
@@ -148,6 +182,7 @@ async function buildTestApp(options: {
       sseManager,
       lifecycleManager: lifecycle,
       observationService: observation,
+      sessionService: options.sessionService,
     }),
   )
 
@@ -190,6 +225,45 @@ describe("observation route authentication", () => {
       headers: AUTH_HEADERS,
     })
     expect(res.statusCode).toBe(403)
+  })
+})
+
+describe("observation route cookie authentication", () => {
+  it("authenticates observe routes via dashboard session cookie", async () => {
+    const sessionService = mockSessionService(VALID_DASHBOARD_SESSION)
+    const { app } = await buildTestApp({ sessionService })
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/agents/agent-1/observe/stream-status",
+      headers: { cookie: "cortex_session=dash-session-1" },
+    })
+
+    expect(res.statusCode).toBe(200)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(sessionService.validateSession).toHaveBeenCalledWith("dash-session-1")
+  })
+
+  it("authenticates browser routes via dashboard session cookie", async () => {
+    const sessionService = mockSessionService(VALID_DASHBOARD_SESSION)
+    const { app } = await buildTestApp({ sessionService })
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/agents/agent-1/browser/steer",
+      headers: {
+        cookie: "cortex_session=dash-session-1",
+        "content-type": "application/json",
+      },
+      payload: {
+        type: "click",
+        coordinates: { x: 10, y: 20 },
+        selector: "#login",
+      },
+    })
+
+    expect(res.statusCode).toBe(202)
+    expect(res.json<{ agentId: string }>().agentId).toBe("agent-1")
   })
 })
 

--- a/packages/control-plane/src/routes/observation.ts
+++ b/packages/control-plane/src/routes/observation.ts
@@ -23,8 +23,9 @@
  * POST   /agents/:agentId/browser/trace/stop          — Stop trace + register metadata
  * GET    /agents/:agentId/browser/screenshot/stream    — SSE screenshot stream
  *
- * All endpoints require per-session Bearer token authentication.
- * Auth handoff additionally requires the "approver" role via API key auth.
+ * Observation and browser streaming endpoints support either dashboard session
+ * cookies or per-session Bearer tokens. Auth handoff additionally requires the
+ * "approver" role.
  */
 
 import { randomUUID } from "node:crypto"
@@ -106,10 +107,11 @@ export function observationRoutes(deps: ObservationRouteDeps) {
     traceCaptureService,
     screenshotModeService,
     authConfig,
+    sessionService,
   } = deps
 
   return function register(app: FastifyInstance): void {
-    const authHook = createStreamAuth(app.db)
+    const authHook = createStreamAuth({ db: app.db, sessionService })
 
     // Helper: verify agent exists and is alive (if lifecycle manager is available)
     function getAgentOrFail(agentId: string, reply: FastifyReply): boolean {

--- a/packages/dashboard/src/__tests__/api-proxy-route.test.ts
+++ b/packages/dashboard/src/__tests__/api-proxy-route.test.ts
@@ -1,0 +1,84 @@
+import { NextRequest } from "next/server"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { GET, POST } from "@/app/api/[...path]/route"
+
+describe("dashboard API proxy browser auth propagation", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("forwards dashboard session cookies on browser observation GET routes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const request = new NextRequest(
+      "http://dashboard.local/api/agents/agent-1/observe/stream-status",
+      {
+        headers: {
+          cookie: "cortex_session=dash-session-1; other=value",
+        },
+      },
+    )
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["agents", "agent-1", "observe", "stream-status"] }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("http://localhost:4000/agents/agent-1/observe/stream-status")
+    expect(new Headers(init.headers).get("cookie")).toContain("cortex_session=dash-session-1")
+  })
+
+  it("forwards bearer auth and request bodies on browser routes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 202,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const request = new NextRequest(
+      "http://dashboard.local/api/agents/agent-1/browser/steer?source=dashboard",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer session-123",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          type: "click",
+          coordinates: { x: 1, y: 2 },
+        }),
+      },
+    )
+
+    const response = await POST(request, {
+      params: Promise.resolve({ path: ["agents", "agent-1", "browser", "steer"] }),
+    })
+
+    expect(response.status).toBe(202)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("http://localhost:4000/agents/agent-1/browser/steer?source=dashboard")
+    expect(init.method).toBe("POST")
+    expect(new Headers(init.headers).get("authorization")).toBe("Bearer session-123")
+
+    const forwardedBody = await new Response(init.body as BodyInit).text()
+    expect(JSON.parse(forwardedBody)).toEqual({
+      type: "click",
+      coordinates: { x: 1, y: 2 },
+    })
+  })
+})


### PR DESCRIPTION
Closes #754.

## Summary
- pass `SessionService` into observation route stream auth so dashboard session cookies are accepted on browser observation and browser orchestration routes
- add control-plane regression tests for cookie-authenticated dashboard access to `/agents/:agentId/observe/*` and `/agents/:agentId/browser/*`
- add dashboard proxy regression tests to ensure browser route cookies, bearer auth headers, query strings, and bodies are forwarded upstream

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Test Evidence
- control-plane: `src/__tests__/observation-routes.test.ts` now covers dashboard session-cookie auth on observe and browser routes
- dashboard: `src/__tests__/api-proxy-route.test.ts` verifies auth propagation through the Next API proxy for browser observation endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Observation and browser streaming endpoints now support authentication via dashboard session cookies in addition to Bearer tokens.

* **Tests**
  * Added comprehensive test coverage for session cookie authentication flows and API proxy request forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->