### PR TITLE
Implement browser tool runtime end to end

### DIFF
--- a/packages/control-plane/src/__tests__/browser-tool-runtime.test.ts
+++ b/packages/control-plane/src/__tests__/browser-tool-runtime.test.ts
@@ -1,0 +1,280 @@
+import type { ExecutionTask, OutputEvent } from "@cortex/shared/backends"
+import { describe, expect, it, vi } from "vitest"
+
+import { HttpLlmBackend } from "../backends/http-llm.js"
+import { BrowserActionError } from "../observation/service.js"
+
+function makeTask(overrides?: Partial<ExecutionTask>): ExecutionTask {
+  return {
+    id: "task-browser-001",
+    jobId: "job-browser-001",
+    agentId: "agent-1",
+    instruction: {
+      prompt: "Open example.com in the browser",
+      goalType: "research",
+    },
+    context: {
+      workspacePath: "/workspace",
+      systemPrompt: "You are a test assistant.",
+      memories: [],
+      relevantFiles: {},
+      environment: {},
+    },
+    constraints: {
+      timeoutMs: 30_000,
+      maxTokens: 4096,
+      model: "claude-sonnet-4-5-20250929",
+      allowedTools: ["playwright_navigate"],
+      deniedTools: [],
+      maxTurns: 3,
+      networkAccess: true,
+      shellAccess: false,
+    },
+    ...overrides,
+  }
+}
+
+function createMockAnthropicStream(opts: {
+  textContent: string
+  toolUseBlocks?: Array<{ id: string; name: string; input: Record<string, unknown> }>
+  stopReason: string
+  inputTokens?: number
+  outputTokens?: number
+}) {
+  const { textContent, toolUseBlocks = [], stopReason, inputTokens = 10, outputTokens = 20 } = opts
+
+  const contentBlocks: unknown[] = []
+  if (textContent) {
+    contentBlocks.push({ type: "text", text: textContent })
+  }
+  for (const tool of toolUseBlocks) {
+    contentBlocks.push({ type: "tool_use", id: tool.id, name: tool.name, input: tool.input })
+  }
+
+  const events: unknown[] = textContent
+    ? [
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: textContent },
+        },
+      ]
+    : []
+
+  const finalMessage = {
+    id: "msg-browser-test",
+    type: "message",
+    role: "assistant",
+    content: contentBlocks,
+    model: "test",
+    stop_reason: stopReason,
+    usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+  }
+
+  let eventIndex = 0
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: () => {
+          if (eventIndex < events.length) {
+            return Promise.resolve({ value: events[eventIndex++], done: false as const })
+          }
+          return Promise.resolve({ value: undefined, done: true as const })
+        },
+      }
+    },
+    finalMessage: () => Promise.resolve(finalMessage),
+    abort: vi.fn(),
+  }
+}
+
+async function collectEvents(handle: { events(): AsyncIterable<OutputEvent> }) {
+  const events: OutputEvent[] = []
+  for await (const event of handle.events()) {
+    events.push(event)
+  }
+  return events
+}
+
+function makeDbRecorder() {
+  const inserts: Array<{ table: string; values: Record<string, unknown> }> = []
+
+  return {
+    db: {
+      insertInto: vi.fn().mockImplementation((table: string) => ({
+        values: (values: Record<string, unknown>) => ({
+          execute: vi.fn().mockImplementation(() => {
+            inserts.push({ table, values })
+            return Promise.resolve([])
+          }),
+        }),
+      })),
+    },
+    inserts,
+  }
+}
+
+describe("browser tool runtime", () => {
+  it("executes playwright_navigate through the standard agent tool loop", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "test-key" })
+
+    const navigate = vi.fn().mockResolvedValue({
+      agentId: "agent-1",
+      url: "https://example.com/",
+      title: "Example Domain",
+      timestamp: "2026-04-04T00:00:00.000Z",
+      session: {
+        agentId: "agent-1",
+        status: "connected",
+        sessionId: "session-1",
+        targetId: "target-1",
+        currentUrl: "https://example.com/",
+        currentTitle: "Example Domain",
+        errorMessage: null,
+        lastHeartbeat: "2026-04-04T00:00:00.000Z",
+      },
+      tabs: [{ index: 0, url: "https://example.com/", title: "Example Domain", active: true }],
+    })
+    const captureScreenshot = vi.fn().mockResolvedValue({
+      agentId: "agent-1",
+      data: "abc123",
+      format: "jpeg",
+      width: 1280,
+      height: 720,
+      timestamp: "2026-04-04T00:00:01.000Z",
+      url: "https://example.com/",
+      title: "Example Domain",
+    })
+    const observationService = {
+      navigate,
+      captureScreenshot,
+    }
+    const { db, inserts } = makeDbRecorder()
+
+    const registry = await backend.createAgentRegistry(
+      {},
+      {
+        agentId: "agent-1",
+        allowedTools: ["playwright_navigate"],
+        deniedTools: [],
+        browser: {
+          db: db as never,
+          observationService: observationService as never,
+        },
+      },
+    )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const client = (backend as any).anthropicClient
+    let callCount = 0
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    vi.spyOn(client.messages, "stream").mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        return createMockAnthropicStream({
+          textContent: "Opening the page.",
+          toolUseBlocks: [
+            {
+              id: "toolu_browser_1",
+              name: "playwright_navigate",
+              input: { url: "https://example.com" },
+            },
+          ],
+          stopReason: "tool_use",
+        })
+      }
+      return createMockAnthropicStream({
+        textContent: "The browser loaded the page successfully.",
+        stopReason: "end_turn",
+      })
+    })
+
+    const handle = await backend.executeTask(makeTask(), registry)
+    const events = await collectEvents(handle)
+
+    const toolResult = events.find(
+      (event): event is Extract<OutputEvent, { type: "tool_result" }> =>
+        event.type === "tool_result",
+    )
+    expect(toolResult).toBeDefined()
+    expect(toolResult?.toolName).toBe("playwright_navigate")
+    expect(toolResult?.isError).toBe(false)
+    expect(toolResult?.output).toContain('"ok": true')
+    expect(toolResult?.output).toContain('"title": "Example Domain"')
+    expect(navigate).toHaveBeenCalledWith("agent-1", "https://example.com/")
+    expect(captureScreenshot).toHaveBeenCalledTimes(1)
+    expect(inserts.filter((entry) => entry.table === "browser_event")).toHaveLength(2)
+    expect(inserts.filter((entry) => entry.table === "browser_screenshot")).toHaveLength(1)
+  })
+
+  it("returns explicit browser connection failures and persists an error event", async () => {
+    const backend = new HttpLlmBackend()
+    await backend.start({ provider: "anthropic", apiKey: "test-key" })
+
+    const navigate = vi
+      .fn()
+      .mockRejectedValue(
+        new BrowserActionError("BROWSER_CONNECTION_FAILED", "WebSocket connection timeout"),
+      )
+    const observationService = {
+      navigate,
+      captureScreenshot: vi.fn(),
+    }
+    const { db, inserts } = makeDbRecorder()
+
+    const registry = await backend.createAgentRegistry(
+      {},
+      {
+        agentId: "agent-1",
+        allowedTools: ["playwright_navigate"],
+        deniedTools: [],
+        browser: {
+          db: db as never,
+          observationService: observationService as never,
+        },
+      },
+    )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const client = (backend as any).anthropicClient
+    let callCount = 0
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    vi.spyOn(client.messages, "stream").mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        return createMockAnthropicStream({
+          textContent: "Trying the browser.",
+          toolUseBlocks: [
+            {
+              id: "toolu_browser_2",
+              name: "playwright_navigate",
+              input: { url: "https://example.com" },
+            },
+          ],
+          stopReason: "tool_use",
+        })
+      }
+      return createMockAnthropicStream({
+        textContent: "The browser connection failed.",
+        stopReason: "end_turn",
+      })
+    })
+
+    const handle = await backend.executeTask(makeTask(), registry)
+    const events = await collectEvents(handle)
+
+    const toolResult = events.find(
+      (event): event is Extract<OutputEvent, { type: "tool_result" }> =>
+        event.type === "tool_result",
+    )
+    expect(toolResult).toBeDefined()
+    expect(toolResult?.isError).toBe(true)
+    expect(toolResult?.output).toContain("BROWSER_CONNECTION_FAILED")
+    expect(inserts.filter((entry) => entry.table === "browser_screenshot")).toHaveLength(0)
+    expect(inserts.filter((entry) => entry.table === "browser_event")).toHaveLength(1)
+    expect(inserts[0]?.values["message"]).toBe(
+      "[BROWSER_CONNECTION_FAILED] WebSocket connection timeout",
+    )
+  })
+})

--- a/packages/control-plane/src/__tests__/cross-boundary-contract.test.ts
+++ b/packages/control-plane/src/__tests__/cross-boundary-contract.test.ts
@@ -230,6 +230,16 @@ async function buildTestApp(
       db,
       enqueueJob: vi.fn().mockResolvedValue(undefined),
       observationService: {
+        getSession: vi.fn().mockReturnValue({
+          agentId: "agent-1",
+          status: "connected",
+          sessionId: "session-agent-1",
+          targetId: "target-agent-1",
+          currentUrl: "https://example.com",
+          currentTitle: "Example",
+          errorMessage: null,
+          lastHeartbeat: new Date().toISOString(),
+        }),
         getStreamStatus: vi.fn().mockResolvedValue({
           agentId: "agent-1",
           quality: "live",
@@ -267,6 +277,16 @@ async function buildTestAppWithSync(memorySyncService: { sync: ReturnType<typeof
       db,
       enqueueJob: vi.fn().mockResolvedValue(undefined),
       observationService: {
+        getSession: vi.fn().mockReturnValue({
+          agentId: "agent-1",
+          status: "disconnected",
+          sessionId: null,
+          targetId: null,
+          currentUrl: null,
+          currentTitle: null,
+          errorMessage: null,
+          lastHeartbeat: null,
+        }),
         getStreamStatus: vi.fn().mockResolvedValue(null),
         listTabs: vi.fn().mockResolvedValue(null),
       } as never,

--- a/packages/control-plane/src/__tests__/dashboard-routes.test.ts
+++ b/packages/control-plane/src/__tests__/dashboard-routes.test.ts
@@ -151,6 +151,16 @@ async function buildTestApp(
       db,
       enqueueJob: vi.fn().mockResolvedValue(undefined),
       observationService: {
+        getSession: vi.fn().mockReturnValue({
+          agentId: "agent-1",
+          status: "connected",
+          sessionId: "session-agent-1",
+          targetId: "target-agent-1",
+          currentUrl: "https://example.com",
+          currentTitle: "Example",
+          errorMessage: null,
+          lastHeartbeat: new Date().toISOString(),
+        }),
         getStreamStatus: vi.fn().mockResolvedValue({
           agentId: "agent-1",
           quality: "live",
@@ -188,6 +198,16 @@ async function buildTestAppWithSync(memorySyncService: { sync: ReturnType<typeof
       db,
       enqueueJob: vi.fn().mockResolvedValue(undefined),
       observationService: {
+        getSession: vi.fn().mockReturnValue({
+          agentId: "agent-1",
+          status: "disconnected",
+          sessionId: null,
+          targetId: null,
+          currentUrl: null,
+          currentTitle: null,
+          errorMessage: null,
+          lastHeartbeat: null,
+        }),
         getStreamStatus: vi.fn().mockResolvedValue(null),
         listTabs: vi.fn().mockResolvedValue(null),
       } as never,
@@ -533,6 +553,46 @@ describe("dashboard routes", () => {
       thumbnailUrl: "/thumbs/shot1.jpg",
       fullUrl: "/shots/shot1.png",
       dimensions: { width: 1920, height: 1080 },
+    })
+  })
+
+  it("returns browser runtime error state from observation service", async () => {
+    const app = Fastify({ logger: false })
+    const db = mockDb()
+
+    await app.register(
+      dashboardRoutes({
+        db,
+        enqueueJob: vi.fn().mockResolvedValue(undefined),
+        observationService: {
+          getSession: vi.fn().mockReturnValue({
+            agentId: "agent-1",
+            status: "error",
+            sessionId: null,
+            targetId: null,
+            currentUrl: null,
+            currentTitle: null,
+            errorMessage: "[BROWSER_CONNECTION_FAILED] WebSocket connection timeout",
+            lastHeartbeat: "2026-03-10T12:01:00.000Z",
+          }),
+          getStreamStatus: vi.fn().mockResolvedValue(null),
+          listTabs: vi.fn().mockResolvedValue(null),
+        } as never,
+        contentService: {
+          list: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+          publish: vi.fn().mockResolvedValue(undefined),
+          archive: vi.fn().mockResolvedValue(undefined),
+        } as never,
+      }),
+    )
+
+    const res = await app.inject({ method: "GET", url: "/agents/agent-1/browser" })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({
+      agentId: "agent-1",
+      status: "error",
+      errorMessage: "[BROWSER_CONNECTION_FAILED] WebSocket connection timeout",
+      tabs: [],
     })
   })
 

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -122,6 +122,12 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
   // resolve per-job LLM credentials from agent_credential_binding (#444).
   const credentialService = config.auth ? new CredentialService(db, config.auth) : undefined
 
+  // Browser observation service + orchestration services
+  const observationService = new BrowserObservationService()
+  const authHandoffService = new AuthHandoffService()
+  const traceCaptureService = new TraceCaptureService()
+  const screenshotModeService = new ScreenshotModeService(observationService)
+
   // Start Graphile Worker alongside Fastify — shared pg.Pool
   const runner = await createWorker({
     pgPool: pool,
@@ -135,6 +141,7 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
     credentialService,
     eventEmitter,
     executionRegistry,
+    observationService,
   })
 
   // Worker utils for job enqueueing from routes
@@ -143,12 +150,6 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
     db,
     threshold: config.memoryExtractThreshold,
   })
-
-  // Browser observation service + orchestration services
-  const observationService = new BrowserObservationService()
-  const authHandoffService = new AuthHandoffService()
-  const traceCaptureService = new TraceCaptureService()
-  const screenshotModeService = new ScreenshotModeService(observationService)
 
   // WebSocket support (used by VNC proxy and future WS endpoints)
   await app.register(fastifyWebSocket)

--- a/packages/control-plane/src/backends/http-llm.ts
+++ b/packages/control-plane/src/backends/http-llm.ts
@@ -44,6 +44,10 @@ export interface McpDeps {
   allowedTools?: string[]
   deniedTools?: string[]
   credentialResolver?: CredentialResolver
+  browser?: {
+    db: import("kysely").Kysely<import("../db/types.js").Database>
+    observationService: import("../observation/service.js").BrowserObservationService
+  }
 }
 
 /**
@@ -306,6 +310,7 @@ export class HttpLlmBackend implements ExecutionBackend {
             allowedTools: mcpDeps.allowedTools,
             deniedTools: mcpDeps.deniedTools,
             credentialResolver: mcpDeps.credentialResolver,
+            browser: mcpDeps.browser,
           }
         : undefined,
     )

--- a/packages/control-plane/src/backends/tool-executor.ts
+++ b/packages/control-plane/src/backends/tool-executor.ts
@@ -5,7 +5,12 @@
  * Tools are registered with a name, description, JSON Schema, and handler.
  */
 
+import type { Kysely } from "kysely"
+
+import type { Database } from "../db/types.js"
 import type { McpToolRouter } from "../mcp/tool-router.js"
+import type { BrowserObservationService } from "../observation/service.js"
+import { createPlaywrightNavigateTool } from "./tools/browser.js"
 import { createHttpRequestTool } from "./tools/http-request.js"
 import { createMemoryQueryTool } from "./tools/memory-query.js"
 import { createMemoryStoreTool } from "./tools/memory-store.js"
@@ -21,6 +26,12 @@ export interface ToolDefinition {
   inputSchema: Record<string, unknown>
   /** Execute the tool and return output text. */
   execute: (input: Record<string, unknown>) => Promise<string>
+}
+
+export interface BrowserToolRegistryDeps {
+  agentId: string
+  db: Kysely<Database>
+  observationService: BrowserObservationService
 }
 
 /**
@@ -94,13 +105,18 @@ export const echoTool: ToolDefinition = {
 }
 
 /** Create a default registry with built-in tools. */
-export function createDefaultToolRegistry(): ToolRegistry {
+export function createDefaultToolRegistry(opts?: {
+  browser?: BrowserToolRegistryDeps
+}): ToolRegistry {
   const registry = new ToolRegistry()
   registry.register(echoTool)
   registry.register(createWebSearchTool())
   registry.register(createMemoryQueryTool())
   registry.register(createMemoryStoreTool())
   registry.register(createHttpRequestTool())
+  if (opts?.browser) {
+    registry.register(createPlaywrightNavigateTool(opts.browser))
+  }
   return registry
 }
 
@@ -122,9 +138,20 @@ export async function createAgentToolRegistry(
     deniedTools?: string[]
     /** Credential resolver for webhook tools with credential refs. */
     credentialResolver?: CredentialResolver
+    browser?: Omit<BrowserToolRegistryDeps, "agentId"> & { agentId?: string }
   },
 ): Promise<ToolRegistry> {
-  const registry = createDefaultToolRegistry()
+  const registry = createDefaultToolRegistry(
+    opts?.browser && (opts.browser.agentId ?? opts.agentId)
+      ? {
+          browser: {
+            agentId: opts.browser.agentId ?? opts.agentId!,
+            db: opts.browser.db,
+            observationService: opts.browser.observationService,
+          },
+        }
+      : undefined,
+  )
 
   const webhookSpecs = parseWebhookTools(agentConfig)
   for (const spec of webhookSpecs) {

--- a/packages/control-plane/src/backends/tools/browser.ts
+++ b/packages/control-plane/src/backends/tools/browser.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from "node:crypto"
+
+import type { Kysely } from "kysely"
+
+import type { Database } from "../../db/types.js"
+import type { BrowserNavigateResult, BrowserObservationService } from "../../observation/service.js"
+import type { ToolDefinition } from "../tool-executor.js"
+
+export interface BrowserToolDeps {
+  agentId: string
+  db: Kysely<Database>
+  observationService: BrowserObservationService
+}
+
+export function createPlaywrightNavigateTool(deps: BrowserToolDeps): ToolDefinition {
+  const { agentId, db, observationService } = deps
+
+  return {
+    name: "playwright_navigate",
+    description:
+      "Navigate the agent browser to a URL, validate the browser connection, and return page observations.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        url: {
+          type: "string",
+          description: "Absolute URL to open in the agent browser session.",
+        },
+      },
+      required: ["url"],
+    },
+    execute: async (input: Record<string, unknown>) => {
+      const rawUrl = typeof input.url === "string" ? input.url.trim() : ""
+      if (!rawUrl) {
+        throw new Error("[BROWSER_ACTION_FAILED] url is required")
+      }
+
+      let targetUrl: string
+      try {
+        targetUrl = new URL(rawUrl).toString()
+      } catch {
+        throw new Error(`[BROWSER_ACTION_FAILED] Invalid URL: ${rawUrl}`)
+      }
+
+      const startedAt = Date.now()
+      try {
+        const result = await observationService.navigate(agentId, targetUrl)
+        await persistNavigateSuccess(db, agentId, result, Date.now() - startedAt)
+
+        const screenshot = await captureScreenshotSafe(observationService, agentId)
+        if (screenshot) {
+          await persistScreenshot(db, agentId, screenshot.url, screenshot.title, screenshot)
+        }
+
+        return JSON.stringify(
+          {
+            ok: true,
+            action: "navigate",
+            session: result.session,
+            page: {
+              url: result.url,
+              title: result.title,
+            },
+            tabs: result.tabs,
+            screenshot:
+              screenshot === null
+                ? null
+                : {
+                    url: screenshot.url,
+                    title: screenshot.title,
+                    width: screenshot.width,
+                    height: screenshot.height,
+                    timestamp: screenshot.timestamp,
+                  },
+          },
+          null,
+          2,
+        )
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "[BROWSER_ACTION_FAILED] Browser action failed"
+
+        await db
+          .insertInto("browser_event")
+          .values({
+            agent_id: agentId,
+            type: "ERROR",
+            url: targetUrl,
+            selector: null,
+            message,
+            duration_ms: Date.now() - startedAt,
+            severity: "error",
+          })
+          .execute()
+
+        throw error instanceof Error ? error : new Error(message)
+      }
+    },
+  }
+}
+
+async function persistNavigateSuccess(
+  db: Kysely<Database>,
+  agentId: string,
+  result: BrowserNavigateResult,
+  durationMs: number,
+): Promise<void> {
+  await db
+    .insertInto("browser_event")
+    .values({
+      agent_id: agentId,
+      type: "NAVIGATE",
+      url: result.url,
+      selector: null,
+      message: result.title ? `Navigated to ${result.title}` : `Navigated to ${result.url}`,
+      duration_ms: durationMs,
+      severity: "info",
+    })
+    .execute()
+}
+
+async function captureScreenshotSafe(
+  observationService: BrowserObservationService,
+  agentId: string,
+): Promise<{
+  data: string
+  format: "jpeg" | "png"
+  width: number
+  height: number
+  timestamp: string
+  url: string
+  title: string
+} | null> {
+  try {
+    return await observationService.captureScreenshot(agentId, {
+      format: "jpeg",
+      quality: 60,
+    })
+  } catch {
+    return null
+  }
+}
+
+async function persistScreenshot(
+  db: Kysely<Database>,
+  agentId: string,
+  pageUrl: string,
+  pageTitle: string,
+  screenshot: {
+    data: string
+    format: "jpeg" | "png"
+    width: number
+    height: number
+    timestamp: string
+    url: string
+    title: string
+  },
+): Promise<void> {
+  const mimeType = screenshot.format === "png" ? "image/png" : "image/jpeg"
+  const dataUrl = `data:${mimeType};base64,${screenshot.data}`
+
+  await db
+    .insertInto("browser_screenshot")
+    .values({
+      id: randomUUID(),
+      agent_id: agentId,
+      thumbnail_url: dataUrl,
+      full_url: dataUrl,
+      width: screenshot.width,
+      height: screenshot.height,
+    })
+    .execute()
+
+  await db
+    .insertInto("browser_event")
+    .values({
+      agent_id: agentId,
+      type: "SNAPSHOT",
+      url: pageUrl,
+      selector: null,
+      message: `Captured screenshot for ${pageTitle || pageUrl}`,
+      duration_ms: null,
+      severity: "info",
+    })
+    .execute()
+}

--- a/packages/control-plane/src/observation/service.ts
+++ b/packages/control-plane/src/observation/service.ts
@@ -50,8 +50,50 @@ interface AgentObservationState {
   traceOptions: TraceRecordingOptions | null
   /** WebSocket connection to CDP for this agent. */
   cdpWs: WebSocket | null
+  sessionStatus: BrowserRuntimeStatus
+  sessionId: string | null
+  targetId: string | null
+  currentUrl: string | null
+  currentTitle: string | null
+  lastError: string | null
+  lastHeartbeat: string | null
   /** Pending annotation callbacks. */
   annotationListeners: Map<string, (event: AnnotationEvent) => void>
+}
+
+export type BrowserRuntimeStatus = "connecting" | "connected" | "disconnected" | "error"
+
+export interface BrowserRuntimeSession {
+  agentId: string
+  status: BrowserRuntimeStatus
+  sessionId: string | null
+  targetId: string | null
+  currentUrl: string | null
+  currentTitle: string | null
+  errorMessage: string | null
+  lastHeartbeat: string | null
+}
+
+export interface BrowserNavigateResult {
+  agentId: string
+  url: string
+  title: string
+  timestamp: string
+  session: BrowserRuntimeSession
+  tabs: TabInfo[]
+}
+
+export class BrowserActionError extends Error {
+  constructor(
+    readonly code:
+      | "BROWSER_PROVISION_FAILED"
+      | "BROWSER_CONNECTION_FAILED"
+      | "BROWSER_ACTION_FAILED",
+    message: string,
+  ) {
+    super(`[${code}] ${message}`)
+    this.name = "BrowserActionError"
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -76,6 +118,20 @@ export class BrowserObservationService {
     this.vncPort = config.vncPort ?? DEFAULT_VNC_PORT
     this.traceDir = config.traceDir ?? DEFAULT_TRACE_DIR
     this.assetDir = config.assetDir ?? DEFAULT_ASSET_DIR
+  }
+
+  getSession(agentId: string): BrowserRuntimeSession {
+    const state = this.getAgentState(agentId)
+    return {
+      agentId,
+      status: state.sessionStatus,
+      sessionId: state.sessionId,
+      targetId: state.targetId,
+      currentUrl: state.currentUrl,
+      currentTitle: state.currentTitle,
+      errorMessage: state.lastError,
+      lastHeartbeat: state.lastHeartbeat,
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -206,6 +262,13 @@ export class BrowserObservationService {
         fromSurface: true,
       })
 
+      this.markConnected(agentId, {
+        sessionId,
+        targetId: pageTarget.targetId,
+        url: pageTarget.url,
+        title: pageTarget.title,
+      })
+
       return {
         agentId,
         data: result.data,
@@ -216,6 +279,78 @@ export class BrowserObservationService {
         url: pageTarget.url,
         title: pageTarget.title,
       }
+    } finally {
+      ws.close()
+    }
+  }
+
+  async navigate(agentId: string, url: string): Promise<BrowserNavigateResult> {
+    const state = this.getAgentState(agentId)
+    state.sessionStatus = "connecting"
+    state.lastError = null
+    state.lastHeartbeat = new Date().toISOString()
+
+    let wsEndpoint: string
+    try {
+      wsEndpoint = await this.discoverCdpWsEndpoint()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Browser sidecar not provisioned"
+      this.markError(agentId, message)
+      throw new BrowserActionError("BROWSER_PROVISION_FAILED", message)
+    }
+
+    const ws = new WebSocket(wsEndpoint)
+
+    try {
+      await this.waitForWsOpen(ws)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Browser connection failed"
+      this.markError(agentId, message)
+      throw new BrowserActionError("BROWSER_CONNECTION_FAILED", message)
+    }
+
+    try {
+      const page = await this.attachToPage(ws)
+      await this.cdpSendSession(ws, page.sessionId, "Page.enable", {})
+
+      const navigateResult = await this.cdpSendSession<{ errorText?: string }>(
+        ws,
+        page.sessionId,
+        "Page.navigate",
+        { url },
+      )
+      if (navigateResult.errorText) {
+        throw new BrowserActionError("BROWSER_ACTION_FAILED", navigateResult.errorText)
+      }
+
+      await this.waitForSessionEvent(ws, page.sessionId, "Page.loadEventFired", 10_000)
+
+      const pageInfo = await this.getTargetInfo(ws, page.targetId)
+      const tabs = await this.listTabs(agentId)
+
+      this.markConnected(agentId, {
+        sessionId: page.sessionId,
+        targetId: page.targetId,
+        url: pageInfo?.url ?? url,
+        title: pageInfo?.title ?? pageInfo?.url ?? url,
+      })
+
+      return {
+        agentId,
+        url: pageInfo?.url ?? url,
+        title: pageInfo?.title ?? pageInfo?.url ?? url,
+        timestamp: new Date().toISOString(),
+        session: this.getSession(agentId),
+        tabs: tabs.tabs,
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Browser action failed"
+      this.markError(agentId, message)
+
+      if (error instanceof BrowserActionError) {
+        throw error
+      }
+      throw new BrowserActionError("BROWSER_ACTION_FAILED", message)
     } finally {
       ws.close()
     }
@@ -253,6 +388,14 @@ export class BrowserObservationService {
         title: page.title,
         active: index === 0, // First page is typically active
       }))
+
+      if (pages[0]) {
+        this.markConnected(agentId, {
+          targetId: pages[0].targetId,
+          url: pages[0].url,
+          title: pages[0].title,
+        })
+      }
 
       return {
         agentId,
@@ -487,6 +630,13 @@ export class BrowserObservationService {
     if (state.cdpWs) {
       state.cdpWs.close()
     }
+    state.sessionStatus = "disconnected"
+    state.sessionId = null
+    state.targetId = null
+    state.currentUrl = null
+    state.currentTitle = null
+    state.lastError = null
+    state.lastHeartbeat = new Date().toISOString()
     state.annotationListeners.clear()
     this.agents.delete(agentId)
     return Promise.resolve()
@@ -506,7 +656,9 @@ export class BrowserObservationService {
   // -------------------------------------------------------------------------
 
   private async discoverCdpWsEndpoint(): Promise<string> {
-    const res = await fetch(`http://${this.cdpHost}:${this.cdpPort}/json/version`)
+    const res = await fetch(`http://${this.cdpHost}:${this.cdpPort}/json/version`, {
+      signal: AbortSignal.timeout(5_000),
+    })
     if (!res.ok) {
       throw new Error(`CDP version endpoint returned ${res.status}`)
     }
@@ -541,6 +693,33 @@ export class BrowserObservationService {
         clearTimeout(timeout)
         reject(err)
       })
+    })
+  }
+
+  private waitForSessionEvent(
+    ws: WebSocket,
+    sessionId: string,
+    method: string,
+    timeoutMs: number,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error(`Timed out waiting for ${method}`)),
+        timeoutMs,
+      )
+
+      const handler = (rawMsg: Buffer | string) => {
+        const msg = JSON.parse(rawMsg.toString()) as {
+          method?: string
+          sessionId?: string
+        }
+        if (msg.method !== method || msg.sessionId !== sessionId) return
+        clearTimeout(timeout)
+        ws.off("message", handler)
+        resolve()
+      }
+
+      ws.on("message", handler)
     })
   }
 
@@ -605,6 +784,80 @@ export class BrowserObservationService {
     })
   }
 
+  private async attachToPage(
+    ws: WebSocket,
+  ): Promise<{ sessionId: string; targetId: string; url: string; title: string }> {
+    const targets = await this.cdpSend<{
+      targetInfos: Array<{ type: string; targetId: string; url: string; title: string }>
+    }>(ws, "Target.getTargets", {})
+    let pageTarget = targets.targetInfos.find((t) => t.type === "page")
+
+    if (!pageTarget) {
+      const created = await this.cdpSend<{ targetId: string }>(ws, "Target.createTarget", {
+        url: "about:blank",
+      })
+      pageTarget = {
+        type: "page",
+        targetId: created.targetId,
+        url: "about:blank",
+        title: "about:blank",
+      }
+    }
+
+    const { sessionId } = await this.cdpSend<{ sessionId: string }>(ws, "Target.attachToTarget", {
+      targetId: pageTarget.targetId,
+      flatten: true,
+    })
+
+    return {
+      sessionId,
+      targetId: pageTarget.targetId,
+      url: pageTarget.url,
+      title: pageTarget.title,
+    }
+  }
+
+  private async getTargetInfo(
+    ws: WebSocket,
+    targetId: string,
+  ): Promise<{ url: string; title: string } | null> {
+    const targets = await this.cdpSend<{
+      targetInfos: Array<{ type: string; targetId: string; url: string; title: string }>
+    }>(ws, "Target.getTargets", {})
+    const pageTarget = targets.targetInfos.find((target) => target.targetId === targetId)
+    if (!pageTarget) return null
+    return {
+      url: pageTarget.url,
+      title: pageTarget.title,
+    }
+  }
+
+  private markConnected(
+    agentId: string,
+    update: {
+      sessionId?: string
+      targetId?: string
+      url?: string
+      title?: string
+    },
+  ): void {
+    const state = this.getAgentState(agentId)
+    state.sessionStatus = "connected"
+    if (update.sessionId !== undefined) state.sessionId = update.sessionId
+    if (update.targetId !== undefined) state.targetId = update.targetId
+    if (update.url !== undefined) state.currentUrl = update.url
+    if (update.title !== undefined) state.currentTitle = update.title
+    state.lastError = null
+    state.lastHeartbeat = new Date().toISOString()
+  }
+
+  private markError(agentId: string, message: string): void {
+    const state = this.getAgentState(agentId)
+    state.sessionStatus = "error"
+    state.lastError = message
+    state.lastHeartbeat = new Date().toISOString()
+  }
+
   // -------------------------------------------------------------------------
   // Private: Per-agent state
   // -------------------------------------------------------------------------
@@ -617,6 +870,13 @@ export class BrowserObservationService {
         traceStartedAt: null,
         traceOptions: null,
         cdpWs: null,
+        sessionStatus: "disconnected",
+        sessionId: null,
+        targetId: null,
+        currentUrl: null,
+        currentTitle: null,
+        lastError: null,
+        lastHeartbeat: null,
         annotationListeners: new Map(),
       }
       this.agents.set(agentId, state)

--- a/packages/control-plane/src/routes/dashboard.ts
+++ b/packages/control-plane/src/routes/dashboard.ts
@@ -827,9 +827,12 @@ export function dashboardRoutes(deps: DashboardRouteDeps) {
     app.get<{ Params: AgentParams }>("/agents/:agentId/browser", async (request, reply) => {
       const { agentId } = request.params
 
+      const runtimeSession = observationService.getSession(agentId)
       const [streamStatus, tabsResult] = await Promise.all([
         observationService.getStreamStatus(agentId).catch(() => null),
-        observationService.listTabs(agentId).catch(() => null),
+        runtimeSession.status === "connected" || runtimeSession.status === "connecting"
+          ? observationService.listTabs(agentId).catch(() => null)
+          : Promise.resolve(null),
       ])
 
       const tabs = (tabsResult?.tabs ?? []).map((tab, index) => ({
@@ -843,10 +846,11 @@ export function dashboardRoutes(deps: DashboardRouteDeps) {
         id: `browser-${agentId}`,
         agentId,
         vncUrl: streamStatus?.vncEndpoint?.websocketUrl ?? null,
-        status: streamStatus?.vncEndpoint ? "connected" : "disconnected",
+        status: runtimeSession.status,
         tabs,
-        latencyMs: streamStatus?.vncEndpoint ? 35 : 0,
-        lastHeartbeat: new Date().toISOString(),
+        latencyMs: runtimeSession.status === "connected" ? 35 : 0,
+        lastHeartbeat: runtimeSession.lastHeartbeat ?? undefined,
+        errorMessage: runtimeSession.errorMessage ?? undefined,
       })
     })
 

--- a/packages/control-plane/src/worker/index.ts
+++ b/packages/control-plane/src/worker/index.ts
@@ -21,6 +21,7 @@ import type { Database } from "../db/types.js"
 import type { McpToolRouter } from "../mcp/tool-router.js"
 import type { AgentEventEmitter } from "../observability/event-emitter.js"
 import type { ExecutionRegistry } from "../observability/execution-registry.js"
+import type { BrowserObservationService } from "../observation/service.js"
 import type { SSEConnectionManager } from "../streaming/manager.js"
 import { createAgentExecuteTask } from "./tasks/agent-execute.js"
 import { createApprovalExpireTask } from "./tasks/approval-expire.js"
@@ -48,6 +49,8 @@ export interface WorkerOptions {
   executionRegistry?: ExecutionRegistry
   /** Optional credential service for resolving per-job LLM credentials from agent bindings. */
   credentialService?: CredentialService
+  /** Optional browser observation/runtime service for browser tools. */
+  observationService?: BrowserObservationService
 }
 
 /**
@@ -68,6 +71,7 @@ export async function createWorker(options: WorkerOptions): Promise<Runner> {
     eventEmitter,
     executionRegistry,
     credentialService,
+    observationService,
   } = options
 
   const workerConcurrency =
@@ -84,6 +88,7 @@ export async function createWorker(options: WorkerOptions): Promise<Runner> {
       credentialService,
       eventEmitter,
       executionRegistry,
+      observationService,
     }),
     memory_extract: createMemoryExtractTask(undefined, db),
     approval_expire: createApprovalExpireTask(db),

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -46,6 +46,7 @@ import type { McpToolRouter } from "../../mcp/tool-router.js"
 import { CostTracker } from "../../observability/cost-tracker.js"
 import type { AgentEventEmitter } from "../../observability/event-emitter.js"
 import type { ExecutionRegistry } from "../../observability/execution-registry.js"
+import type { BrowserObservationService } from "../../observation/service.js"
 import type { SSEConnectionManager } from "../../streaming/manager.js"
 import type { AgentOutputPayload } from "../../streaming/types.js"
 import { classifyError, isConfigErrorCategory } from "../error-classifier.js"
@@ -85,6 +86,8 @@ export interface AgentExecuteDeps {
   userRateLimiter?: UserRateLimiter
   /** Optional capability assembler for V2 capability model (CAPABILITY_MODEL_V2=true). */
   capabilityAssembler?: CapabilityAssembler
+  /** Optional browser observation/runtime service for browser tools. */
+  observationService?: BrowserObservationService
 }
 
 /** Polling interval (ms) for checking cancellation. */
@@ -113,6 +116,7 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
     executionRegistry,
     userRateLimiter,
     capabilityAssembler,
+    observationService,
   } = deps
   const memoryScheduler = createMemoryScheduler({ db, threshold: memoryExtractThreshold })
 
@@ -589,6 +593,7 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                   allowedTools: task.constraints.allowedTools,
                   deniedTools: task.constraints.deniedTools,
                   credentialResolver,
+                  ...(observationService ? { browser: { db, observationService } } : {}),
                 }
               : credentialResolver
                 ? {
@@ -597,7 +602,14 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                     deniedTools: task.constraints.deniedTools,
                     credentialResolver,
                   }
-                : undefined
+                : observationService
+                  ? {
+                      agentId: agent.id,
+                      allowedTools: task.constraints.allowedTools,
+                      deniedTools: task.constraints.deniedTools,
+                      browser: { db, observationService },
+                    }
+                  : undefined
 
             const agentRegistry = await (
               backend as {

--- a/packages/dashboard/src/app/agents/[agentId]/browser/page.tsx
+++ b/packages/dashboard/src/app/agents/[agentId]/browser/page.tsx
@@ -130,6 +130,7 @@ export default function BrowserPage({ params }: BrowserPageProps): React.JSX.Ele
             vncUrl={session.vncUrl}
             status={session.status}
             latencyMs={session.latencyMs}
+            errorMessage={session.errorMessage}
             latestScreenshot={latestScreenshot}
             onReconnect={handleReconnect}
           />
@@ -200,6 +201,7 @@ export default function BrowserPage({ params }: BrowserPageProps): React.JSX.Ele
                 vncUrl={session.vncUrl}
                 status={session.status}
                 latencyMs={session.latencyMs}
+                errorMessage={session.errorMessage}
                 latestScreenshot={latestScreenshot}
                 onReconnect={handleReconnect}
               />

--- a/packages/dashboard/src/components/browser/browser-viewport.tsx
+++ b/packages/dashboard/src/components/browser/browser-viewport.tsx
@@ -10,6 +10,7 @@ interface BrowserViewportProps {
   vncUrl: string | null
   status: BrowserSessionStatus
   latencyMs?: number
+  errorMessage?: string
   latestScreenshot?: Screenshot | null
   onReconnect?: () => void
 }
@@ -18,6 +19,7 @@ export function BrowserViewport({
   vncUrl,
   status,
   latencyMs,
+  errorMessage,
   latestScreenshot,
   onReconnect,
 }: BrowserViewportProps): React.JSX.Element {
@@ -42,7 +44,12 @@ export function BrowserViewport({
     >
       {/* Toolbar */}
       <div className="flex items-center justify-between border-b border-chrome-border bg-chrome-bg px-3 py-2">
-        <ConnectionStatus status={status} latencyMs={latencyMs} onReconnect={onReconnect} />
+        <ConnectionStatus
+          status={status}
+          latencyMs={latencyMs}
+          errorMessage={errorMessage}
+          onReconnect={onReconnect}
+        />
 
         <div className="flex items-center gap-1">
           <button
@@ -90,7 +97,11 @@ export function BrowserViewport({
         ) : latestScreenshot ? (
           <ScreenshotFallback screenshot={latestScreenshot} />
         ) : (
-          <ViewportPlaceholder status={status} onReconnect={onReconnect} />
+          <ViewportPlaceholder
+            status={status}
+            errorMessage={errorMessage}
+            onReconnect={onReconnect}
+          />
         )}
       </div>
 
@@ -140,9 +151,11 @@ function ScreenshotFallback({ screenshot }: { screenshot: Screenshot }): React.J
 
 function ViewportPlaceholder({
   status,
+  errorMessage,
   onReconnect,
 }: {
   status: BrowserSessionStatus
+  errorMessage?: string
   onReconnect?: () => void
 }): React.JSX.Element {
   return (
@@ -158,7 +171,7 @@ function ViewportPlaceholder({
         </p>
         <p className="mt-1 text-xs text-slate-500">
           {status === "error"
-            ? "Failed to connect to the browser session"
+            ? (errorMessage ?? "Failed to connect to the browser session")
             : "Waiting for agent to start a browser session"}
         </p>
       </div>

--- a/packages/dashboard/src/components/browser/connection-status.tsx
+++ b/packages/dashboard/src/components/browser/connection-status.tsx
@@ -5,6 +5,7 @@ import type { BrowserSessionStatus } from "@/lib/api-client"
 interface ConnectionStatusProps {
   status: BrowserSessionStatus
   latencyMs?: number
+  errorMessage?: string
   onReconnect?: () => void
 }
 
@@ -48,6 +49,7 @@ function qualityLabel(latencyMs: number): { label: string; colorClass: string } 
 export function ConnectionStatus({
   status,
   latencyMs,
+  errorMessage,
   onReconnect,
 }: ConnectionStatusProps): React.JSX.Element {
   const config = statusConfig[status]
@@ -81,6 +83,12 @@ export function ConnectionStatus({
           <span className="material-symbols-outlined text-sm">refresh</span>
           Reconnect
         </button>
+      )}
+
+      {status === "error" && errorMessage && (
+        <span className="max-w-[24rem] truncate text-xs text-red-300" title={errorMessage}>
+          {errorMessage}
+        </span>
       )}
     </div>
   )

--- a/packages/dashboard/src/lib/schemas/browser.ts
+++ b/packages/dashboard/src/lib/schemas/browser.ts
@@ -34,6 +34,7 @@ export const BrowserSessionSchema = z.object({
   tabs: z.array(BrowserTabSchema),
   latencyMs: z.number(),
   lastHeartbeat: z.string().optional(),
+  errorMessage: z.string().optional(),
 })
 
 export const BrowserEventSchema = z.object({


### PR DESCRIPTION
## Summary
- wire `playwright_navigate` into the standard runtime tool registry for agent runs
- validate browser provisioning/connection lifecycle and persist browser events/screenshots
- surface real browser session errors in the dashboard browser API and UI

Closes #773


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added browser navigation capability enabling agents to visit and interact with URLs.
  * Implemented real-time browser session status tracking with connection lifecycle visibility.

* **Improvements**
  * Enhanced browser connection error handling with detailed error messaging.
  * Error messages now displayed in the dashboard when browser sessions encounter issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->