### PR TITLE
Fix provider-bound agent chat path (#774)

### DIFF
--- a/packages/control-plane/src/__tests__/agent-execute-credential-wiring.test.ts
+++ b/packages/control-plane/src/__tests__/agent-execute-credential-wiring.test.ts
@@ -114,6 +114,7 @@ function makeMockDb(opts: MockDbOptions = {}) {
   const agent = opts.agent !== undefined ? opts.agent : defaultAgent
   const recentJobs = opts.recentJobs ?? []
   const credentialBinding = opts.credentialBinding ?? null
+  const updateSets: Array<{ table: string; values: Record<string, unknown> }> = []
 
   function createChain(tableName: string, isSelect: boolean) {
     const chain: Record<string, unknown> = {}
@@ -159,10 +160,17 @@ function makeMockDb(opts: MockDbOptions = {}) {
 
   const db = {
     selectFrom: vi.fn((table: string) => createChain(table, true)),
-    updateTable: vi.fn((table: string) => createChain(table, false)),
+    updateTable: vi.fn((table: string) => {
+      const chain = createChain(table, false)
+      chain.set = vi.fn().mockImplementation((values: Record<string, unknown>) => {
+        updateSets.push({ table, values })
+        return chain
+      })
+      return chain
+    }),
   }
 
-  return db
+  return { db, updateSets }
 }
 
 function makeMockRegistry(handle: ExecutionHandle = createMockHandle()) {
@@ -265,7 +273,7 @@ function makeMockCredentialService(
 
 describe("agent-execute credential wiring (#444)", () => {
   it("resolves llmCredential from agent_credential_binding when credentialService is provided", async () => {
-    const db = makeMockDb({
+    const { db } = makeMockDb({
       credentialBinding: {
         id: "binding-cred-1",
         user_account_id: "user-owner-1",
@@ -295,7 +303,7 @@ describe("agent-execute credential wiring (#444)", () => {
 
     // Verify the task passed to executeTask has llmCredential set
     expect(executeTaskSpy).toHaveBeenCalled()
-    const executedTask = executeTaskSpy.mock.calls[0][0] as ExecutionTask
+    const executedTask = executeTaskSpy.mock.calls[0]![0] as ExecutionTask
     expect(executedTask.constraints.llmCredential).toEqual({
       provider: "google-antigravity",
       token: "resolved-oauth-token",
@@ -306,7 +314,7 @@ describe("agent-execute credential wiring (#444)", () => {
   })
 
   it("falls back to env var when no credential binding exists", async () => {
-    const db = makeMockDb({
+    const { db } = makeMockDb({
       credentialBinding: null, // No binding
     })
     const { registry, executeTaskSpy } = makeMockRegistry()
@@ -326,12 +334,12 @@ describe("agent-execute credential wiring (#444)", () => {
 
     // Task should not have llmCredential set
     expect(executeTaskSpy).toHaveBeenCalled()
-    const executedTask = executeTaskSpy.mock.calls[0][0] as ExecutionTask
+    const executedTask = executeTaskSpy.mock.calls[0]![0] as ExecutionTask
     expect(executedTask.constraints.llmCredential).toBeUndefined()
   })
 
   it("fails clearly when a bound OAuth credential requires re-authentication", async () => {
-    const db = makeMockDb({
+    const { db } = makeMockDb({
       credentialBinding: {
         id: "binding-cred-2",
         user_account_id: "user-owner-1",
@@ -369,7 +377,7 @@ describe("agent-execute credential wiring (#444)", () => {
   })
 
   it("selects the bound provider/model pair and passes it into execution", async () => {
-    const db = makeMockDb({
+    const { db } = makeMockDb({
       agent: {
         id: "agent-1",
         name: "TestAgent",
@@ -412,7 +420,7 @@ describe("agent-execute credential wiring (#444)", () => {
 
     // Verify the task has llmCredential set
     expect(executeTaskSpy).toHaveBeenCalled()
-    const executedTask = executeTaskSpy.mock.calls[0][0] as ExecutionTask
+    const executedTask = executeTaskSpy.mock.calls[0]![0] as ExecutionTask
     expect(executedTask.constraints.llmCredential).toEqual({
       provider: "google-antigravity",
       token: "resolved-oauth-token",
@@ -423,8 +431,61 @@ describe("agent-execute credential wiring (#444)", () => {
     expect(executedTask.constraints.model).toBe("claude-sonnet-4-5")
   })
 
+  it("fails instead of silently falling back when the configured provider is not bound", async () => {
+    const { db, updateSets } = makeMockDb({
+      agent: {
+        id: "agent-1",
+        name: "TestAgent",
+        slug: "test-agent",
+        role: "developer",
+        description: null,
+        status: "ACTIVE",
+        model_config: { provider: "google-antigravity", model: "claude-sonnet-4-5" },
+        skill_config: {},
+        resource_limits: {},
+        config: null,
+        health_reset_at: null,
+      },
+      credentialBinding: {
+        id: "binding-cred-openai",
+        user_account_id: "user-owner-1",
+        provider: "openai",
+        credential_type: "api_key",
+        credential_class: "llm_provider",
+        account_id: null,
+      },
+    })
+    const { registry, executeTaskSpy } = makeMockRegistry()
+    const credentialService = makeMockCredentialService()
+
+    const task = createAgentExecuteTask({
+      db: db as unknown as AgentExecuteDeps["db"],
+      registry,
+      credentialService,
+    })
+
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
+
+    expect(executeTaskSpy).not.toHaveBeenCalled()
+    const failedUpdate = updateSets.find(
+      (entry) =>
+        entry.table === "job" &&
+        entry.values.status === "FAILED" &&
+        typeof entry.values.error === "object" &&
+        entry.values.error !== null,
+    )
+    expect(failedUpdate).toBeDefined()
+    expect(failedUpdate?.values.error).toEqual(
+      expect.objectContaining({
+        code: "provider_unbound",
+        provider: "google-antigravity",
+        model: "claude-sonnet-4-5",
+      }),
+    )
+  })
+
   it("resolves api_key credential with credentialType 'api_key' for direct-key providers", async () => {
-    const db = makeMockDb({
+    const { db } = makeMockDb({
       credentialBinding: {
         id: "binding-cred-4",
         user_account_id: "user-owner-1",
@@ -459,7 +520,7 @@ describe("agent-execute credential wiring (#444)", () => {
     })
 
     expect(executeTaskSpy).toHaveBeenCalled()
-    const executedTask = executeTaskSpy.mock.calls[0][0] as ExecutionTask
+    const executedTask = executeTaskSpy.mock.calls[0]![0] as ExecutionTask
     expect(executedTask.constraints.llmCredential).toEqual({
       provider: "openai",
       token: "sk-openai-key-12345678",
@@ -470,7 +531,7 @@ describe("agent-execute credential wiring (#444)", () => {
   })
 
   it("proceeds without credential resolution when credentialService is not injected", async () => {
-    const db = makeMockDb()
+    const { db } = makeMockDb()
     const { registry, executeTaskSpy } = makeMockRegistry()
 
     // No credentialService provided — simulates the pre-fix behavior
@@ -488,7 +549,7 @@ describe("agent-execute credential wiring (#444)", () => {
   })
 
   it("injects truthful runtime capability disclosure into the execution system prompt", async () => {
-    const db = makeMockDb()
+    const { db } = makeMockDb()
     const { registry, executeTaskSpy } = makeMockRegistry()
 
     const task = createAgentExecuteTask({
@@ -513,7 +574,7 @@ describe("agent-execute credential wiring (#444)", () => {
   })
 
   it("uses the actual resolved registry to disclose MCP availability", async () => {
-    const db = makeMockDb({
+    const { db } = makeMockDb({
       agent: {
         id: "agent-1",
         name: "TestAgent",
@@ -549,10 +610,25 @@ describe("agent-execute credential wiring (#444)", () => {
     )
   })
 
-  it("injects a runtime tool manifest and guarded executable tools for a simple V2-enabled run", async () => {
-    vi.stubEnv("CAPABILITY_MODEL_V2", "true")
-
-    const db = makeMockDb()
+  it("injects a runtime tool manifest and guarded executable tools for chat runs without relying on the feature flag", async () => {
+    const { db } = makeMockDb({
+      job: {
+        id: "job-1",
+        agent_id: "agent-1",
+        status: "SCHEDULED",
+        attempt: 0,
+        max_attempts: 3,
+        timeout_seconds: 300,
+        session_id: null,
+        payload: { type: "CHAT_RESPONSE", prompt: "hello", goalType: "research" },
+        error: null,
+        result: null,
+        started_at: null,
+        completed_at: null,
+        heartbeat_at: null,
+        approval_expires_at: null,
+      },
+    })
     const executeTaskSpy = vi.fn().mockResolvedValue(createMockHandle())
     const registry = {
       routeTask: vi.fn().mockReturnValue({
@@ -594,11 +670,7 @@ describe("agent-execute credential wiring (#444)", () => {
       capabilityAssembler: capabilityAssembler as never,
     })
 
-    try {
-      await task({ jobId: "job-1" }, makeMockHelpers() as never)
-    } finally {
-      vi.unstubAllEnvs()
-    }
+    await task({ jobId: "job-1" }, makeMockHelpers() as never)
 
     const executedTask = executeTaskSpy.mock.calls[0]![0] as ExecutionTask
     const guardedRegistry = executeTaskSpy.mock.calls[0]![1] as ToolRegistry

--- a/packages/control-plane/src/__tests__/chat-flow.test.ts
+++ b/packages/control-plane/src/__tests__/chat-flow.test.ts
@@ -20,9 +20,11 @@ import {
 } from "../channels/message-dispatch.js"
 import type { Database } from "../db/types.js"
 
+const mockRunPreflight = vi.hoisted(() => vi.fn())
+
 // Mock preflight to always pass (unit tests for preflight are in preflight.test.ts)
 vi.mock("../channels/preflight.js", () => ({
-  runPreflight: vi.fn().mockResolvedValue({ ok: true }),
+  runPreflight: mockRunPreflight,
   mapJobErrorToUserMessage: vi
     .fn()
     .mockReturnValue("Something went wrong processing your message. Please try again."),
@@ -80,6 +82,7 @@ function buildFlowDb(opts: {
   } = opts
 
   const sessionMessageInserts: Array<Record<string, unknown>> = []
+  const jobInserts: Array<Record<string, unknown>> = []
 
   const selectFromFn = vi.fn().mockImplementation((table: string) => {
     if (table === "session") {
@@ -143,7 +146,10 @@ function buildFlowDb(opts: {
     // job insert
     const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(jobRow)
     const returning = vi.fn().mockReturnValue({ executeTakeFirstOrThrow })
-    const values = vi.fn().mockReturnValue({ returning })
+    const values = vi.fn().mockImplementation((val: Record<string, unknown>) => {
+      jobInserts.push(val)
+      return { returning }
+    })
     return { values }
   })
 
@@ -162,6 +168,7 @@ function buildFlowDb(opts: {
       updateTable: updateTableFn,
     } as unknown as Kysely<Database>,
     sessionMessageInserts,
+    jobInserts,
   }
 }
 
@@ -170,7 +177,110 @@ function buildFlowDb(opts: {
 // ---------------------------------------------------------------------------
 
 describe("end-to-end chat flow", () => {
+  it("persists channel-path diagnostics and effective tool contract in the created chat job", async () => {
+    mockRunPreflight.mockResolvedValue({
+      ok: true,
+      diagnostics: {
+        providerModel: {
+          requestedProvider: "google-antigravity",
+          requestedModel: "claude-sonnet-4-5",
+          resolvedProvider: "google-antigravity",
+          resolvedModel: "claude-sonnet-4-5",
+          boundProviders: ["google-antigravity"],
+          bindingRequired: true,
+          mismatchCode: null,
+          mismatchMessage: null,
+        },
+      },
+    })
+    const { db, sessionMessageInserts, jobInserts } = buildFlowDb({
+      existingSession: { id: "session-e2e" },
+    })
+    const agentChannelService = mockAgentChannelService("agent-e2e")
+    const router = mockRouter()
+    const enqueueJob = vi.fn().mockResolvedValue(undefined)
+    const capabilityAssembler = {
+      resolveEffectiveTools: vi
+        .fn()
+        .mockResolvedValue([{ toolRef: "web_search" }, { toolRef: "mcp:filesystem:read_file" }]),
+    }
+    const logger = { info: vi.fn(), warn: vi.fn() }
+
+    const dispatch = createMessageDispatch({
+      db,
+      agentChannelService,
+      router: router as never,
+      enqueueJob,
+      capabilityAssembler: capabilityAssembler as never,
+      logger,
+    })
+
+    await dispatch(makeRoutedMessage("Explain the deployment."))
+
+    const insertedMessage = sessionMessageInserts[0] as {
+      metadata?: {
+        source?: {
+          surface?: string
+          channelType?: string
+          channelId?: string
+          chatId?: string
+          messageId?: string
+        }
+      }
+    }
+    const insertedJob = jobInserts[0] as {
+      payload?: {
+        chatDiagnostics?: {
+          source?: { surface?: string; channelId?: string }
+          providerModel?: { resolvedProvider?: string; resolvedModel?: string }
+          tools?: { mode?: string; refs?: string[] }
+        }
+      }
+    }
+
+    expect(sessionMessageInserts).toContainEqual(
+      expect.objectContaining({
+        metadata: {
+          source: {
+            surface: "channel",
+            channelType: "telegram",
+            channelId: "telegram:chat-42",
+            chatId: "chat-42",
+            messageId: "msg-1",
+          },
+        },
+      }),
+    )
+
+    expect(insertedMessage.metadata?.source).toEqual(
+      expect.objectContaining({
+        surface: "channel",
+        channelType: "telegram",
+        channelId: "telegram:chat-42",
+        chatId: "chat-42",
+        messageId: "msg-1",
+      }),
+    )
+
+    expect(insertedJob.payload?.chatDiagnostics?.source).toEqual(
+      expect.objectContaining({ surface: "channel", channelId: "telegram:chat-42" }),
+    )
+    expect(insertedJob.payload?.chatDiagnostics?.providerModel).toEqual(
+      expect.objectContaining({
+        resolvedProvider: "google-antigravity",
+        resolvedModel: "claude-sonnet-4-5",
+      }),
+    )
+    expect(insertedJob.payload?.chatDiagnostics?.tools).toEqual(
+      expect.objectContaining({
+        mode: "effective",
+        refs: ["web_search", "mcp:filesystem:read_file"],
+      }),
+    )
+  })
+
   it("dispatches a message, creates a job, and relays the full response", async () => {
+    mockRunPreflight.mockResolvedValue({ ok: true })
     const { db, sessionMessageInserts } = buildFlowDb({
       existingSession: { id: "session-e2e" },
       historyRows: [{ role: "assistant", content: "Previous answer" }],

--- a/packages/control-plane/src/__tests__/chat-session-crud.test.ts
+++ b/packages/control-plane/src/__tests__/chat-session-crud.test.ts
@@ -256,13 +256,18 @@ function mockDb(
 }
 
 /** Build a Fastify app with both chat + session routes registered. */
-async function buildApp(db: Kysely<Database>, enqueueJob = vi.fn().mockResolvedValue(undefined)) {
+async function buildApp(
+  db: Kysely<Database>,
+  enqueueJob = vi.fn().mockResolvedValue(undefined),
+  capabilityAssembler?: { resolveEffectiveTools: ReturnType<typeof vi.fn> },
+) {
   const app = Fastify({ logger: false })
   await app.register(
     chatRoutes({
       db,
       authConfig: DEV_AUTH_CONFIG,
       enqueueJob,
+      capabilityAssembler: capabilityAssembler as never,
     }),
   )
   await app.register(
@@ -297,10 +302,30 @@ afterEach(() => {
 
 describe("Create session → appears in list", () => {
   it("sending a chat message creates a session that appears in GET /agents/:id/sessions", async () => {
+    mockRunPreflight.mockResolvedValue({
+      ok: true,
+      diagnostics: {
+        providerModel: {
+          requestedProvider: "openai",
+          requestedModel: "gpt-4o",
+          resolvedProvider: "openai",
+          resolvedModel: "gpt-4o",
+          boundProviders: ["openai"],
+          bindingRequired: true,
+          mismatchCode: null,
+          mismatchMessage: null,
+        },
+      },
+    })
     const createdSession = makeSession()
     const { db, sessionMessageInserts } = mockDb({ session: createdSession })
     const enqueueJob = vi.fn().mockResolvedValue(undefined)
-    const app = await buildApp(db, enqueueJob)
+    const capabilityAssembler = {
+      resolveEffectiveTools: vi
+        .fn()
+        .mockResolvedValue([{ toolRef: "web_search" }, { toolRef: "echo" }]),
+    }
+    const app = await buildApp(db, enqueueJob, capabilityAssembler)
 
     // Send a chat message (creates/reuses session)
     const chatRes = await app.inject({
@@ -308,10 +333,37 @@ describe("Create session → appears in list", () => {
       url: `/agents/${AGENT_ID}/chat`,
       payload: { text: "Hello, agent!" },
     })
+    const chatBody = chatRes.json<{
+      session_id: string
+      status: string
+      diagnostics?: {
+        source?: { surface?: string; channelType?: string; channelId?: string }
+        providerModel?: { resolvedProvider?: string; resolvedModel?: string }
+        tools?: { mode?: string; refs?: string[] }
+      }
+    }>()
+    const insertedMessage = sessionMessageInserts[0] as {
+      metadata?: { source?: { surface?: string; channelId?: string } }
+    }
 
     expect(chatRes.statusCode).toBe(202)
-    expect(chatRes.json().session_id).toBe(SESSION_ID)
-    expect(chatRes.json().status).toBe("SCHEDULED")
+    expect(chatBody.session_id).toBe(SESSION_ID)
+    expect(chatBody.status).toBe("SCHEDULED")
+    expect(chatBody.diagnostics).toMatchObject({
+      source: {
+        surface: "ui",
+        channelType: "rest",
+        channelId: "rest:api",
+      },
+      providerModel: {
+        resolvedProvider: "openai",
+        resolvedModel: "gpt-4o",
+      },
+      tools: {
+        mode: "effective",
+        refs: ["web_search", "echo"],
+      },
+    })
 
     // Verify user message was stored
     expect(sessionMessageInserts).toContainEqual(
@@ -321,17 +373,21 @@ describe("Create session → appears in list", () => {
         content: "Hello, agent!",
       }),
     )
+    expect(insertedMessage.metadata?.source).toEqual(
+      expect.objectContaining({ surface: "ui", channelId: "rest:api" }),
+    )
 
     // List sessions — the session should appear
     const listRes = await app.inject({
       method: "GET",
       url: `/agents/${AGENT_ID}/sessions`,
     })
+    const listBody = listRes.json<{ sessions: Array<{ id: string; status: string }> }>()
 
     expect(listRes.statusCode).toBe(200)
-    expect(listRes.json().sessions).toHaveLength(1)
-    expect(listRes.json().sessions[0].id).toBe(SESSION_ID)
-    expect(listRes.json().sessions[0].status).toBe("active")
+    expect(listBody.sessions).toHaveLength(1)
+    expect(listBody.sessions[0]?.id).toBe(SESSION_ID)
+    expect(listBody.sessions[0]?.status).toBe("active")
   })
 })
 

--- a/packages/control-plane/src/__tests__/preflight.test.ts
+++ b/packages/control-plane/src/__tests__/preflight.test.ts
@@ -19,10 +19,11 @@ function selectChain(rows: Record<string, unknown>[]) {
 
 function joinChain(rows: Record<string, unknown>[]) {
   const executeTakeFirst = vi.fn().mockResolvedValue(rows[0] ?? null)
+  const execute = vi.fn().mockResolvedValue(rows)
   const terminal = { executeTakeFirst }
   const whereFn: ReturnType<typeof vi.fn> = vi.fn()
-  whereFn.mockReturnValue({ where: whereFn, ...terminal })
-  const selectFn = vi.fn().mockReturnValue({ where: whereFn, ...terminal })
+  whereFn.mockReturnValue({ where: whereFn, execute, ...terminal })
+  const selectFn = vi.fn().mockReturnValue({ where: whereFn, execute, ...terminal })
   const innerJoinFn = vi.fn().mockReturnValue({ select: selectFn })
   return { innerJoinFn }
 }
@@ -45,23 +46,28 @@ describe("runPreflight", () => {
   it("returns ok when agent is ACTIVE and LLM_API_KEY env var is set", async () => {
     process.env.LLM_API_KEY = "sk-test"
 
-    const agentSelect = selectChain([{ id: "agent-1", status: "ACTIVE" }])
+    const agentSelect = selectChain([{ id: "agent-1", status: "ACTIVE", model_config: {} }])
     const db = {
       selectFrom: vi.fn().mockReturnValue({ select: agentSelect.selectFn }),
     } as unknown as Kysely<Database>
 
     const result = await runPreflight(db, "agent-1")
 
-    expect(result).toEqual({ ok: true })
+    expect(result.ok).toBe(true)
+    expect(result.diagnostics?.providerModel).toEqual(
+      expect.objectContaining({
+        bindingRequired: false,
+      }),
+    )
   })
 
   it("returns ok when agent is ACTIVE and has bound LLM credential", async () => {
     delete process.env.LLM_API_KEY
 
     // Agent lookup
-    const agentSelect = selectChain([{ id: "agent-1", status: "ACTIVE" }])
+    const agentSelect = selectChain([{ id: "agent-1", status: "ACTIVE", model_config: {} }])
     // Credential binding lookup
-    const credJoin = joinChain([{ id: "cred-1" }])
+    const credJoin = joinChain([{ id: "cred-1", provider: "openai", status: "active" }])
 
     let callCount = 0
     const db = {
@@ -78,7 +84,12 @@ describe("runPreflight", () => {
 
     const result = await runPreflight(db, "agent-1")
 
-    expect(result).toEqual({ ok: true })
+    expect(result.ok).toBe(true)
+    expect(result.diagnostics?.providerModel).toEqual(
+      expect.objectContaining({
+        boundProviders: ["openai"],
+      }),
+    )
   })
 
   it("returns not_active for QUARANTINED agent", async () => {
@@ -138,7 +149,13 @@ describe("runPreflight", () => {
     delete process.env.LLM_API_KEY
 
     // Agent lookup returns ACTIVE
-    const agentSelect = selectChain([{ id: "agent-1", status: "ACTIVE" }])
+    const agentSelect = selectChain([
+      {
+        id: "agent-1",
+        status: "ACTIVE",
+        model_config: { provider: "google-antigravity", model: "claude-sonnet-4-5" },
+      },
+    ])
     // Credential binding returns nothing
     const credJoin = joinChain([])
 
@@ -159,6 +176,37 @@ describe("runPreflight", () => {
     expect(result.code).toBe("no_llm_credential")
     expect(result.userMessage).toContain("LLM API key")
     expect(result.userMessage).toContain("operator")
+  })
+
+  it("blocks explicit provider/model contracts that do not match bound providers", async () => {
+    delete process.env.LLM_API_KEY
+
+    const agentSelect = selectChain([
+      {
+        id: "agent-1",
+        status: "ACTIVE",
+        model_config: { provider: "google-antigravity", model: "claude-sonnet-4-5" },
+      },
+    ])
+    const credJoin = joinChain([
+      { id: "cred-1", provider: "openai", status: "active", credential_class: "llm_provider" },
+    ])
+
+    let callCount = 0
+    const db = {
+      selectFrom: vi.fn().mockImplementation(() => {
+        callCount++
+        if (callCount === 1) return { select: agentSelect.selectFn }
+        return { innerJoin: credJoin.innerJoinFn }
+      }),
+    } as unknown as Kysely<Database>
+
+    const result = await runPreflight(db, "agent-1")
+
+    expect(result.ok).toBe(false)
+    expect(result.code).toBe("provider_model_misconfigured")
+    expect(result.userMessage).toContain("google-antigravity")
+    expect(result.userMessage).toContain("claude-sonnet-4-5")
   })
 })
 

--- a/packages/control-plane/src/app.ts
+++ b/packages/control-plane/src/app.ts
@@ -385,6 +385,7 @@ export async function buildApp(options: AppOptions): Promise<AppContext> {
       sessionService,
       channelAuthGuard: chatAuthGuard,
       userRateLimiter: chatRateLimiter,
+      capabilityAssembler,
     }),
   )
 

--- a/packages/control-plane/src/channels/message-dispatch.ts
+++ b/packages/control-plane/src/channels/message-dispatch.ts
@@ -19,10 +19,16 @@ import type { Kysely } from "kysely"
 
 import type { AuthDecision, ChannelAuthGuard } from "../auth/channel-auth-guard.js"
 import type { UserRateLimiter } from "../auth/user-rate-limiter.js"
+import type { CapabilityAssembler } from "../capabilities/index.js"
+import {
+  buildChatDispatchDiagnostics,
+  type ResolvedProviderModelContract,
+  type SessionResolutionDiagnostics,
+} from "../chat/runtime-contract.js"
 import type { ChannelType, Database, RateLimit, TokenBudget } from "../db/types.js"
 import type { AgentEventEmitter } from "../observability/event-emitter.js"
 import type { AgentChannelService } from "./agent-channel-service.js"
-import { mapJobErrorToUserMessage, runPreflight } from "./preflight.js"
+import { mapJobErrorToUserMessage, type PreflightResult, runPreflight } from "./preflight.js"
 
 /** Pattern matching pairing codes (6-char uppercase alphanumeric). */
 const PAIRING_CODE_PATTERN = /^[A-Z0-9]{6}$/
@@ -35,6 +41,7 @@ export interface MessageDispatchDeps {
   channelAuthGuard?: ChannelAuthGuard
   userRateLimiter?: UserRateLimiter
   eventEmitter?: AgentEventEmitter
+  capabilityAssembler?: CapabilityAssembler
   logger?: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void }
 }
 
@@ -71,6 +78,7 @@ export function createMessageDispatch(
     channelAuthGuard,
     userRateLimiter,
     eventEmitter,
+    capabilityAssembler,
     logger = console,
   } = deps
 
@@ -207,6 +215,24 @@ export function createMessageDispatch(
 
     // Find or create a session for (agent_id, user_account_id, channel_id)
     const session = await findOrCreateSession(db, agentId, routed.userAccountId, channelId)
+    const source: SessionResolutionDiagnostics = {
+      surface: "channel",
+      channelType,
+      channelId,
+      chatId,
+      messageId: routed.message.messageId,
+    }
+    const toolRefs = capabilityAssembler
+      ? (await capabilityAssembler.resolveEffectiveTools(agentId)).map((tool) => tool.toolRef)
+      : undefined
+    const chatDiagnostics = buildChatDispatchDiagnostics({
+      agentId,
+      sessionId: session.id,
+      source,
+      providerModel: extractProviderModelDiagnostics(preflight),
+      toolRefs,
+      toolContractMode: capabilityAssembler ? "effective" : "legacy",
+    })
 
     // Store inbound user message
     await db
@@ -215,6 +241,9 @@ export function createMessageDispatch(
         session_id: session.id,
         role: "user",
         content: routed.message.text,
+        metadata: {
+          source,
+        },
       })
       .execute()
 
@@ -232,6 +261,7 @@ export function createMessageDispatch(
           prompt: routed.message.text,
           goalType: "research",
           conversationHistory,
+          chatDiagnostics,
           ...(authDecision && {
             authorizedUserId: authDecision.userId,
             grantId: authDecision.grantId,
@@ -319,6 +349,25 @@ export function createMessageDispatch(
         },
       },
     )
+  }
+}
+
+function extractProviderModelDiagnostics(
+  preflight: PreflightResult,
+): ResolvedProviderModelContract {
+  const providerModel = preflight.diagnostics?.providerModel
+  if (providerModel && typeof providerModel === "object") {
+    return providerModel as ResolvedProviderModelContract
+  }
+  return {
+    requestedProvider: null,
+    requestedModel: null,
+    resolvedProvider: null,
+    resolvedModel: null,
+    boundProviders: [],
+    bindingRequired: false,
+    mismatchCode: null,
+    mismatchMessage: null,
   }
 }
 

--- a/packages/control-plane/src/channels/preflight.ts
+++ b/packages/control-plane/src/channels/preflight.ts
@@ -13,6 +13,7 @@
 
 import type { Kysely } from "kysely"
 
+import { loadActiveLlmBindings, resolveProviderModelContract } from "../chat/runtime-contract.js"
 import type { Database } from "../db/types.js"
 
 // ---------------------------------------------------------------------------
@@ -24,7 +25,8 @@ export interface PreflightResult {
   /** User-facing message explaining *why* the agent cannot run and *what to do*. */
   userMessage?: string
   /** Machine-readable code for programmatic callers (REST API). */
-  code?: "agent_not_active" | "no_llm_credential"
+  code?: "agent_not_active" | "no_llm_credential" | "provider_model_misconfigured"
+  diagnostics?: Record<string, unknown>
 }
 
 // ---------------------------------------------------------------------------
@@ -44,6 +46,25 @@ const NO_CREDENTIAL_MESSAGE =
   "This agent does not have an LLM API key configured. " +
   "An operator needs to bind an LLM credential in the agent settings."
 
+function providerModelMismatchMessage(details: {
+  provider?: string | null
+  model?: string | null
+  fallback?: string | null
+}): string {
+  const summary = [details.provider, details.model].filter(Boolean).join(" / ")
+  if (summary) {
+    return (
+      `This agent is configured for ${summary}, but that provider/model is not currently ` +
+      "bound and available. An operator needs to fix the agent's provider or model binding."
+    )
+  }
+  return (
+    details.fallback ??
+    "This agent's configured provider/model is not currently bound and available. " +
+      "An operator needs to fix the agent's provider or model binding."
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Core check
 // ---------------------------------------------------------------------------
@@ -61,7 +82,7 @@ export async function runPreflight(
   // ── 1. Agent status ─────────────────────────────────────────────────
   const agent = await db
     .selectFrom("agent")
-    .select(["id", "status"])
+    .select(["id", "status", "model_config"])
     .where("id", "=", agentId)
     .executeTakeFirst()
 
@@ -79,34 +100,68 @@ export async function runPreflight(
   }
 
   // ── 2. LLM credential availability ─────────────────────────────────
-  // Check env var first (cheapest path).
-  if (process.env.LLM_API_KEY) {
-    return { ok: true }
+  const requestedProvider =
+    typeof agent.model_config?.provider === "string"
+      ? agent.model_config.provider
+      : typeof agent.model_config?.providerId === "string"
+        ? agent.model_config.providerId
+        : null
+  const requestedModel =
+    typeof agent.model_config?.model === "string" ? agent.model_config.model : null
+
+  if (process.env.LLM_API_KEY && requestedProvider === null && requestedModel === null) {
+    return {
+      ok: true,
+      diagnostics: {
+        providerModel: {
+          requestedProvider: null,
+          requestedModel: null,
+          resolvedProvider: null,
+          resolvedModel: null,
+          boundProviders: [],
+          bindingRequired: false,
+          mismatchCode: null,
+          mismatchMessage: null,
+        },
+      },
+    }
   }
 
-  // Check for a bound, active LLM credential.
-  const binding = await db
-    .selectFrom("agent_credential_binding")
-    .innerJoin(
-      "provider_credential",
-      "provider_credential.id",
-      "agent_credential_binding.provider_credential_id",
-    )
-    .select(["provider_credential.id"])
-    .where("agent_credential_binding.agent_id", "=", agentId)
-    .where("provider_credential.credential_class", "=", "llm_provider")
-    .where("provider_credential.status", "=", "active")
-    .executeTakeFirst()
+  const bindings = await loadActiveLlmBindings(db, agentId)
+  const providerModel = resolveProviderModelContract(agent.model_config, bindings)
 
-  if (!binding) {
+  if (providerModel.mismatchCode) {
+    return {
+      ok: false,
+      userMessage: providerModelMismatchMessage({
+        provider: providerModel.resolvedProvider ?? providerModel.requestedProvider,
+        model: providerModel.resolvedModel ?? providerModel.requestedModel,
+        fallback: providerModel.mismatchMessage,
+      }),
+      code: "provider_model_misconfigured",
+      diagnostics: {
+        providerModel,
+      },
+    }
+  }
+
+  if (bindings.length === 0) {
     return {
       ok: false,
       userMessage: NO_CREDENTIAL_MESSAGE,
       code: "no_llm_credential",
+      diagnostics: {
+        providerModel,
+      },
     }
   }
 
-  return { ok: true }
+  return {
+    ok: true,
+    diagnostics: {
+      providerModel,
+    },
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/control-plane/src/chat/runtime-contract.ts
+++ b/packages/control-plane/src/chat/runtime-contract.ts
@@ -1,0 +1,141 @@
+import { normalizeModelConfigSelection } from "@cortex/shared/llm"
+import type { Kysely } from "kysely"
+
+import type { Database } from "../db/types.js"
+
+export interface ActiveLlmBinding {
+  id: string
+  user_account_id: string | null
+  provider: string
+  credential_type: string
+  credential_class: string
+  account_id: string | null
+  status: string
+}
+
+export interface ResolvedProviderModelContract {
+  requestedProvider: string | null
+  requestedModel: string | null
+  resolvedProvider: string | null
+  resolvedModel: string | null
+  boundProviders: string[]
+  bindingRequired: boolean
+  mismatchCode:
+    | "provider_unbound"
+    | "provider_model_invalid"
+    | "model_provider_ambiguous"
+    | "model_unknown"
+    | "provider_unknown"
+    | null
+  mismatchMessage: string | null
+}
+
+export interface SessionResolutionDiagnostics {
+  surface: "channel" | "ui"
+  channelType: string
+  channelId: string
+  chatId: string
+  messageId?: string
+}
+
+export async function loadActiveLlmBindings(
+  db: Kysely<Database>,
+  agentId: string,
+): Promise<ActiveLlmBinding[]> {
+  return db
+    .selectFrom("agent_credential_binding")
+    .innerJoin(
+      "provider_credential",
+      "provider_credential.id",
+      "agent_credential_binding.provider_credential_id",
+    )
+    .select([
+      "provider_credential.id",
+      "provider_credential.user_account_id",
+      "provider_credential.provider",
+      "provider_credential.credential_type",
+      "provider_credential.credential_class",
+      "provider_credential.account_id",
+      "provider_credential.status",
+    ])
+    .where("agent_credential_binding.agent_id", "=", agentId)
+    .where("provider_credential.credential_class", "=", "llm_provider")
+    .where("provider_credential.status", "=", "active")
+    .execute()
+}
+
+export function resolveProviderModelContract(
+  modelConfig: Record<string, unknown> | null | undefined,
+  bindings: Pick<ActiveLlmBinding, "provider">[],
+): ResolvedProviderModelContract {
+  const requestedProvider =
+    typeof modelConfig?.provider === "string"
+      ? modelConfig.provider
+      : typeof modelConfig?.providerId === "string"
+        ? modelConfig.providerId
+        : null
+  const requestedModel = typeof modelConfig?.model === "string" ? modelConfig.model : null
+  const boundProviders = [...new Set(bindings.map((binding) => binding.provider))].sort()
+  const bindingRequired = requestedProvider !== null || requestedModel !== null
+  const normalized = normalizeModelConfigSelection(modelConfig, boundProviders)
+
+  if (!normalized.ok) {
+    return {
+      requestedProvider,
+      requestedModel,
+      resolvedProvider: null,
+      resolvedModel: requestedModel,
+      boundProviders,
+      bindingRequired,
+      mismatchCode: normalized.error.code,
+      mismatchMessage: normalized.error.message,
+    }
+  }
+
+  return {
+    requestedProvider,
+    requestedModel,
+    resolvedProvider: normalized.selection?.provider ?? null,
+    resolvedModel: normalized.selection?.model ?? requestedModel,
+    boundProviders,
+    bindingRequired,
+    mismatchCode: null,
+    mismatchMessage: null,
+  }
+}
+
+export function buildChatDispatchDiagnostics(params: {
+  agentId: string
+  sessionId: string
+  source: SessionResolutionDiagnostics
+  providerModel: ResolvedProviderModelContract
+  toolRefs?: string[]
+  toolContractMode: "effective" | "legacy"
+}): Record<string, unknown> {
+  return {
+    agentId: params.agentId,
+    sessionId: params.sessionId,
+    source: {
+      surface: params.source.surface,
+      channelType: params.source.channelType,
+      channelId: params.source.channelId,
+      chatId: params.source.chatId,
+      ...(params.source.messageId ? { messageId: params.source.messageId } : {}),
+    },
+    providerModel: {
+      requestedProvider: params.providerModel.requestedProvider,
+      requestedModel: params.providerModel.requestedModel,
+      resolvedProvider: params.providerModel.resolvedProvider,
+      resolvedModel: params.providerModel.resolvedModel,
+      boundProviders: params.providerModel.boundProviders,
+      bindingRequired: params.providerModel.bindingRequired,
+      mismatchCode: params.providerModel.mismatchCode,
+      mismatchMessage: params.providerModel.mismatchMessage,
+    },
+    tools: {
+      mode: params.toolContractMode,
+      refs: params.toolRefs ?? [],
+      count: params.toolRefs?.length ?? 0,
+    },
+  }
+}

--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -9,6 +9,7 @@ import { AccessRequestService } from "./auth/access-request-service.js"
 import { ChannelAuthGuard } from "./auth/channel-auth-guard.js"
 import { PairingService } from "./auth/pairing-service.js"
 import { UserRateLimiter } from "./auth/user-rate-limiter.js"
+import { CapabilityAssembler } from "./capabilities/assembler.js"
 import { AgentChannelService } from "./channels/agent-channel-service.js"
 import { ChannelAllowlistService } from "./channels/channel-allowlist-service.js"
 import { ChannelConfigService } from "./channels/channel-config-service.js"
@@ -147,6 +148,7 @@ const channelAuthGuard = new ChannelAuthGuard({
   channelAllowlistService,
 })
 const userRateLimiter = new UserRateLimiter(db)
+const capabilityAssembler = new CapabilityAssembler({ db })
 
 const dispatch = createMessageDispatch({
   db,
@@ -155,6 +157,7 @@ const dispatch = createMessageDispatch({
   enqueueJob: enqueueJobDeferred,
   channelAuthGuard,
   userRateLimiter,
+  capabilityAssembler,
 })
 messageRouter.onMessage(dispatch)
 messageRouter.bind()

--- a/packages/control-plane/src/routes/chat.ts
+++ b/packages/control-plane/src/routes/chat.ts
@@ -13,8 +13,18 @@ import type { Kysely } from "kysely"
 import type { ChannelAuthGuard } from "../auth/channel-auth-guard.js"
 import type { SessionService } from "../auth/session-service.js"
 import type { UserRateLimiter } from "../auth/user-rate-limiter.js"
+import type { CapabilityAssembler } from "../capabilities/index.js"
 import { loadConversationHistory, watchJobCompletion } from "../channels/message-dispatch.js"
-import { mapJobErrorToUserMessage, runPreflight } from "../channels/preflight.js"
+import {
+  mapJobErrorToUserMessage,
+  type PreflightResult,
+  runPreflight,
+} from "../channels/preflight.js"
+import {
+  buildChatDispatchDiagnostics,
+  type ResolvedProviderModelContract,
+  type SessionResolutionDiagnostics,
+} from "../chat/runtime-contract.js"
 import type { Database, RateLimit, TokenBudget } from "../db/types.js"
 import {
   type AuthMiddlewareOptions,
@@ -54,10 +64,19 @@ export interface ChatRouteDeps {
   sessionService?: SessionService
   channelAuthGuard?: ChannelAuthGuard
   userRateLimiter?: UserRateLimiter
+  capabilityAssembler?: CapabilityAssembler
 }
 
 export function chatRoutes(deps: ChatRouteDeps) {
-  const { db, authConfig, enqueueJob, sessionService, channelAuthGuard, userRateLimiter } = deps
+  const {
+    db,
+    authConfig,
+    enqueueJob,
+    sessionService,
+    channelAuthGuard,
+    userRateLimiter,
+    capabilityAssembler,
+  } = deps
 
   const authOpts: AuthMiddlewareOptions = { config: authConfig, sessionService }
   const requireAuth: PreHandler = createRequireAuth(authOpts)
@@ -186,6 +205,23 @@ export function chatRoutes(deps: ChatRouteDeps) {
           channelId,
           requestedSessionId,
         )
+        const source: SessionResolutionDiagnostics = {
+          surface: "ui",
+          channelType: "rest",
+          channelId,
+          chatId: "rest:api",
+        }
+        const toolRefs = capabilityAssembler
+          ? (await capabilityAssembler.resolveEffectiveTools(agentId)).map((tool) => tool.toolRef)
+          : undefined
+        const chatDiagnostics = buildChatDispatchDiagnostics({
+          agentId,
+          sessionId: session.id,
+          source,
+          providerModel: extractProviderModelDiagnostics(preflight),
+          toolRefs,
+          toolContractMode: capabilityAssembler ? "effective" : "legacy",
+        })
 
         // Store user message
         await db
@@ -194,6 +230,9 @@ export function chatRoutes(deps: ChatRouteDeps) {
             session_id: session.id,
             role: "user",
             content: text,
+            metadata: {
+              source,
+            },
           })
           .execute()
 
@@ -211,6 +250,7 @@ export function chatRoutes(deps: ChatRouteDeps) {
               prompt: text,
               goalType: "research",
               conversationHistory,
+              chatDiagnostics,
             },
             priority: 0,
             max_attempts: 3,
@@ -238,6 +278,7 @@ export function chatRoutes(deps: ChatRouteDeps) {
             job_id: job.id,
             session_id: session.id,
             status: "SCHEDULED",
+            diagnostics: chatDiagnostics,
           })
         }
 
@@ -250,6 +291,7 @@ export function chatRoutes(deps: ChatRouteDeps) {
             session_id: session.id,
             status: "RUNNING",
             message: "Job is still running. Poll GET /agents/:id/jobs for status.",
+            diagnostics: chatDiagnostics,
           })
         }
 
@@ -280,6 +322,11 @@ export function chatRoutes(deps: ChatRouteDeps) {
             status: "WAITING_FOR_APPROVAL",
             response: null,
             approval_needed: true,
+            diagnostics: extractChatDiagnostics({
+              payload: { chatDiagnostics },
+              result: result.result,
+              error: result.error,
+            }),
           })
         }
 
@@ -299,6 +346,11 @@ export function chatRoutes(deps: ChatRouteDeps) {
               message: errorMessage,
               code: result.status === "TIMED_OUT" ? "job_timed_out" : "job_failed",
             },
+            diagnostics: extractChatDiagnostics({
+              payload: { chatDiagnostics },
+              result: result.result,
+              error: result.error,
+            }),
           })
         }
 
@@ -307,6 +359,11 @@ export function chatRoutes(deps: ChatRouteDeps) {
           session_id: session.id,
           status: result.status,
           response: responseText,
+          diagnostics: extractChatDiagnostics({
+            payload: { chatDiagnostics },
+            result: result.result,
+            error: result.error,
+          }),
         })
       },
     )
@@ -334,7 +391,7 @@ export function chatRoutes(deps: ChatRouteDeps) {
 
         const row = await db
           .selectFrom("job")
-          .select(["status", "result", "error", "session_id"])
+          .select(["status", "result", "error", "session_id", "payload"])
           .where("id", "=", jobId)
           .where("agent_id", "=", agentId)
           .executeTakeFirst()
@@ -383,6 +440,7 @@ export function chatRoutes(deps: ChatRouteDeps) {
             status: "WAITING_FOR_APPROVAL",
             response: null,
             approval_needed: true,
+            diagnostics: extractChatDiagnostics(row),
           })
         }
 
@@ -402,6 +460,7 @@ export function chatRoutes(deps: ChatRouteDeps) {
               message: errorMessage,
               code: row.status === "TIMED_OUT" ? "job_timed_out" : "job_failed",
             },
+            diagnostics: extractChatDiagnostics(row),
           })
         }
 
@@ -410,6 +469,7 @@ export function chatRoutes(deps: ChatRouteDeps) {
           session_id: row.session_id,
           status: row.status,
           response: responseText,
+          diagnostics: extractChatDiagnostics(row),
         })
       },
     )
@@ -492,6 +552,60 @@ interface WaitForJobResult {
   status: string
   result: Record<string, unknown>
   error: Record<string, unknown> | null
+}
+
+function extractProviderModelDiagnostics(
+  preflight: PreflightResult,
+): ResolvedProviderModelContract {
+  const providerModel = preflight.diagnostics?.providerModel
+  if (providerModel && typeof providerModel === "object") {
+    return providerModel as ResolvedProviderModelContract
+  }
+  return {
+    requestedProvider: null,
+    requestedModel: null,
+    resolvedProvider: null,
+    resolvedModel: null,
+    boundProviders: [],
+    bindingRequired: false,
+    mismatchCode: null,
+    mismatchMessage: null,
+  }
+}
+
+function extractChatDiagnostics(row: {
+  payload?: Record<string, unknown> | null
+  result?: Record<string, unknown> | null
+  error?: Record<string, unknown> | null
+}): Record<string, unknown> | undefined {
+  const payloadDiagnostics =
+    row.payload?.chatDiagnostics &&
+    typeof row.payload.chatDiagnostics === "object" &&
+    row.payload.chatDiagnostics !== null
+      ? (row.payload.chatDiagnostics as Record<string, unknown>)
+      : undefined
+
+  const resultDiagnostics =
+    row.result?.runtime && typeof row.result.runtime === "object" && row.result.runtime !== null
+      ? (row.result.runtime as Record<string, unknown>)
+      : undefined
+
+  const errorDiagnostics =
+    row.error && typeof row.error === "object"
+      ? {
+          error: row.error,
+        }
+      : undefined
+
+  if (!payloadDiagnostics && !resultDiagnostics && !errorDiagnostics) {
+    return undefined
+  }
+
+  return {
+    ...(payloadDiagnostics ? { requested: payloadDiagnostics } : {}),
+    ...(resultDiagnostics ? { runtime: resultDiagnostics } : {}),
+    ...(errorDiagnostics ?? {}),
+  }
 }
 
 function waitForJob(

--- a/packages/control-plane/src/worker/tasks/agent-execute.ts
+++ b/packages/control-plane/src/worker/tasks/agent-execute.ts
@@ -19,7 +19,6 @@ import type {
   OutputEvent,
 } from "@cortex/shared/backends"
 import type { BufferWriter } from "@cortex/shared/buffer"
-import { normalizeModelConfigSelection } from "@cortex/shared/llm"
 import type { ResolvedSkills } from "@cortex/shared/skills"
 import { CortexAttributes, injectTraceContext, withSpan } from "@cortex/shared/tracing"
 import type { JobHelpers, Task } from "graphile-worker"
@@ -35,6 +34,7 @@ import {
   type RuntimeToolManifestRecord,
 } from "../../capabilities/contracts.js"
 import type { CapabilityAssembler } from "../../capabilities/index.js"
+import { loadActiveLlmBindings, resolveProviderModelContract } from "../../chat/runtime-contract.js"
 import type { Database, Job } from "../../db/types.js"
 import { AgentCircuitBreaker, isQuarantineDisabled } from "../../lifecycle/agent-circuit-breaker.js"
 import {
@@ -378,106 +378,140 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
         // ── Step 4b: Resolve LLM credential from agent_credential_binding ──
         let credentialResolver: CredentialResolver | undefined
         let tokenRefresher: TokenRefresher | undefined
-        if (credentialService) {
-          try {
-            const bindings = await db
-              .selectFrom("agent_credential_binding")
-              .innerJoin(
-                "provider_credential",
-                "provider_credential.id",
-                "agent_credential_binding.provider_credential_id",
-              )
-              .select([
-                "provider_credential.id",
-                "provider_credential.user_account_id",
-                "provider_credential.provider",
-                "provider_credential.credential_type",
-                "provider_credential.credential_class",
-                "provider_credential.account_id",
-                "provider_credential.status",
-              ])
-              .where("agent_credential_binding.agent_id", "=", agent.id)
-              .where("provider_credential.credential_class", "=", "llm_provider")
-              .execute()
+        const llmBindings = await loadActiveLlmBindings(db, agent.id)
+        const providerModelContract = resolveProviderModelContract(agent.model_config, llmBindings)
 
-            const normalizedSelection = normalizeModelConfigSelection(
-              agent.model_config,
-              bindings.map((binding) => binding.provider),
+        if (providerModelContract.mismatchCode) {
+          await db
+            .updateTable("job")
+            .set({
+              status: "FAILED",
+              error: {
+                category: "PERMANENT",
+                code: providerModelContract.mismatchCode,
+                message:
+                  providerModelContract.mismatchMessage ??
+                  "Configured provider/model is not available for this agent",
+                provider:
+                  providerModelContract.resolvedProvider ?? providerModelContract.requestedProvider,
+                model: providerModelContract.resolvedModel ?? providerModelContract.requestedModel,
+              },
+              completed_at: new Date(),
+            })
+            .where("id", "=", jobId)
+            .where("status", "=", "RUNNING")
+            .execute()
+          return
+        }
+
+        if (providerModelContract.resolvedModel) {
+          task.constraints.model = providerModelContract.resolvedModel
+        }
+
+        const selectedBinding = providerModelContract.resolvedProvider
+          ? llmBindings.find(
+              (binding) => binding.provider === providerModelContract.resolvedProvider,
             )
-            if (!normalizedSelection.ok) {
-              throw new Error(normalizedSelection.error.message)
-            }
+          : llmBindings[0]
 
-            if (normalizedSelection.selection) {
-              task.constraints.model = normalizedSelection.selection.model
-            }
+        if (providerModelContract.bindingRequired && !selectedBinding) {
+          await db
+            .updateTable("job")
+            .set({
+              status: "FAILED",
+              error: {
+                category: "PERMANENT",
+                code: "provider_unbound",
+                message: "Configured provider is not bound to an active LLM credential",
+                provider: providerModelContract.resolvedProvider,
+                model: providerModelContract.resolvedModel,
+              },
+              completed_at: new Date(),
+            })
+            .where("id", "=", jobId)
+            .where("status", "=", "RUNNING")
+            .execute()
+          return
+        }
 
-            const binding = normalizedSelection.selection
-              ? bindings.find(
-                  (candidate) => candidate.provider === normalizedSelection.selection?.provider,
-                )
-              : bindings[0]
+        if (selectedBinding && !credentialService) {
+          await db
+            .updateTable("job")
+            .set({
+              status: "FAILED",
+              error: {
+                category: "PERMANENT",
+                code: "credential_resolution_unavailable",
+                message:
+                  "Bound LLM credential could not be resolved because credentialService is unavailable",
+                provider: selectedBinding.provider,
+                model: task.constraints.model,
+              },
+              completed_at: new Date(),
+            })
+            .where("id", "=", jobId)
+            .where("status", "=", "RUNNING")
+            .execute()
+          return
+        }
 
-            if (binding) {
-              const resolution = await credentialService.resolveCredentialAccessToken(binding.id, {
+        if (credentialService) {
+          if (selectedBinding) {
+            const resolution = await credentialService.resolveCredentialAccessToken(
+              selectedBinding.id,
+              {
                 agentId: agent.id,
                 jobId: job.id,
-              })
-              if (resolution.ok) {
-                task.constraints.llmCredential = {
-                  provider: binding.provider,
-                  token: resolution.token,
-                  credentialId: resolution.credentialId,
-                  accountId: binding.account_id,
-                  credentialType: binding.credential_type as "oauth" | "api_key",
-                }
-
-                // Build a token refresher for transparent 401 retry.
-                // On auth failure from the LLM provider, the backend will
-                // call this to obtain a fresh token and retry once.
-                const cs = credentialService
-                const auditCtx = { agentId: agent.id, jobId: job.id }
-                tokenRefresher = buildTokenRefresher(cs, auditCtx)
-              } else {
-                if (binding.credential_type === "oauth") {
-                  rootSpan.addEvent("credential_unusable", {
-                    "cortex.credential.id": binding.id,
-                    "cortex.credential.provider": binding.provider,
-                    "cortex.credential.reason": resolution.message,
-                    "cortex.credential.code": resolution.code,
-                  })
-
-                  await db
-                    .updateTable("job")
-                    .set({
-                      status: "FAILED",
-                      error: {
-                        category: "PERMANENT",
-                        code: resolution.code,
-                        message: `${binding.provider} credential unavailable: ${resolution.message}`,
-                        provider: binding.provider,
-                        model: task.constraints.model,
-                      },
-                      completed_at: new Date(),
-                    })
-                    .where("id", "=", jobId)
-                    .where("status", "=", "RUNNING")
-                    .execute()
-                  return
-                }
-
-                rootSpan.addEvent("credential_unusable", {
-                  "cortex.credential.provider": binding.provider,
-                  "cortex.credential.reason": resolution.message,
-                })
+              },
+            )
+            if (resolution.ok) {
+              task.constraints.llmCredential = {
+                provider: selectedBinding.provider,
+                token: resolution.token,
+                credentialId: resolution.credentialId,
+                accountId: selectedBinding.account_id,
+                credentialType: selectedBinding.credential_type as "oauth" | "api_key",
               }
+
+              const cs = credentialService
+              const auditCtx = { agentId: agent.id, jobId: job.id }
+              tokenRefresher = buildTokenRefresher(cs, auditCtx)
+            } else if (
+              providerModelContract.bindingRequired ||
+              selectedBinding.credential_type === "oauth"
+            ) {
+              rootSpan.addEvent("credential_unusable", {
+                "cortex.credential.id": selectedBinding.id,
+                "cortex.credential.provider": selectedBinding.provider,
+                "cortex.credential.reason": resolution.message,
+                "cortex.credential.code": resolution.code,
+              })
+
+              await db
+                .updateTable("job")
+                .set({
+                  status: "FAILED",
+                  error: {
+                    category: "PERMANENT",
+                    code: resolution.code,
+                    message: `${selectedBinding.provider} credential unavailable: ${resolution.message}`,
+                    provider: selectedBinding.provider,
+                    model: task.constraints.model,
+                  },
+                  completed_at: new Date(),
+                })
+                .where("id", "=", jobId)
+                .where("status", "=", "RUNNING")
+                .execute()
+              return
+            } else {
+              rootSpan.addEvent("credential_unusable", {
+                "cortex.credential.provider": selectedBinding.provider,
+                "cortex.credential.reason": resolution.message,
+              })
             }
-            // If no binding exists, fall back to env var LLM_API_KEY (backward compat)
-          } catch {
-            // Credential resolution is non-fatal — fall back to env var
           }
 
-          // Build a credential resolver for tool credential injection
           credentialResolver = buildCredentialResolver(credentialService, db, agent.id, job.id)
         }
 
@@ -541,10 +575,12 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
           // Feature flag: CAPABILITY_MODEL_V2=true uses CapabilityAssembler
           // to resolve effective tools from agent_tool_binding rows instead
           // of the legacy MCP tool router + allowedTools/deniedTools path.
-          const useCapabilityV2 = capabilityAssembler && process.env.CAPABILITY_MODEL_V2 === "true"
+          const useEffectiveToolContract =
+            capabilityAssembler &&
+            (job.payload.type === "CHAT_RESPONSE" || process.env.CAPABILITY_MODEL_V2 === "true")
 
           if (
-            useCapabilityV2 &&
+            useEffectiveToolContract &&
             "createAgentRegistry" in backend &&
             typeof backend.createAgentRegistry === "function"
           ) {
@@ -962,7 +998,7 @@ export function createAgentExecuteTask(deps: AgentExecuteDeps): Task {
             .set({
               status: jobStatus,
               completed_at: new Date(),
-              result: executionResultToJson(result),
+              result: executionResultToJson(result, task),
               error: jobError,
               tool_call_count: toolCallCount,
             })
@@ -1389,7 +1425,10 @@ function mapExecutionStatus(status: ExecutionStatus): JobFinalStatus {
 
 // ── Helper: convert ExecutionResult to JSON-safe record ──
 
-function executionResultToJson(result: ExecutionResult): Record<string, unknown> {
+function executionResultToJson(
+  result: ExecutionResult,
+  task: ExecutionTask,
+): Record<string, unknown> {
   return {
     taskId: result.taskId,
     status: result.status,
@@ -1401,6 +1440,11 @@ function executionResultToJson(result: ExecutionResult): Record<string, unknown>
     artifacts: result.artifacts,
     durationMs: result.durationMs,
     error: result.error ?? null,
+    runtime: {
+      provider: task.constraints.llmCredential?.provider ?? null,
+      model: task.constraints.model,
+      toolManifest: task.context.runtimeToolManifest ?? null,
+    },
   }
 }
 

--- a/packages/dashboard/src/lib/schemas/chat.ts
+++ b/packages/dashboard/src/lib/schemas/chat.ts
@@ -10,6 +10,7 @@ export const SessionSchema = z.object({
   user_account_id: z.string().nullable().optional(),
   channel_id: z.string().nullable().optional(),
   status: z.string(),
+  metadata: z.record(z.string(), z.unknown()).nullable().optional(),
   created_at: z.string(),
   updated_at: z.string(),
 })
@@ -31,6 +32,7 @@ export const SessionMessageSchema = z.object({
   role: z.enum(["user", "assistant", "system"]),
   content: z.string(),
   created_at: z.string(),
+  metadata: z.record(z.string(), z.unknown()).nullable().optional(),
 })
 
 export type SessionMessage = z.infer<typeof SessionMessageSchema>
@@ -71,6 +73,7 @@ export const ChatResponseSchema = z.object({
   status: z.string(),
   response: z.string().nullable().optional(),
   message: z.string().optional(),
+  diagnostics: z.record(z.string(), z.unknown()).optional(),
   error: z
     .object({
       message: z.string(),


### PR DESCRIPTION
## Summary
- enforce provider/model bindings end to end for channel and UI chat dispatch
- carry source, provider/model, and effective tool diagnostics through chat jobs and responses
- add integration coverage for a channel path and a UI path plus execution/preflight regressions

Closes #774

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostics to chat responses, including session resolution details, bound providers, and effective tool information.
  * Introduced session metadata tracking to record message source location.

* **Bug Fixes**
  * Enhanced validation to prevent execution when agent's configured LLM provider/model lacks a credential binding; job now fails with a clear error message.

* **Tests**
  * Expanded test coverage for credential binding validation, provider/model configuration mismatch scenarios, and end-to-end chat flow with diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->