### PR TITLE
Implement issue #772 effective tool manifests

### DIFF
--- a/packages/control-plane/src/__tests__/agent-execute-credential-wiring.test.ts
+++ b/packages/control-plane/src/__tests__/agent-execute-credential-wiring.test.ts
@@ -18,7 +18,7 @@ import type {
 import { describe, expect, it, vi } from "vitest"
 
 import type { CredentialService } from "../auth/credential-service.js"
-import { ToolRegistry } from "../backends/tool-executor.js"
+import { echoTool, ToolRegistry } from "../backends/tool-executor.js"
 import { type AgentExecuteDeps, createAgentExecuteTask } from "../worker/tasks/agent-execute.js"
 
 // ---------------------------------------------------------------------------
@@ -513,7 +513,21 @@ describe("agent-execute credential wiring (#444)", () => {
   })
 
   it("uses the actual resolved registry to disclose MCP availability", async () => {
-    const db = makeMockDb()
+    const db = makeMockDb({
+      agent: {
+        id: "agent-1",
+        name: "TestAgent",
+        slug: "test-agent",
+        role: "developer",
+        description: null,
+        status: "ACTIVE",
+        model_config: {},
+        skill_config: { allowedTools: ["web_search", "mcp:filesystem:read_file"] },
+        resource_limits: {},
+        config: null,
+        health_reset_at: null,
+      },
+    })
     const { registry, executeTaskSpy } = makeMockRegistryWithAgentRegistry()
 
     const task = createAgentExecuteTask({
@@ -533,5 +547,74 @@ describe("agent-execute credential wiring (#444)", () => {
     expect(executedTask.context.systemPrompt).toContain(
       "Exposed tool names: mcp:filesystem:read_file, web_search.",
     )
+  })
+
+  it("injects a runtime tool manifest and guarded executable tools for a simple V2-enabled run", async () => {
+    vi.stubEnv("CAPABILITY_MODEL_V2", "true")
+
+    const db = makeMockDb()
+    const executeTaskSpy = vi.fn().mockResolvedValue(createMockHandle())
+    const registry = {
+      routeTask: vi.fn().mockReturnValue({
+        backend: {
+          backendId: "mock-backend",
+          createAgentRegistry: vi.fn(),
+          executeTask: executeTaskSpy,
+        },
+        providerId: "mock-provider",
+      }),
+      acquirePermit: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      recordOutcome: vi.fn(),
+    } as unknown as BackendRegistry
+
+    const capabilityAssembler = {
+      resolveEffectiveTools: vi.fn().mockResolvedValue([
+        {
+          toolRef: "echo",
+          bindingId: "binding-echo",
+          approvalPolicy: "auto",
+          approvalCondition: null,
+          rateLimit: null,
+          costBudget: null,
+          dataScope: null,
+          source: { kind: "builtin" },
+          toolDefinition: echoTool,
+        },
+      ]),
+      buildGuardedRegistry: vi.fn().mockImplementation(() => {
+        const toolRegistry = new ToolRegistry()
+        toolRegistry.register(echoTool)
+        return toolRegistry
+      }),
+    }
+
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+      capabilityAssembler: capabilityAssembler as never,
+    })
+
+    try {
+      await task({ jobId: "job-1" }, makeMockHelpers() as never)
+    } finally {
+      vi.unstubAllEnvs()
+    }
+
+    const executedTask = executeTaskSpy.mock.calls[0]![0] as ExecutionTask
+    const guardedRegistry = executeTaskSpy.mock.calls[0]![1] as ToolRegistry
+
+    expect(executedTask.context.runtimeToolManifest?.version).toBe("v1")
+    expect(typeof executedTask.context.runtimeToolManifest?.assembledAt).toBe("string")
+    expect(executedTask.context.runtimeToolManifest?.tools).toEqual([
+      {
+        toolRef: "echo",
+        runtimeName: "echo",
+        description: echoTool.description,
+        inputSchema: echoTool.inputSchema,
+        source: { kind: "builtin" },
+      },
+    ])
+    expect(executedTask.context.systemPrompt).toContain("Exposed tool names: echo.")
+    expect(guardedRegistry.get("echo")).toBeDefined()
   })
 })

--- a/packages/control-plane/src/__tests__/agent-tool-binding-routes.test.ts
+++ b/packages/control-plane/src/__tests__/agent-tool-binding-routes.test.ts
@@ -243,10 +243,36 @@ function mockDb(
 async function buildTestApp(dbOpts: Parameters<typeof mockDb>[0] = {}) {
   const app = Fastify({ logger: false })
   const { db, auditInsertValues, deleteExecute } = mockDb(dbOpts)
+  const capabilityAssembler = {
+    resolveEffectiveTools: vi.fn().mockResolvedValue([
+      {
+        toolRef: "mcp:slack:chat_postMessage",
+        bindingId: BINDING_ID,
+        approvalPolicy: "auto",
+        approvalCondition: null,
+        rateLimit: { maxCalls: 5, windowSeconds: 60 },
+        costBudget: null,
+        dataScope: null,
+        source: { kind: "mcp" },
+        toolDefinition: {
+          name: "slack.chat_postMessage",
+          description: "Post a Slack message",
+          inputSchema: { type: "object", properties: { channel: { type: "string" } } },
+          execute: vi.fn().mockResolvedValue("ok"),
+        },
+      },
+    ]),
+  }
 
-  await app.register(agentToolBindingRoutes({ db, authConfig: DEV_AUTH_CONFIG }))
+  await app.register(
+    agentToolBindingRoutes({
+      db,
+      authConfig: DEV_AUTH_CONFIG,
+      capabilityAssembler: capabilityAssembler as never,
+    }),
+  )
 
-  return { app, db, auditInsertValues, deleteExecute }
+  return { app, db, auditInsertValues, deleteExecute, capabilityAssembler }
 }
 
 // ---------------------------------------------------------------------------
@@ -549,8 +575,8 @@ describe("POST /agents/:agentId/tool-bindings/bulk", () => {
 // ---------------------------------------------------------------------------
 
 describe("GET /agents/:agentId/effective-tools", () => {
-  it("returns effective tools for an agent", async () => {
-    const { app } = await buildTestApp()
+  it("returns computed effective tools for an agent", async () => {
+    const { app, capabilityAssembler } = await buildTestApp()
 
     const res = await app.inject({
       method: "GET",
@@ -561,7 +587,24 @@ describe("GET /agents/:agentId/effective-tools", () => {
     const body = res.json()
     expect(body.tools).toBeDefined()
     expect(Array.isArray(body.tools)).toBe(true)
+    expect(body.tools).toEqual([
+      {
+        toolRef: "mcp:slack:chat_postMessage",
+        runtimeName: "slack.chat_postMessage",
+        description: "Post a Slack message",
+        inputSchema: { type: "object", properties: { channel: { type: "string" } } },
+        bindingId: BINDING_ID,
+        approvalPolicy: "auto",
+        approvalCondition: null,
+        rateLimit: { maxCalls: 5, windowSeconds: 60 },
+        costBudget: null,
+        dataScope: null,
+        source: { kind: "mcp" },
+      },
+    ])
     expect(body.assembledAt).toBeDefined()
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(capabilityAssembler.resolveEffectiveTools).toHaveBeenCalledWith(AGENT_ID)
   })
 
   it("returns 404 when agent does not exist", async () => {

--- a/packages/control-plane/src/__tests__/runtime-capability-disclosure.test.ts
+++ b/packages/control-plane/src/__tests__/runtime-capability-disclosure.test.ts
@@ -1,6 +1,7 @@
 import type { ExecutionTask } from "@cortex/shared/backends"
 import { describe, expect, it } from "vitest"
 
+import { buildRuntimeToolManifestFromToolDefinitions } from "../capabilities/index.js"
 import { buildRuntimeCapabilityDisclosure } from "../worker/runtime-capability-disclosure.js"
 
 function makeTask(overrides?: Partial<ExecutionTask>): ExecutionTask {
@@ -34,6 +35,28 @@ function makeTask(overrides?: Partial<ExecutionTask>): ExecutionTask {
 }
 
 describe("runtime capability disclosure", () => {
+  it("builds a runtime tool manifest for actual executable tools", () => {
+    const manifest = buildRuntimeToolManifestFromToolDefinitions([
+      {
+        name: "echo",
+        description: "Echo text",
+        inputSchema: { type: "object", properties: { text: { type: "string" } } },
+        execute: () => Promise.resolve("ok"),
+      },
+    ])
+
+    expect(manifest.version).toBe("v1")
+    expect(manifest.tools).toEqual([
+      {
+        toolRef: "echo",
+        runtimeName: "echo",
+        description: "Echo text",
+        inputSchema: { type: "object", properties: { text: { type: "string" } } },
+        source: { kind: "builtin" },
+      },
+    ])
+  })
+
   it("reports actual MCP and browser tools when runtime tool names are known", () => {
     const disclosure = buildRuntimeCapabilityDisclosure({
       task: makeTask(),
@@ -86,5 +109,24 @@ describe("runtime capability disclosure", () => {
     expect(disclosure).toContain(
       "Do not claim curl, package installation, or arbitrary command access.",
     )
+  })
+
+  it("reads capability disclosure from the runtime tool manifest", () => {
+    const disclosure = buildRuntimeCapabilityDisclosure({
+      task: makeTask(),
+      runtimeToolManifest: buildRuntimeToolManifestFromToolDefinitions([
+        {
+          name: "mcp:filesystem:read_file",
+          description: "Read a file",
+          inputSchema: { type: "object", properties: {} },
+          execute: () => Promise.resolve("ok"),
+        },
+      ]),
+    })
+
+    expect(disclosure).toContain(
+      "MCP tools exposed by Cortex: available (mcp:filesystem:read_file).",
+    )
+    expect(disclosure).toContain("Exposed tool names: mcp:filesystem:read_file.")
   })
 })

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -19,6 +19,7 @@ import { HttpLlmBackend } from "./backends/http-llm.js"
 import { AuthHandoffService } from "./browser/auth-handoff.js"
 import { ScreenshotModeService } from "./browser/screenshot-mode.js"
 import { TraceCaptureService } from "./browser/trace-capture.js"
+import { CapabilityAssembler } from "./capabilities/index.js"
 import { AgentChannelService } from "./channels/agent-channel-service.js"
 import { ChannelAllowlistService } from "./channels/channel-allowlist-service.js"
 import { ChannelConfigService } from "./channels/channel-config-service.js"
@@ -113,6 +114,7 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
   // MCP client pool + tool router — resolves MCP tools for agent registries
   const mcpClientPool = new McpClientPool()
   const mcpToolRouter = new McpToolRouter({ db, clientPool: mcpClientPool })
+  const capabilityAssembler = new CapabilityAssembler({ db, mcpToolRouter })
 
   // Observability: event emitter + execution registry
   const eventEmitter = new AgentEventEmitter(db, sseManager)
@@ -142,6 +144,7 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
     eventEmitter,
     executionRegistry,
     observationService,
+    capabilityAssembler,
   })
 
   // Worker utils for job enqueueing from routes
@@ -305,6 +308,7 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
       db,
       authConfig,
       sessionService,
+      capabilityAssembler,
     }),
   )
 

--- a/packages/control-plane/src/capabilities/__tests__/assembler.test.ts
+++ b/packages/control-plane/src/capabilities/__tests__/assembler.test.ts
@@ -76,6 +76,22 @@ describe("CapabilityAssembler", () => {
       expect(tools).toEqual([])
     })
 
+    it("fails closed for configured tools without an executable definition", async () => {
+      const registry = new ToolRegistry()
+      registry.register({
+        name: "broken_tool",
+        description: "broken",
+        inputSchema: { type: "object" },
+        execute: undefined as never,
+      })
+
+      const db = mockDb([makeBinding({ tool_ref: "broken_tool" })])
+      const assembler = new CapabilityAssembler({ db, defaultRegistry: registry })
+
+      const tools = await assembler.resolveEffectiveTools("agent-1")
+      expect(tools).toEqual([])
+    })
+
     it("resolves MCP tools via McpToolRouter", async () => {
       const mcpToolDef = {
         name: "mcp:slack:chat_post",
@@ -161,6 +177,7 @@ describe("CapabilityAssembler", () => {
           toolRef: "echo",
           bindingId: "b1",
           approvalPolicy: "auto",
+          source: { kind: "builtin" },
           toolDefinition: echoTool,
         },
       ]
@@ -198,6 +215,7 @@ describe("CapabilityAssembler", () => {
           toolRef: "echo",
           bindingId: "b1",
           approvalPolicy: "auto",
+          source: { kind: "builtin" },
           toolDefinition: echoTool,
         },
       ]
@@ -222,6 +240,7 @@ describe("CapabilityGuard", () => {
       toolRef: "echo",
       bindingId: "b1",
       approvalPolicy: "auto",
+      source: { kind: "builtin" },
       toolDefinition: echoTool,
     }
 
@@ -240,6 +259,7 @@ describe("CapabilityGuard", () => {
       bindingId: "b1",
       approvalPolicy: "auto",
       dataScope: { calendars: ["primary"] },
+      source: { kind: "builtin" },
       toolDefinition: {
         name: "test",
         description: "test",
@@ -264,6 +284,7 @@ describe("CapabilityGuard", () => {
       toolRef: "echo",
       bindingId: "b1",
       approvalPolicy: "always_approve",
+      source: { kind: "builtin" },
       toolDefinition: echoTool,
     }
 

--- a/packages/control-plane/src/capabilities/__tests__/delegation.test.ts
+++ b/packages/control-plane/src/capabilities/__tests__/delegation.test.ts
@@ -12,6 +12,7 @@ function makeEffectiveTool(overrides: Partial<EffectiveTool> = {}): EffectiveToo
     toolRef: "tool_a",
     bindingId: "binding-a",
     approvalPolicy: "auto",
+    source: { kind: "builtin" },
     toolDefinition: echoTool,
     ...overrides,
   }

--- a/packages/control-plane/src/capabilities/__tests__/guard.test.ts
+++ b/packages/control-plane/src/capabilities/__tests__/guard.test.ts
@@ -28,6 +28,7 @@ function makeEffectiveTool(overrides: Partial<EffectiveTool> = {}): EffectiveToo
     toolRef: "mcp:server:test-tool",
     bindingId: "binding-1",
     approvalPolicy: "auto",
+    source: { kind: "mcp" },
     toolDefinition: makeToolDef(),
     ...overrides,
   }

--- a/packages/control-plane/src/capabilities/assembler.ts
+++ b/packages/control-plane/src/capabilities/assembler.ts
@@ -11,6 +11,7 @@ import type { ToolDefinition } from "../backends/tool-executor.js"
 import { createDefaultToolRegistry, ToolRegistry } from "../backends/tool-executor.js"
 import type { Database } from "../db/types.js"
 import type { McpToolRouter } from "../mcp/tool-router.js"
+import { isExecutableToolDefinition } from "./contracts.js"
 import { CapabilityGuard } from "./guard.js"
 import type { EffectiveTool } from "./types.js"
 
@@ -50,14 +51,14 @@ export class CapabilityAssembler {
     for (const binding of bindings) {
       const toolDef = this.defaultRegistry.get(binding.tool_ref)
 
-      if (toolDef) {
+      if (toolDef && isExecutableToolDefinition(toolDef)) {
         // Built-in tool
         effectiveTools.push(this.bindingToEffectiveTool(binding, toolDef))
       } else if (binding.tool_ref.startsWith("mcp:") && this.mcpToolRouter) {
         // MCP tool — resolve via router
         try {
           const mcpTool = await this.mcpToolRouter.resolve(binding.tool_ref, agentId)
-          if (mcpTool) {
+          if (mcpTool && isExecutableToolDefinition(mcpTool)) {
             effectiveTools.push(this.bindingToEffectiveTool(binding, mcpTool))
           }
         } catch {
@@ -109,6 +110,7 @@ export class CapabilityAssembler {
       rateLimit: binding.rate_limit as EffectiveTool["rateLimit"],
       costBudget: binding.cost_budget as EffectiveTool["costBudget"],
       dataScope: binding.data_scope ?? undefined,
+      source: { kind: binding.tool_ref.startsWith("mcp:") ? "mcp" : "builtin" },
       toolDefinition: toolDef,
     }
   }

--- a/packages/control-plane/src/capabilities/contracts.ts
+++ b/packages/control-plane/src/capabilities/contracts.ts
@@ -1,0 +1,98 @@
+import type { ToolDefinition } from "../backends/tool-executor.js"
+import type { EffectiveTool, EffectiveToolContract, EffectiveToolSourceKind } from "./types.js"
+
+export interface RuntimeToolManifestToolRecord {
+  toolRef: string
+  runtimeName: string
+  description: string
+  inputSchema: Record<string, unknown>
+  source: {
+    kind: EffectiveToolSourceKind
+  }
+}
+
+export interface RuntimeToolManifestRecord {
+  version: "v1"
+  assembledAt: string
+  tools: RuntimeToolManifestToolRecord[]
+}
+
+function inferSourceKind(toolRef: string): EffectiveToolSourceKind {
+  if (toolRef.startsWith("mcp:")) return "mcp"
+  if (toolRef.includes("/") || toolRef.includes("::")) return "webhook"
+  if (toolRef.length > 0) return "builtin"
+  return "unknown"
+}
+
+export function isExecutableToolDefinition(value: unknown): value is ToolDefinition {
+  if (!value || typeof value !== "object") return false
+  const tool = value as Partial<ToolDefinition>
+  return (
+    typeof tool.name === "string" &&
+    tool.name.length > 0 &&
+    typeof tool.description === "string" &&
+    typeof tool.execute === "function" &&
+    typeof tool.inputSchema === "object" &&
+    tool.inputSchema !== null
+  )
+}
+
+export function toEffectiveToolContract(tool: EffectiveTool): EffectiveToolContract {
+  return {
+    toolRef: tool.toolRef,
+    runtimeName: tool.toolDefinition.name,
+    description: tool.toolDefinition.description,
+    inputSchema: tool.toolDefinition.inputSchema,
+    bindingId: tool.bindingId,
+    approvalPolicy: tool.approvalPolicy,
+    approvalCondition: tool.approvalCondition ?? null,
+    rateLimit: tool.rateLimit ?? null,
+    costBudget: tool.costBudget ?? null,
+    dataScope: tool.dataScope ?? null,
+    source: tool.source,
+  }
+}
+
+export function buildRuntimeToolManifestFromEffectiveTools(
+  effectiveTools: EffectiveTool[],
+  assembledAt = new Date().toISOString(),
+): RuntimeToolManifestRecord {
+  const tools = effectiveTools
+    .filter((tool) => isExecutableToolDefinition(tool.toolDefinition))
+    .map<RuntimeToolManifestToolRecord>((tool) => ({
+      toolRef: tool.toolRef,
+      runtimeName: tool.toolDefinition.name,
+      description: tool.toolDefinition.description,
+      inputSchema: tool.toolDefinition.inputSchema,
+      source: tool.source,
+    }))
+    .sort((a, b) => String(a.toolRef).localeCompare(String(b.toolRef)))
+
+  return {
+    version: "v1",
+    assembledAt,
+    tools,
+  }
+}
+
+export function buildRuntimeToolManifestFromToolDefinitions(
+  tools: ToolDefinition[],
+  assembledAt = new Date().toISOString(),
+): RuntimeToolManifestRecord {
+  const manifestTools = tools
+    .filter((tool) => isExecutableToolDefinition(tool))
+    .map<RuntimeToolManifestToolRecord>((tool) => ({
+      toolRef: tool.name,
+      runtimeName: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      source: { kind: inferSourceKind(tool.name) },
+    }))
+    .sort((a, b) => String(a.toolRef).localeCompare(String(b.toolRef)))
+
+  return {
+    version: "v1",
+    assembledAt,
+    tools: manifestTools,
+  }
+}

--- a/packages/control-plane/src/capabilities/delegation.ts
+++ b/packages/control-plane/src/capabilities/delegation.ts
@@ -86,6 +86,7 @@ export async function validateDelegation(
       rateLimit: parentTool.rateLimit,
       costBudget: parentTool.costBudget,
       dataScope: parentTool.dataScope,
+      source: parentTool.source,
       toolDefinition: parentTool.toolDefinition,
     }
 

--- a/packages/control-plane/src/capabilities/index.ts
+++ b/packages/control-plane/src/capabilities/index.ts
@@ -3,8 +3,15 @@
  */
 
 export { CapabilityAssembler } from "./assembler.js"
+export type { RuntimeToolManifestRecord, RuntimeToolManifestToolRecord } from "./contracts.js"
+export {
+  buildRuntimeToolManifestFromEffectiveTools,
+  buildRuntimeToolManifestFromToolDefinitions,
+  isExecutableToolDefinition,
+  toEffectiveToolContract,
+} from "./contracts.js"
 export type { DelegationRequest, ValidatedDelegation } from "./delegation.js"
 export { narrowDataScope, validateDelegation } from "./delegation.js"
 export { ToolApprovalRequiredError, ToolRateLimitError } from "./errors.js"
 export { CapabilityGuard, evaluateCondition } from "./guard.js"
-export type { EffectiveTool } from "./types.js"
+export type { EffectiveTool, EffectiveToolContract, EffectiveToolSourceKind } from "./types.js"

--- a/packages/control-plane/src/capabilities/types.ts
+++ b/packages/control-plane/src/capabilities/types.ts
@@ -8,6 +8,8 @@
 
 import type { ToolDefinition } from "../backends/tool-executor.js"
 
+export type EffectiveToolSourceKind = "builtin" | "mcp" | "webhook" | "unknown"
+
 export interface EffectiveTool {
   /** Qualified tool reference (e.g. 'mcp:slack:chat_postMessage' or 'web_search'). */
   toolRef: string
@@ -23,6 +25,22 @@ export interface EffectiveTool {
   costBudget?: { maxUsd: number; windowSeconds: number }
   /** Tool-specific data scope constraints. */
   dataScope?: Record<string, unknown>
+  /** Resolved tool source family. */
+  source: { kind: EffectiveToolSourceKind }
   /** The resolved executable tool definition. */
   toolDefinition: ToolDefinition
+}
+
+export interface EffectiveToolContract {
+  toolRef: string
+  runtimeName: string
+  description: string
+  inputSchema: Record<string, unknown>
+  bindingId: string
+  approvalPolicy: "auto" | "always_approve" | "conditional"
+  approvalCondition: Record<string, unknown> | null
+  rateLimit: { maxCalls: number; windowSeconds: number } | null
+  costBudget: { maxUsd: number; windowSeconds: number } | null
+  dataScope: Record<string, unknown> | null
+  source: { kind: EffectiveToolSourceKind }
 }

--- a/packages/control-plane/src/routes/agent-tool-bindings.ts
+++ b/packages/control-plane/src/routes/agent-tool-bindings.ts
@@ -15,6 +15,8 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
 import type { Kysely } from "kysely"
 
 import type { SessionService } from "../auth/session-service.js"
+import type { CapabilityAssembler } from "../capabilities/index.js"
+import { toEffectiveToolContract } from "../capabilities/index.js"
 import type { Database, ToolApprovalPolicy } from "../db/types.js"
 import { createRequireAuth, createRequireRole, type PreHandler } from "../middleware/auth.js"
 import type { AuthConfig, AuthenticatedRequest } from "../middleware/types.js"
@@ -78,10 +80,11 @@ export interface AgentToolBindingRouteDeps {
   db: Kysely<Database>
   authConfig: AuthConfig
   sessionService?: SessionService
+  capabilityAssembler?: CapabilityAssembler
 }
 
 export function agentToolBindingRoutes(deps: AgentToolBindingRouteDeps) {
-  const { db, authConfig, sessionService } = deps
+  const { db, authConfig, sessionService, capabilityAssembler } = deps
 
   const requireAuth: PreHandler = createRequireAuth({
     config: authConfig,
@@ -635,27 +638,12 @@ export function agentToolBindingRoutes(deps: AgentToolBindingRouteDeps) {
           return reply.status(404).send({ error: "not_found", message: "Agent not found" })
         }
 
-        // Return enabled bindings as effective tools.
-        // When CapabilityAssembler (#302) is integrated, this will call
-        // assembler.resolveEffectiveTools(agentId) instead.
-        const bindings = await db
-          .selectFrom("agent_tool_binding")
-          .selectAll()
-          .where("agent_id", "=", agentId)
-          .where("enabled", "=", true)
-          .orderBy("created_at", "asc")
-          .execute()
+        const effectiveTools = capabilityAssembler
+          ? await capabilityAssembler.resolveEffectiveTools(agentId)
+          : []
 
         return reply.status(200).send({
-          tools: bindings.map((b) => ({
-            toolRef: b.tool_ref,
-            bindingId: b.id,
-            approvalPolicy: b.approval_policy,
-            approvalCondition: b.approval_condition,
-            rateLimit: b.rate_limit,
-            costBudget: b.cost_budget,
-            dataScope: b.data_scope,
-          })),
+          tools: effectiveTools.map(toEffectiveToolContract),
           assembledAt: new Date().toISOString(),
         })
       },

--- a/packages/control-plane/src/worker/index.ts
+++ b/packages/control-plane/src/worker/index.ts
@@ -16,6 +16,7 @@ import type { Kysely } from "kysely"
 import type { Pool } from "pg"
 
 import type { CredentialService } from "../auth/credential-service.js"
+import type { CapabilityAssembler } from "../capabilities/index.js"
 import type { AuthOAuthConfig } from "../config.js"
 import type { Database } from "../db/types.js"
 import type { McpToolRouter } from "../mcp/tool-router.js"
@@ -51,6 +52,8 @@ export interface WorkerOptions {
   credentialService?: CredentialService
   /** Optional browser observation/runtime service for browser tools. */
   observationService?: BrowserObservationService
+  /** Optional capability assembler for effective tool/runtime-manifest flows. */
+  capabilityAssembler?: CapabilityAssembler
 }
 
 /**
@@ -72,6 +75,7 @@ export async function createWorker(options: WorkerOptions): Promise<Runner> {
     executionRegistry,
     credentialService,
     observationService,
+    capabilityAssembler,
   } = options
 
   const workerConcurrency =
@@ -89,6 +93,7 @@ export async function createWorker(options: WorkerOptions): Promise<Runner> {
       eventEmitter,
       executionRegistry,
       observationService,
+      capabilityAssembler,
     }),
     memory_extract: createMemoryExtractTask(undefined, db),
     approval_expire: createApprovalExpireTask(db),

--- a/packages/control-plane/src/worker/runtime-capability-disclosure.ts
+++ b/packages/control-plane/src/worker/runtime-capability-disclosure.ts
@@ -1,5 +1,7 @@
 import type { ExecutionTask } from "@cortex/shared/backends"
 
+import type { RuntimeToolManifestRecord } from "../capabilities/contracts.js"
+
 type CapabilityState = "available" | "unavailable" | "unknown"
 
 const BROWSER_TOOL_PATTERN = /(browser|playwright|chrome|chromium|cdp)/i
@@ -7,6 +9,7 @@ const BROWSER_TOOL_PATTERN = /(browser|playwright|chrome|chromium|cdp)/i
 export interface RuntimeCapabilityDisclosureInput {
   task: ExecutionTask
   actualToolNames?: string[]
+  runtimeToolManifest?: RuntimeToolManifestRecord
 }
 
 function uniqueSorted(values: string[]): string[] {
@@ -47,6 +50,13 @@ function buildMcpLine(actualToolNames: string[] | undefined): string {
   return "- MCP tools exposed by Cortex: unknown."
 }
 
+function manifestToToolNames(
+  runtimeToolManifest?: RuntimeToolManifestRecord,
+): string[] | undefined {
+  if (!runtimeToolManifest) return undefined
+  return runtimeToolManifest.tools.map((tool) => tool.runtimeName)
+}
+
 function buildBrowserLine(actualToolNames: string[] | undefined): string {
   const browser = classifyToolState(actualToolNames, (toolName) =>
     BROWSER_TOOL_PATTERN.test(toolName),
@@ -81,7 +91,10 @@ export function listToolNamesFromRegistryLike(registry: {
 }
 
 export function buildRuntimeCapabilityDisclosure(input: RuntimeCapabilityDisclosureInput): string {
-  const actualToolNames = input.actualToolNames ? uniqueSorted(input.actualToolNames) : undefined
+  const manifestNames = manifestToToolNames(input.runtimeToolManifest)
+  const actualToolNames = uniqueSorted(input.actualToolNames ?? manifestNames ?? [])
+  const knownToolNames =
+    input.actualToolNames || input.runtimeToolManifest ? actualToolNames : undefined
   const { task } = input
 
   const lines = [
@@ -90,13 +103,13 @@ export function buildRuntimeCapabilityDisclosure(input: RuntimeCapabilityDisclos
     `- Filesystem scope: this run is configured with ${task.context.workspacePath} as its workspace root. Access outside that workspace is unknown unless verified during execution.`,
     `- Network access: ${task.constraints.networkAccess ? "available" : "unavailable"}.`,
     `- Shell execution: ${task.constraints.shellAccess ? "available" : "unavailable"}.`,
-    buildMcpLine(actualToolNames),
-    buildBrowserLine(actualToolNames),
+    buildMcpLine(knownToolNames),
+    buildBrowserLine(knownToolNames),
     buildCommandAvailabilityLine(task.constraints.shellAccess),
   ]
 
-  if (actualToolNames) {
-    lines.push(`- Exposed tool names: ${summarizeToolNames(actualToolNames)}.`)
+  if (knownToolNames) {
+    lines.push(`- Exposed tool names: ${summarizeToolNames(knownToolNames)}.`)
   } else {
     lines.push("- Exposed tool names: unknown.")
   }

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -29,6 +29,11 @@ import type { CredentialService } from "../../auth/credential-service.js"
 import type { UserRateLimiter } from "../../auth/user-rate-limiter.js"
 import type { TokenRefresher } from "../../backends/http-llm.js"
 import type { CredentialResolver } from "../../backends/tools/webhook.js"
+import {
+  buildRuntimeToolManifestFromEffectiveTools,
+  buildRuntimeToolManifestFromToolDefinitions,
+  type RuntimeToolManifestRecord,
+} from "../../capabilities/contracts.js"
 import type { CapabilityAssembler } from "../../capabilities/index.js"
 import type { Database, Job } from "../../db/types.js"
 import { AgentCircuitBreaker, isQuarantineDisabled } from "../../lifecycle/agent-circuit-breaker.js"
@@ -53,10 +58,7 @@ import { classifyError, isConfigErrorCategory } from "../error-classifier.js"
 import { startHeartbeat } from "../heartbeat.js"
 import { createMemoryScheduler } from "../memory-scheduler.js"
 import { calculateRunAt } from "../retry.js"
-import {
-  appendRuntimeCapabilityDisclosure,
-  listToolNamesFromRegistryLike,
-} from "../runtime-capability-disclosure.js"
+import { appendRuntimeCapabilityDisclosure } from "../runtime-capability-disclosure.js"
 
 export interface AgentExecutePayload {
   jobId: string
@@ -564,11 +566,14 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
               jobId: job.id,
               userId,
             })
+            const runtimeToolManifest: RuntimeToolManifestRecord =
+              buildRuntimeToolManifestFromEffectiveTools(effectiveTools)
+            task.context.runtimeToolManifest = runtimeToolManifest
             task.context.systemPrompt = appendRuntimeCapabilityDisclosure(
               task.context.systemPrompt,
               {
                 task,
-                actualToolNames: effectiveTools.map((tool) => tool.toolRef),
+                runtimeToolManifest,
               },
             )
 
@@ -616,19 +621,20 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
                 createAgentRegistry: (c: Record<string, unknown>, m?: unknown) => Promise<unknown>
               }
             ).createAgentRegistry(agent.config ?? {}, mcpDeps)
+            const runtimeToolManifest: RuntimeToolManifestRecord =
+              buildRuntimeToolManifestFromToolDefinitions(
+                resolveActualToolDefinitions(
+                  agentRegistry,
+                  task.constraints.allowedTools,
+                  task.constraints.deniedTools,
+                ),
+              )
+            task.context.runtimeToolManifest = runtimeToolManifest
             task.context.systemPrompt = appendRuntimeCapabilityDisclosure(
               task.context.systemPrompt,
               {
                 task,
-                actualToolNames:
-                  typeof agentRegistry === "object" &&
-                  agentRegistry !== null &&
-                  "list" in agentRegistry &&
-                  typeof agentRegistry.list === "function"
-                    ? listToolNamesFromRegistryLike(
-                        agentRegistry as { list: () => Array<{ name: string }> },
-                      )
-                    : undefined,
+                runtimeToolManifest,
               },
             )
             handle = await (
@@ -641,11 +647,14 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
               }
             ).executeTask(task, agentRegistry, tokenRefresher)
           } else {
+            const runtimeToolManifest: RuntimeToolManifestRecord =
+              buildRuntimeToolManifestFromToolDefinitions([])
+            task.context.runtimeToolManifest = runtimeToolManifest
             task.context.systemPrompt = appendRuntimeCapabilityDisclosure(
               task.context.systemPrompt,
               {
                 task,
-                actualToolNames: task.constraints.allowedTools,
+                runtimeToolManifest,
               },
             )
             handle = await backend.executeTask(task)
@@ -1145,6 +1154,26 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
       }
     }) // end withSpan
   }
+}
+
+function resolveActualToolDefinitions(
+  registry: unknown,
+  allowedTools: string[],
+  deniedTools: string[],
+): import("../../backends/tool-executor.js").ToolDefinition[] {
+  if (!registry || typeof registry !== "object" || !("resolve" in registry)) return []
+
+  const resolve = (
+    registry as {
+      resolve?: (
+        allowed: string[],
+        denied: string[],
+      ) => import("../../backends/tool-executor.js").ToolDefinition[]
+    }
+  ).resolve
+  if (typeof resolve !== "function") return []
+
+  return resolve.call(registry, allowedTools, deniedTools)
 }
 
 // ── Helper: build ExecutionTask from job + agent ──

--- a/packages/dashboard/fixtures/api-responses/effective-tools.json
+++ b/packages/dashboard/fixtures/api-responses/effective-tools.json
@@ -2,12 +2,16 @@
   "tools": [
     {
       "toolRef": "mcp-server-1/web_search",
+      "runtimeName": "web_search",
+      "description": "Search the web",
+      "inputSchema": { "type": "object", "properties": { "query": { "type": "string" } } },
       "bindingId": "tb-001",
       "approvalPolicy": "auto",
       "approvalCondition": null,
       "rateLimit": { "maxCalls": 10, "windowSeconds": 60 },
       "costBudget": null,
-      "dataScope": null
+      "dataScope": null,
+      "source": { "kind": "mcp" }
     }
   ],
   "assembledAt": "2025-11-01T10:00:00.000Z"

--- a/packages/dashboard/src/__tests__/schemas.test.ts
+++ b/packages/dashboard/src/__tests__/schemas.test.ts
@@ -572,12 +572,16 @@ describe("EffectiveToolSchema", () => {
   it("accepts a valid effective tool", () => {
     const tool = {
       toolRef: "s::search",
+      runtimeName: "search",
+      description: "Search docs",
+      inputSchema: { type: "object", properties: {} },
       bindingId: "tb-001",
       approvalPolicy: "auto" as const,
       approvalCondition: null,
       rateLimit: null,
       costBudget: null,
       dataScope: null,
+      source: { kind: "builtin" as const },
     }
     expect(EffectiveToolSchema.parse(tool).toolRef).toBe("s::search")
   })
@@ -589,12 +593,16 @@ describe("EffectiveToolsResponseSchema", () => {
       tools: [
         {
           toolRef: "s::t",
+          runtimeName: "t",
+          description: "Tool t",
+          inputSchema: { type: "object", properties: {} },
           bindingId: "b",
           approvalPolicy: "auto" as const,
           approvalCondition: null,
           rateLimit: null,
           costBudget: null,
           dataScope: null,
+          source: { kind: "builtin" as const },
         },
       ],
       assembledAt: "2026-03-01T00:00:00Z",

--- a/packages/dashboard/src/app/agents/[agentId]/capabilities/page.tsx
+++ b/packages/dashboard/src/app/agents/[agentId]/capabilities/page.tsx
@@ -18,7 +18,6 @@ import {
   getMcpServer,
   listMcpServers,
   listToolBindings,
-  updateToolBinding,
 } from "@/lib/api-client"
 
 // ---------------------------------------------------------------------------
@@ -170,14 +169,6 @@ export default function AgentCapabilitiesPage({
     [agentId, refreshAll],
   )
 
-  const handleToggleEnabled = useCallback(
-    async (binding: ToolBinding) => {
-      await updateToolBinding(agentId, binding.id, { enabled: !binding.enabled })
-      refreshAll()
-    },
-    [agentId, refreshAll],
-  )
-
   const handleDelete = useCallback(async () => {
     if (!deleteTarget) return
     await deleteToolBinding(agentId, deleteTarget.id)
@@ -198,15 +189,15 @@ export default function AgentCapabilitiesPage({
   const effectiveTools = effectiveData?.tools ?? []
   const servers = (serversData?.servers ?? []).map((s) => ({ id: s.id, name: s.name }))
 
-  const filteredBindings = categoryFilter
-    ? bindings.filter((b) => b.toolRef.includes(categoryFilter))
-    : bindings
+  const filteredEffectiveTools = categoryFilter
+    ? effectiveTools.filter((tool) => tool.toolRef.includes(categoryFilter))
+    : effectiveTools
 
   // Extract unique category-like prefixes from tool refs (server slug before ::)
   const categories = [
     ...new Set(
-      bindings
-        .map((b) => b.toolRef.split("::")[0])
+      effectiveTools
+        .map((tool) => tool.toolRef.split("::")[0] ?? tool.source.kind)
         .filter((c): c is string => typeof c === "string" && c.length > 0),
     ),
   ]
@@ -288,14 +279,14 @@ export default function AgentCapabilitiesPage({
           </span>
         </h2>
 
-        {filteredBindings.length === 0 ? (
+        {filteredEffectiveTools.length === 0 ? (
           <div className="rounded-xl border border-dashed border-surface-border p-8 text-center">
             <span className="material-symbols-outlined mb-2 text-3xl text-text-muted">
               extension
             </span>
-            <p className="text-sm text-text-muted">No tool bindings yet</p>
+            <p className="text-sm text-text-muted">No executable effective tools</p>
             <p className="mt-1 text-xs text-text-muted">
-              Use the form below to bind tools to this agent
+              Bind supported tools below. Disabled or unresolvable bindings are excluded here.
             </p>
           </div>
         ) : (
@@ -307,13 +298,16 @@ export default function AgentCapabilitiesPage({
                     Tool
                   </th>
                   <th className="px-3 py-2 text-xs font-bold uppercase tracking-widest text-text-muted">
+                    Runtime
+                  </th>
+                  <th className="px-3 py-2 text-xs font-bold uppercase tracking-widest text-text-muted">
                     Policy
                   </th>
                   <th className="px-3 py-2 text-xs font-bold uppercase tracking-widest text-text-muted">
                     Rate Limit
                   </th>
                   <th className="px-3 py-2 text-xs font-bold uppercase tracking-widest text-text-muted">
-                    Enabled
+                    Source
                   </th>
                   <th className="px-3 py-2 text-xs font-bold uppercase tracking-widest text-text-muted">
                     Actions
@@ -321,41 +315,39 @@ export default function AgentCapabilitiesPage({
                 </tr>
               </thead>
               <tbody>
-                {filteredBindings.map((b) => (
+                {filteredEffectiveTools.map((tool) => (
                   <tr
-                    key={b.id}
+                    key={tool.bindingId}
                     className="border-b border-surface-border last:border-b-0 hover:bg-secondary/20"
                   >
-                    <td className="px-3 py-2 font-mono text-xs text-text-main">{b.toolRef}</td>
                     <td className="px-3 py-2">
-                      <Badge variant={policyVariant(b.approvalPolicy)}>
-                        {policyLabel(b.approvalPolicy)}
+                      <div className="font-mono text-xs text-text-main">{tool.toolRef}</div>
+                      <div className="mt-1 text-xs text-text-muted">{tool.description}</div>
+                    </td>
+                    <td className="px-3 py-2">
+                      <span className="font-mono text-xs text-text-main">{tool.runtimeName}</span>
+                    </td>
+                    <td className="px-3 py-2">
+                      <Badge variant={policyVariant(tool.approvalPolicy)}>
+                        {policyLabel(tool.approvalPolicy)}
                       </Badge>
                     </td>
                     <td className="px-3 py-2 text-xs text-text-muted">
-                      {rateLimitDisplay(b.rateLimit)}
+                      {rateLimitDisplay(tool.rateLimit)}
                     </td>
                     <td className="px-3 py-2">
-                      <button
-                        type="button"
-                        onClick={() => void handleToggleEnabled(b)}
-                        className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
-                          b.enabled ? "bg-primary" : "bg-slate-600"
-                        }`}
-                        title={b.enabled ? "Disable" : "Enable"}
-                      >
-                        <span
-                          className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
-                            b.enabled ? "translate-x-4" : "translate-x-1"
-                          }`}
-                        />
-                      </button>
+                      <Badge variant="info">{tool.source.kind}</Badge>
                     </td>
                     <td className="px-3 py-2">
                       <Button
                         size="sm"
                         variant="ghost"
-                        onClick={() => setDeleteTarget(b)}
+                        onClick={() => {
+                          const binding = bindings.find(
+                            (candidate) => candidate.id === tool.bindingId,
+                          )
+                          if (binding) setDeleteTarget(binding)
+                        }}
                         title="Remove binding"
                       >
                         <span className="material-symbols-outlined text-sm text-danger">

--- a/packages/dashboard/src/lib/schemas/tool-bindings.ts
+++ b/packages/dashboard/src/lib/schemas/tool-bindings.ts
@@ -53,12 +53,18 @@ export const BulkBindResponseSchema = z.object({
 
 export const EffectiveToolSchema = z.object({
   toolRef: z.string(),
+  runtimeName: z.string(),
+  description: z.string(),
+  inputSchema: z.record(z.string(), z.unknown()),
   bindingId: z.string(),
   approvalPolicy: ToolApprovalPolicySchema,
   approvalCondition: z.record(z.string(), z.unknown()).nullable(),
   rateLimit: z.record(z.string(), z.unknown()).nullable(),
   costBudget: z.record(z.string(), z.unknown()).nullable(),
   dataScope: z.record(z.string(), z.unknown()).nullable(),
+  source: z.object({
+    kind: z.enum(["builtin", "mcp", "webhook", "unknown"]),
+  }),
 })
 
 export const EffectiveToolsResponseSchema = z.object({

--- a/packages/shared/src/backends/types.ts
+++ b/packages/shared/src/backends/types.ts
@@ -80,6 +80,36 @@ export interface TaskContext {
    * for selected skills. Empty string when no skills are loaded.
    */
   skillInstructions?: string
+
+  /**
+   * Resolved runtime tool manifest for this execution.
+   * Contains only tools actually exposed to the runtime for this run.
+   */
+  runtimeToolManifest?: RuntimeToolManifest
+}
+
+export interface RuntimeToolManifest {
+  /** Contract version for forward-compatible readers. */
+  version: "v1"
+  /** Timestamp when the manifest was assembled. */
+  assembledAt: string
+  /** Tools actually exposed to the runtime for this execution. */
+  tools: RuntimeToolManifestTool[]
+}
+
+export interface RuntimeToolManifestTool {
+  /** Stable configured reference when known, otherwise the runtime name. */
+  toolRef: string
+  /** Executable name exposed to the model/runtime. */
+  runtimeName: string
+  /** Human-readable description exposed to the model/runtime. */
+  description: string
+  /** Input schema exposed to the model/runtime. */
+  inputSchema: Record<string, unknown>
+  /** Source family for display and auditing. */
+  source: {
+    kind: "builtin" | "mcp" | "webhook" | "unknown"
+  }
 }
 
 /**


### PR DESCRIPTION
Implements #772.

Summary:
- return computed effective tools from /agents/:agentId/effective-tools
- define and inject a runtime tool manifest into execution
- fail closed for unexecutable or unresolvable configured tools
- align dashboard effective-tool schema/display with the computed contract
- add route, manifest, and simple tool-enabled execution-path coverage

Validation:
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard capabilities page now displays tool source (builtin, MCP, webhook) instead of enable/disable toggles
  * Tool runtime information including descriptions and input schemas now visible throughout the app

* **Refactor**
  * Restructured internal tool capability disclosure system to use runtime tool manifests

* **Tests**
  * Extended test coverage for effective tool resolution and manifest generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->