### PR TITLE
fix: Anthropic OAuth connection test uses x-api-key for /v1/models

### DIFF
--- a/packages/control-plane/src/__tests__/credential-service.test.ts
+++ b/packages/control-plane/src/__tests__/credential-service.test.ts
@@ -945,7 +945,7 @@ describe("CredentialService.testCredential", () => {
     })
   })
 
-  it("verifies Anthropic OAuth credentials with Bearer auth", async () => {
+  it("verifies Anthropic OAuth credentials with x-api-key auth", async () => {
     const oauthToken = "anthropic-oauth-token"
     const cred = makeCredRow({
       provider: "anthropic",
@@ -972,10 +972,10 @@ describe("CredentialService.testCredential", () => {
     expect(init.method).toBe("GET")
     expect(init.signal).toBeInstanceOf(AbortSignal)
     expect(init.headers).toMatchObject({
-      Authorization: `Bearer ${oauthToken}`,
+      "x-api-key": oauthToken,
       "anthropic-version": "2023-06-01",
     })
-    expect((init.headers as Record<string, string>)["x-api-key"]).toBeUndefined()
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined()
   })
 
   it("verifies OpenAI Codex OAuth via /v1/me instead of /v1/models", async () => {

--- a/packages/control-plane/src/auth/credential-service.ts
+++ b/packages/control-plane/src/auth/credential-service.ts
@@ -1125,7 +1125,7 @@ export class CredentialService {
   private buildProviderPing(
     provider: string,
     token: string,
-    credentialType?: "oauth" | "api_key",
+    _credentialType?: "oauth" | "api_key",
   ): { url: string; init: RequestInit } {
     switch (provider) {
       case "openai":
@@ -1144,9 +1144,9 @@ export class CredentialService {
       case "anthropic": {
         const headers: Record<string, string> = {
           "anthropic-version": "2023-06-01",
-          ...(credentialType === "oauth"
-            ? { Authorization: `Bearer ${token}` }
-            : { "x-api-key": token }),
+          // Anthropic /v1/models expects x-api-key for both API-key and
+          // OAuth-derived tokens in Cortex Plane flows.
+          "x-api-key": token,
         }
         return {
           url: "https://api.anthropic.com/v1/models",


### PR DESCRIPTION
## Summary
Fixes #758 by aligning Anthropic credential verification with existing runtime/discovery behavior.

## Changes
- Updated `CredentialService.buildProviderPing` for `anthropic` to send `x-api-key` for both API key and OAuth-derived tokens on `/v1/models`.
- Updated credential-service tests to assert `x-api-key` usage for Anthropic OAuth verification.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Anthropic credential authentication to use x-api-key headers instead of Bearer authorization tokens for proper API communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->