### PR TITLE
docs: close #705 tracker audit references

### DIFF
--- a/docs/audits/ui-api-contract-ledger-2026-03-20.md
+++ b/docs/audits/ui-api-contract-ledger-2026-03-20.md
@@ -1,6 +1,6 @@
 # UI/API Contract Ledger: Dashboard Action Surface
 
-Issues: #704, #726 (re-triage)
+Issues: #704, #705 (epic tracker closure)
 
 Audit scope: dashboard action client methods in `packages/dashboard/src/lib/api-client.ts` and their paired response schemas in `packages/dashboard/src/lib/schemas/actions.ts`, mapped to live control-plane routes.
 
@@ -23,7 +23,7 @@ Session contract follow-up (#724):
 | Session delete semantics   | `DELETE /sessions/:id` | Fixed  | Hard-delete contract (`action: "deleted"`, `deleted: true`) aligned |
 | Dashboard session controls | Session list UI        | Fixed  | Labels and toasts use "Delete" semantics                            |
 
-#726 acceptance snapshot:
+#705 epic acceptance snapshot:
 
 - ✅ Action matrix produced with per-endpoint status (table above)
 - ✅ In-scope mismatches resolved (see `Fixed` rows)


### PR DESCRIPTION
## Summary\n- align the UI/API contract audit ledger issue references to the active epic tracker (#705)\n- rename acceptance snapshot heading from #726 to #705 for consistent tracker closure notes\n\n## Validation\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n- pnpm build\n\nFixes #705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal audit documentation references and section headings for tracking purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->