### PR TITLE
Implement first-class session lifecycle and resume flow

### DIFF
--- a/packages/control-plane/migrations/035_session_lifecycle.down.sql
+++ b/packages/control-plane/migrations/035_session_lifecycle.down.sql
@@ -1,0 +1,16 @@
+-- 035: Remove session lifecycle timestamps and restore legacy close semantics.
+
+DROP INDEX IF EXISTS idx_session_agent_user_status_activity;
+
+UPDATE session
+SET status = CASE
+  WHEN status = 'closed' THEN 'ended'
+  ELSE status
+END;
+
+ALTER TABLE session
+  DROP COLUMN IF EXISTS last_activity_at,
+  DROP COLUMN IF EXISTS last_resumed_at,
+  DROP COLUMN IF EXISTS idle_at,
+  DROP COLUMN IF EXISTS archived_at,
+  DROP COLUMN IF EXISTS closed_at;

--- a/packages/control-plane/migrations/035_session_lifecycle.up.sql
+++ b/packages/control-plane/migrations/035_session_lifecycle.up.sql
@@ -1,0 +1,42 @@
+-- 035: Add first-class session lifecycle timestamps and normalize close semantics.
+
+ALTER TABLE session
+  ADD COLUMN last_activity_at TIMESTAMPTZ,
+  ADD COLUMN last_resumed_at TIMESTAMPTZ,
+  ADD COLUMN idle_at TIMESTAMPTZ,
+  ADD COLUMN archived_at TIMESTAMPTZ,
+  ADD COLUMN closed_at TIMESTAMPTZ;
+
+UPDATE session
+SET
+  status = CASE
+    WHEN lower(status) IN ('ended', 'terminated', 'closed') THEN 'closed'
+    WHEN lower(status) IN ('paused', 'idle') THEN 'idle'
+    WHEN lower(status) = 'archived' THEN 'archived'
+    ELSE 'active'
+  END,
+  last_activity_at = COALESCE(updated_at, created_at),
+  last_resumed_at = CASE
+    WHEN lower(status) IN ('ended', 'terminated', 'closed') THEN NULL
+    ELSE COALESCE(updated_at, created_at)
+  END,
+  idle_at = CASE
+    WHEN lower(status) IN ('paused', 'idle') THEN COALESCE(updated_at, created_at)
+    ELSE NULL
+  END,
+  archived_at = CASE
+    WHEN lower(status) = 'archived' THEN COALESCE(updated_at, created_at)
+    ELSE NULL
+  END,
+  closed_at = CASE
+    WHEN lower(status) IN ('ended', 'terminated', 'closed') THEN COALESCE(updated_at, created_at)
+    ELSE NULL
+  END;
+
+ALTER TABLE session
+  ALTER COLUMN last_activity_at SET NOT NULL,
+  ALTER COLUMN last_activity_at SET DEFAULT now();
+
+CREATE INDEX idx_session_agent_user_status_activity
+  ON session (agent_id, user_account_id, status, last_activity_at DESC);
+

--- a/packages/control-plane/src/__tests__/chat-session-crud.test.ts
+++ b/packages/control-plane/src/__tests__/chat-session-crud.test.ts
@@ -78,6 +78,11 @@ function makeSession(overrides: Record<string, unknown> = {}) {
     total_tokens_in: 0,
     total_tokens_out: 0,
     total_cost_usd: 0,
+    last_activity_at: new Date("2026-03-09T00:00:00Z"),
+    last_resumed_at: new Date("2026-03-09T00:00:00Z"),
+    idle_at: null,
+    archived_at: null,
+    closed_at: null,
     created_at: new Date("2026-03-09T00:00:00Z"),
     updated_at: new Date("2026-03-09T00:00:00Z"),
     ...overrides,
@@ -122,6 +127,7 @@ function mockDb(
 
   const sessionMessageInserts: Array<Record<string, unknown>> = []
   const sessionInserts: Array<Record<string, unknown>> = []
+  const jobInserts: Array<Record<string, unknown>> = []
   const deleteFromCalls: string[] = []
 
   const selectFromFn = vi.fn().mockImplementation((table: string) => {
@@ -225,7 +231,10 @@ function mockDb(
     // job insert
     const executeTakeFirstOrThrow = vi.fn().mockResolvedValue(job)
     const returning = vi.fn().mockReturnValue({ executeTakeFirstOrThrow })
-    const values = vi.fn().mockReturnValue({ returning })
+    const values = vi.fn().mockImplementation((val: Record<string, unknown>) => {
+      jobInserts.push(val)
+      return { returning }
+    })
     return { values }
   })
 
@@ -252,7 +261,7 @@ function mockDb(
     deleteFrom: deleteFromFn,
   } as unknown as Kysely<Database>
 
-  return { db, sessionMessageInserts, sessionInserts, deleteFromCalls, deleteFromFn }
+  return { db, sessionMessageInserts, sessionInserts, jobInserts, deleteFromCalls, deleteFromFn }
 }
 
 /** Build a Fastify app with both chat + session routes registered. */
@@ -464,12 +473,12 @@ describe("Send message → stored and returned in history", () => {
 })
 
 // ---------------------------------------------------------------------------
-// 3. Delete session → removed, messages cleared, status ended
+// 3. Delete session → closed lifecycle state
 // ---------------------------------------------------------------------------
 
-describe("Delete session → messages cleared, status ended", () => {
-  it("DELETE /sessions/:id clears messages and sets status to ended", async () => {
-    const { db, deleteFromFn } = mockDb()
+describe("Delete session → closed lifecycle state", () => {
+  it("DELETE /sessions/:id closes the session", async () => {
+    const { db } = mockDb()
     const app = await buildApp(db)
 
     const res = await app.inject({
@@ -479,11 +488,8 @@ describe("Delete session → messages cleared, status ended", () => {
 
     expect(res.statusCode).toBe(200)
     expect(res.json().id).toBe(SESSION_ID)
-    expect(res.json().status).toBe("ended")
-    expect(res.json().action).toBe("cleared")
-
-    // Verify session_message rows were deleted
-    expect(deleteFromFn).toHaveBeenCalledWith("session_message")
+    expect(res.json().status).toBe("closed")
+    expect(res.json().action).toBe("closed")
 
     // Verify session status was updated
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -564,6 +570,7 @@ describe("Delete active session → activeSessionId cleared", () => {
     })
 
     const updateTableFn = vi.fn().mockImplementation(() => {
+      sessionDeleted = true
       const execute = vi.fn().mockResolvedValue(undefined)
       const whereFn: ReturnType<typeof vi.fn> = vi.fn()
       whereFn.mockReturnValue({ where: whereFn, execute })
@@ -595,7 +602,7 @@ describe("Delete active session → activeSessionId cleared", () => {
       url: `/sessions/${SESSION_ID}`,
     })
     expect(deleteRes.statusCode).toBe(200)
-    expect(deleteRes.json().status).toBe("ended")
+    expect(deleteRes.json().status).toBe("closed")
 
     // Post-condition: no active sessions remain
     const listAfter = await app.inject({
@@ -781,6 +788,29 @@ describe("Dashboard reflects session state changes", () => {
     expect(res.json().session_id).toBe(SESSION_ID)
     expect(res.json().status).toBe("SCHEDULED")
     expect(enqueueJob).toHaveBeenCalledWith("job-async-1")
+  })
+
+  it("links multiple chat jobs to the same session", async () => {
+    const { db, jobInserts } = mockDb()
+    const app = await buildApp(db)
+
+    const first = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/chat`,
+      payload: { text: "First message" },
+    })
+    expect(first.statusCode).toBe(202)
+
+    const second = await app.inject({
+      method: "POST",
+      url: `/agents/${AGENT_ID}/chat`,
+      payload: { text: "Second message", session_id: SESSION_ID },
+    })
+    expect(second.statusCode).toBe(202)
+
+    expect(jobInserts).toHaveLength(2)
+    expect(jobInserts[0]!.session_id).toBe(SESSION_ID)
+    expect(jobInserts[1]!.session_id).toBe(SESSION_ID)
   })
 })
 

--- a/packages/control-plane/src/__tests__/session-routes.test.ts
+++ b/packages/control-plane/src/__tests__/session-routes.test.ts
@@ -23,6 +23,11 @@ function makeSession(overrides: Record<string, unknown> = {}) {
     channel_id: "telegram:chat-42",
     status: "active",
     metadata: {},
+    last_activity_at: new Date(),
+    last_resumed_at: new Date(),
+    idle_at: null,
+    archived_at: null,
+    closed_at: null,
     created_at: new Date(),
     updated_at: new Date(),
     ...overrides,
@@ -181,6 +186,21 @@ describe("GET /agents/:id/sessions", () => {
 })
 
 describe("GET /sessions/:id/messages", () => {
+  it("returns the session record", async () => {
+    const db = mockDb()
+    const app = await buildApp(db)
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/sessions/aaaaaaaa-1111-2222-3333-444444444444`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body: { id: string; status: string } = res.json()
+    expect(body.id).toBe("aaaaaaaa-1111-2222-3333-444444444444")
+    expect(body.status).toBe("active")
+  })
+
   it("returns messages for a session", async () => {
     const db = mockDb({
       messages: [
@@ -218,7 +238,7 @@ describe("GET /sessions/:id/messages", () => {
 })
 
 describe("DELETE /sessions/:id", () => {
-  it("clears session messages and marks session as ended", async () => {
+  it("closes the session and marks it as closed", async () => {
     const db = mockDb()
     const app = await buildApp(db)
 
@@ -231,13 +251,9 @@ describe("DELETE /sessions/:id", () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const body = res.json()
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(body.status).toBe("ended")
+    expect(body.status).toBe("closed")
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(body.action).toBe("cleared")
-
-    // Should have deleted session messages
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(db.deleteFrom).toHaveBeenCalledWith("session_message")
+    expect(body.action).toBe("closed")
     // Should have updated session status
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(db.updateTable).toHaveBeenCalledWith("session")
@@ -253,5 +269,24 @@ describe("DELETE /sessions/:id", () => {
     })
 
     expect(res.statusCode).toBe(404)
+  })
+})
+
+describe("POST /sessions/:id/resume", () => {
+  it("resumes an idle session", async () => {
+    const db = mockDb({ session: makeSession({ status: "idle", idle_at: new Date() }) })
+    const app = await buildApp(db)
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/sessions/aaaaaaaa-1111-2222-3333-444444444444/resume`,
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body: { action: string; session: { status: string } } = res.json()
+    expect(body.action).toBe("resumed")
+    expect(body.session.status).toBe("active")
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(db.updateTable).toHaveBeenCalledWith("session")
   })
 })

--- a/packages/control-plane/src/channels/message-dispatch.ts
+++ b/packages/control-plane/src/channels/message-dispatch.ts
@@ -25,6 +25,7 @@ import {
   type ResolvedProviderModelContract,
   type SessionResolutionDiagnostics,
 } from "../chat/runtime-contract.js"
+import { resolveSessionRecord } from "../chat/session-record.js"
 import type { ChannelType, Database, RateLimit, TokenBudget } from "../db/types.js"
 import type { AgentEventEmitter } from "../observability/event-emitter.js"
 import type { AgentChannelService } from "./agent-channel-service.js"
@@ -214,7 +215,6 @@ export function createMessageDispatch(
     const channelId = `${channelType}:${chatId}`
 
     // Find or create a session for (agent_id, user_account_id, channel_id)
-    const session = await findOrCreateSession(db, agentId, routed.userAccountId, channelId)
     const source: SessionResolutionDiagnostics = {
       surface: "channel",
       channelType,
@@ -222,12 +222,18 @@ export function createMessageDispatch(
       chatId,
       messageId: routed.message.messageId,
     }
+    const session = await resolveSessionRecord(db, {
+      agentId,
+      userAccountId: routed.userAccountId,
+      source,
+    })
     const toolRefs = capabilityAssembler
       ? (await capabilityAssembler.resolveEffectiveTools(agentId)).map((tool) => tool.toolRef)
       : undefined
     const chatDiagnostics = buildChatDispatchDiagnostics({
       agentId,
       sessionId: session.id,
+      sessionStatus: session.status,
       source,
       providerModel: extractProviderModelDiagnostics(preflight),
       toolRefs,
@@ -469,41 +475,4 @@ export async function loadConversationHistory(
   }
 
   return chronological as Array<{ role: "user" | "assistant"; content: string }>
-}
-
-async function findOrCreateSession(
-  db: Kysely<Database>,
-  agentId: string,
-  userAccountId: string,
-  channelId?: string,
-): Promise<{ id: string }> {
-  // Try to find existing active session scoped by channel
-  let query = db
-    .selectFrom("session")
-    .select("id")
-    .where("agent_id", "=", agentId)
-    .where("user_account_id", "=", userAccountId)
-    .where("status", "=", "active")
-
-  if (channelId) {
-    query = query.where("channel_id", "=", channelId)
-  }
-
-  const existing = await query.executeTakeFirst()
-
-  if (existing) return existing
-
-  // Create a new session
-  const created = await db
-    .insertInto("session")
-    .values({
-      agent_id: agentId,
-      user_account_id: userAccountId,
-      channel_id: channelId ?? null,
-      status: "active",
-    })
-    .returning("id")
-    .executeTakeFirstOrThrow()
-
-  return created
 }

--- a/packages/control-plane/src/chat/runtime-contract.ts
+++ b/packages/control-plane/src/chat/runtime-contract.ts
@@ -107,6 +107,7 @@ export function resolveProviderModelContract(
 export function buildChatDispatchDiagnostics(params: {
   agentId: string
   sessionId: string
+  sessionStatus?: string
   source: SessionResolutionDiagnostics
   providerModel: ResolvedProviderModelContract
   toolRefs?: string[]
@@ -121,6 +122,10 @@ export function buildChatDispatchDiagnostics(params: {
       channelId: params.source.channelId,
       chatId: params.source.chatId,
       ...(params.source.messageId ? { messageId: params.source.messageId } : {}),
+    },
+    session: {
+      id: params.sessionId,
+      status: params.sessionStatus ?? "active",
     },
     providerModel: {
       requestedProvider: params.providerModel.requestedProvider,

--- a/packages/control-plane/src/chat/session-record.ts
+++ b/packages/control-plane/src/chat/session-record.ts
@@ -1,0 +1,373 @@
+import type { Kysely } from "kysely"
+
+import type { Database, Session } from "../db/types.js"
+import type { SessionResolutionDiagnostics } from "./runtime-contract.js"
+
+export type SessionLifecycleStatus = "active" | "idle" | "archived" | "closed"
+
+export class SessionResolutionError extends Error {
+  constructor(
+    readonly code: "not_found" | "closed",
+    message: string,
+  ) {
+    super(message)
+    this.name = "SessionResolutionError"
+  }
+}
+
+interface SessionLifecycleEvent {
+  source: SessionResolutionDiagnostics
+  at: string
+}
+
+function asLifecycleObject(
+  metadata: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  const lifecycle =
+    metadata?.lifecycle && typeof metadata.lifecycle === "object" && metadata.lifecycle !== null
+      ? { ...(metadata.lifecycle as Record<string, unknown>) }
+      : {}
+  return lifecycle
+}
+
+function buildLifecycleMetadata(params: {
+  existingMetadata: Record<string, unknown> | null | undefined
+  event: "create" | "resume" | "activity" | "idle" | "close"
+  source: SessionResolutionDiagnostics
+  at: Date
+}): Record<string, unknown> {
+  const base = { ...(params.existingMetadata ?? {}) }
+  const lifecycle = asLifecycleObject(base)
+  const eventPayload: SessionLifecycleEvent = {
+    source: params.source,
+    at: params.at.toISOString(),
+  }
+  const resumeCount = typeof lifecycle.resume_count === "number" ? lifecycle.resume_count : 0
+
+  if (params.event === "create") {
+    lifecycle.created = eventPayload
+    lifecycle.resume_count = 0
+  }
+  if (params.event === "resume") {
+    lifecycle.last_resumed = eventPayload
+    lifecycle.resume_count = resumeCount + 1
+  }
+  if (params.event === "activity") {
+    lifecycle.last_activity = eventPayload
+  }
+  if (params.event === "idle") {
+    lifecycle.last_idle = eventPayload
+  }
+  if (params.event === "close") {
+    lifecycle.closed = eventPayload
+  }
+
+  lifecycle.last_source = params.source
+  base.lifecycle = lifecycle
+  return base
+}
+
+function isReusableStatus(status: string): boolean {
+  if (!status) return true
+  return status === "active" || status === "idle" || status === "archived"
+}
+
+function applySessionPatch(session: Session, patch: Partial<Session>): Session {
+  return {
+    ...session,
+    ...patch,
+  }
+}
+
+async function activateSession(
+  db: Kysely<Database>,
+  session: Session,
+  source: SessionResolutionDiagnostics,
+): Promise<Session> {
+  if (session.status === "closed") {
+    throw new SessionResolutionError("closed", "Session is closed and cannot be resumed")
+  }
+
+  const now = new Date()
+  const resumed = session.status !== "active" || session.channel_id !== source.channelId
+  const metadata = buildLifecycleMetadata({
+    existingMetadata: session.metadata,
+    event: resumed ? "resume" : "activity",
+    source,
+    at: now,
+  })
+
+  await db
+    .updateTable("session")
+    .set({
+      status: "active",
+      channel_id: source.channelId,
+      metadata,
+      last_activity_at: now,
+      last_resumed_at: resumed ? now : (session.last_resumed_at ?? now),
+      idle_at: resumed ? null : session.idle_at,
+      archived_at: resumed ? null : session.archived_at,
+    })
+    .where("id", "=", session.id)
+    .execute()
+
+  return applySessionPatch(session, {
+    status: "active",
+    channel_id: source.channelId,
+    metadata,
+    last_activity_at: now,
+    last_resumed_at: resumed ? now : (session.last_resumed_at ?? now),
+    idle_at: resumed ? null : session.idle_at,
+    archived_at: resumed ? null : session.archived_at,
+  })
+}
+
+async function idleSiblingSessions(
+  db: Kysely<Database>,
+  params: {
+    agentId: string
+    userAccountId: string
+    keepSessionId: string
+    source: SessionResolutionDiagnostics
+  },
+): Promise<void> {
+  const activeSiblings = db
+    .selectFrom("session")
+    .selectAll()
+    .where("agent_id", "=", params.agentId)
+    .where("user_account_id", "=", params.userAccountId)
+    .where("status", "=", "active")
+
+  const siblingRows =
+    typeof activeSiblings.execute === "function"
+      ? await activeSiblings.execute()
+      : [await activeSiblings.executeTakeFirst()].filter((row): row is Session => Boolean(row))
+
+  const now = new Date()
+  for (const sibling of siblingRows) {
+    if (sibling.id === params.keepSessionId) continue
+    await db
+      .updateTable("session")
+      .set({
+        status: "idle",
+        metadata: buildLifecycleMetadata({
+          existingMetadata: sibling.metadata,
+          event: "idle",
+          source: params.source,
+          at: now,
+        }),
+        last_activity_at: now,
+        idle_at: now,
+      })
+      .where("id", "=", sibling.id)
+      .execute()
+  }
+}
+
+export async function ensureUserAccount(
+  db: Kysely<Database>,
+  userAccountId: string,
+  displayName?: string,
+): Promise<void> {
+  const existing = await db
+    .selectFrom("user_account")
+    .select("id")
+    .where("id", "=", userAccountId)
+    .executeTakeFirst()
+
+  if (existing) return
+
+  await db
+    .insertInto("user_account")
+    .values({
+      id: userAccountId,
+      display_name: displayName ?? null,
+      role: "operator",
+    })
+    .execute()
+}
+
+export async function resolveSessionRecord(
+  db: Kysely<Database>,
+  params: {
+    agentId: string
+    userAccountId: string
+    source: SessionResolutionDiagnostics
+    requestedSessionId?: string
+  },
+): Promise<Session> {
+  const { agentId, userAccountId, source, requestedSessionId } = params
+
+  if (requestedSessionId) {
+    const requested = await db
+      .selectFrom("session")
+      .selectAll()
+      .where("id", "=", requestedSessionId)
+      .where("agent_id", "=", agentId)
+      .where("user_account_id", "=", userAccountId)
+      .executeTakeFirst()
+
+    if (!requested) {
+      throw new SessionResolutionError("not_found", "Session not found")
+    }
+
+    const active = await activateSession(db, requested, source)
+    await idleSiblingSessions(db, {
+      agentId,
+      userAccountId,
+      keepSessionId: active.id,
+      source,
+    })
+    return active
+  }
+
+  const sameChannel = await db
+    .selectFrom("session")
+    .selectAll()
+    .where("agent_id", "=", agentId)
+    .where("user_account_id", "=", userAccountId)
+    .where("channel_id", "=", source.channelId)
+    .executeTakeFirst()
+
+  if (sameChannel && isReusableStatus(sameChannel.status)) {
+    const active = await activateSession(db, sameChannel, source)
+    await idleSiblingSessions(db, {
+      agentId,
+      userAccountId,
+      keepSessionId: active.id,
+      source,
+    })
+    return active
+  }
+
+  const anyReusable = await db
+    .selectFrom("session")
+    .selectAll()
+    .where("agent_id", "=", agentId)
+    .where("user_account_id", "=", userAccountId)
+    .executeTakeFirst()
+
+  if (anyReusable && isReusableStatus(anyReusable.status)) {
+    const active = await activateSession(db, anyReusable, source)
+    await idleSiblingSessions(db, {
+      agentId,
+      userAccountId,
+      keepSessionId: active.id,
+      source,
+    })
+    return active
+  }
+
+  const now = new Date()
+  const metadata = buildLifecycleMetadata({
+    existingMetadata: null,
+    event: "create",
+    source,
+    at: now,
+  })
+  const created = await db
+    .insertInto("session")
+    .values({
+      agent_id: agentId,
+      user_account_id: userAccountId,
+      channel_id: source.channelId,
+      status: "active",
+      metadata,
+      last_activity_at: now,
+      last_resumed_at: now,
+    })
+    .returning([
+      "id",
+      "agent_id",
+      "user_account_id",
+      "channel_id",
+      "status",
+      "metadata",
+      "total_tokens_in",
+      "total_tokens_out",
+      "total_cost_usd",
+      "last_activity_at",
+      "last_resumed_at",
+      "idle_at",
+      "archived_at",
+      "closed_at",
+      "created_at",
+      "updated_at",
+    ])
+    .executeTakeFirstOrThrow()
+
+  await idleSiblingSessions(db, {
+    agentId,
+    userAccountId,
+    keepSessionId: created.id,
+    source,
+  })
+
+  return created
+}
+
+export async function getSessionRecord(
+  db: Kysely<Database>,
+  sessionId: string,
+): Promise<Session | undefined> {
+  return db.selectFrom("session").selectAll().where("id", "=", sessionId).executeTakeFirst()
+}
+
+export async function closeSessionRecord(
+  db: Kysely<Database>,
+  params: {
+    sessionId: string
+    source: SessionResolutionDiagnostics
+  },
+): Promise<Session | undefined> {
+  const existing = await getSessionRecord(db, params.sessionId)
+  if (!existing) return undefined
+
+  const now = new Date()
+  const metadata = buildLifecycleMetadata({
+    existingMetadata: existing.metadata,
+    event: "close",
+    source: params.source,
+    at: now,
+  })
+
+  await db
+    .updateTable("session")
+    .set({
+      status: "closed",
+      metadata,
+      last_activity_at: now,
+      closed_at: now,
+    })
+    .where("id", "=", params.sessionId)
+    .execute()
+
+  return applySessionPatch(existing, {
+    status: "closed",
+    metadata,
+    last_activity_at: now,
+    closed_at: now,
+  })
+}
+
+export async function resumeSessionRecord(
+  db: Kysely<Database>,
+  params: {
+    sessionId: string
+    source: SessionResolutionDiagnostics
+  },
+): Promise<Session> {
+  const existing = await getSessionRecord(db, params.sessionId)
+  if (!existing) {
+    throw new SessionResolutionError("not_found", "Session not found")
+  }
+
+  const active = await activateSession(db, existing, params.source)
+  await idleSiblingSessions(db, {
+    agentId: active.agent_id,
+    userAccountId: active.user_account_id,
+    keepSessionId: active.id,
+    source: params.source,
+  })
+  return active
+}

--- a/packages/control-plane/src/db/types.ts
+++ b/packages/control-plane/src/db/types.ts
@@ -159,6 +159,11 @@ export interface SessionTable {
   total_tokens_in: ColumnType<number, number | undefined, number>
   total_tokens_out: ColumnType<number, number | undefined, number>
   total_cost_usd: ColumnType<string, string | number | undefined, string | number>
+  last_activity_at: ColumnType<Date, Date | undefined, Date>
+  last_resumed_at: Date | null
+  idle_at: Date | null
+  archived_at: Date | null
+  closed_at: Date | null
   created_at: ColumnType<Date, Date | undefined, never>
   updated_at: ColumnType<Date, Date | undefined, never>
 }

--- a/packages/control-plane/src/routes/chat.ts
+++ b/packages/control-plane/src/routes/chat.ts
@@ -25,6 +25,11 @@ import {
   type ResolvedProviderModelContract,
   type SessionResolutionDiagnostics,
 } from "../chat/runtime-contract.js"
+import {
+  ensureUserAccount,
+  resolveSessionRecord,
+  SessionResolutionError,
+} from "../chat/session-record.js"
 import type { Database, RateLimit, TokenBudget } from "../db/types.js"
 import {
   type AuthMiddlewareOptions,
@@ -198,18 +203,29 @@ export function chatRoutes(deps: ChatRouteDeps) {
 
         // Find or create session
         const channelId = "rest:api"
-        const session = await findOrCreateSession(
-          db,
-          agentId,
-          userAccountId,
-          channelId,
-          requestedSessionId,
-        )
         const source: SessionResolutionDiagnostics = {
           surface: "ui",
           channelType: "rest",
           channelId,
           chatId: "rest:api",
+        }
+        let session
+        try {
+          session = await resolveSessionRecord(db, {
+            agentId,
+            userAccountId,
+            source,
+            requestedSessionId,
+          })
+        } catch (error) {
+          if (error instanceof SessionResolutionError) {
+            const statusCode = error.code === "closed" ? 409 : 404
+            return reply.status(statusCode).send({
+              error: error.code,
+              message: error.message,
+            })
+          }
+          throw error
         }
         const toolRefs = capabilityAssembler
           ? (await capabilityAssembler.resolveEffectiveTools(agentId)).map((tool) => tool.toolRef)
@@ -217,6 +233,7 @@ export function chatRoutes(deps: ChatRouteDeps) {
         const chatDiagnostics = buildChatDispatchDiagnostics({
           agentId,
           sessionId: session.id,
+          sessionStatus: session.status,
           source,
           providerModel: extractProviderModelDiagnostics(preflight),
           toolRefs,
@@ -479,74 +496,6 @@ export function chatRoutes(deps: ChatRouteDeps) {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-async function ensureUserAccount(
-  db: Kysely<Database>,
-  userAccountId: string,
-  displayName?: string,
-): Promise<void> {
-  const existing = await db
-    .selectFrom("user_account")
-    .select("id")
-    .where("id", "=", userAccountId)
-    .executeTakeFirst()
-
-  if (existing) return
-
-  await db
-    .insertInto("user_account")
-    .values({
-      id: userAccountId,
-      display_name: displayName ?? null,
-      role: "operator",
-    })
-    .execute()
-}
-
-async function findOrCreateSession(
-  db: Kysely<Database>,
-  agentId: string,
-  userAccountId: string,
-  channelId: string,
-  requestedSessionId?: string,
-): Promise<{ id: string }> {
-  // If a specific session is requested, verify and use it
-  if (requestedSessionId) {
-    const existing = await db
-      .selectFrom("session")
-      .select("id")
-      .where("id", "=", requestedSessionId)
-      .where("agent_id", "=", agentId)
-      .where("status", "=", "active")
-      .executeTakeFirst()
-
-    if (existing) return existing
-  }
-
-  // Try to find existing active session
-  const existing = await db
-    .selectFrom("session")
-    .select("id")
-    .where("agent_id", "=", agentId)
-    .where("user_account_id", "=", userAccountId)
-    .where("channel_id", "=", channelId)
-    .where("status", "=", "active")
-    .executeTakeFirst()
-
-  if (existing) return existing
-
-  // Create new session
-  return db
-    .insertInto("session")
-    .values({
-      agent_id: agentId,
-      user_account_id: userAccountId,
-      channel_id: channelId,
-      status: "active",
-    })
-    .returning("id")
-    .executeTakeFirstOrThrow()
-}
 
 interface WaitForJobResult {
   status: string

--- a/packages/control-plane/src/routes/sessions.ts
+++ b/packages/control-plane/src/routes/sessions.ts
@@ -10,6 +10,12 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
 import type { Kysely } from "kysely"
 
 import type { SessionService } from "../auth/session-service.js"
+import {
+  closeSessionRecord,
+  getSessionRecord,
+  resumeSessionRecord,
+  SessionResolutionError,
+} from "../chat/session-record.js"
 import type { Database } from "../db/types.js"
 import {
   type AuthMiddlewareOptions,
@@ -113,6 +119,32 @@ export function sessionRoutes(deps: SessionRouteDeps) {
     )
 
     // -----------------------------------------------------------------
+    // GET /sessions/:id — Fetch a single session record
+    // -----------------------------------------------------------------
+    app.get<{ Params: SessionParams }>(
+      "/sessions/:id",
+      {
+        preHandler: [requireAuth],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              id: { type: "string", format: "uuid" },
+            },
+            required: ["id"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: SessionParams }>, reply: FastifyReply) => {
+        const session = await getSessionRecord(db, request.params.id)
+        if (!session) {
+          return reply.status(404).send({ error: "not_found", message: "Session not found" })
+        }
+        return reply.status(200).send(session)
+      },
+    )
+
+    // -----------------------------------------------------------------
     // GET /sessions/:id/messages — Get conversation history
     // -----------------------------------------------------------------
     app.get<{ Params: SessionParams; Querystring: ListMessagesQuery }>(
@@ -168,7 +200,48 @@ export function sessionRoutes(deps: SessionRouteDeps) {
     )
 
     // -----------------------------------------------------------------
-    // DELETE /sessions/:id — Clear / reset a session
+    // POST /sessions/:id/resume — Resume a reusable session
+    // -----------------------------------------------------------------
+    app.post<{ Params: SessionParams }>(
+      "/sessions/:id/resume",
+      {
+        preHandler: [requireAuth],
+        schema: {
+          params: {
+            type: "object",
+            properties: {
+              id: { type: "string", format: "uuid" },
+            },
+            required: ["id"],
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Params: SessionParams }>, reply: FastifyReply) => {
+        try {
+          const session = await resumeSessionRecord(db, {
+            sessionId: request.params.id,
+            source: {
+              surface: "ui",
+              channelType: "rest",
+              channelId: "rest:api",
+              chatId: "rest:api",
+            },
+          })
+          return reply.status(200).send({ session, action: "resumed" })
+        } catch (error) {
+          if (error instanceof SessionResolutionError) {
+            return reply.status(error.code === "closed" ? 409 : 404).send({
+              error: error.code,
+              message: error.message,
+            })
+          }
+          throw error
+        }
+      },
+    )
+
+    // -----------------------------------------------------------------
+    // DELETE /sessions/:id — Close a session
     // -----------------------------------------------------------------
     app.delete<{ Params: SessionParams }>(
       "/sessions/:id",
@@ -185,28 +258,20 @@ export function sessionRoutes(deps: SessionRouteDeps) {
         },
       },
       async (request: FastifyRequest<{ Params: SessionParams }>, reply: FastifyReply) => {
-        const { id: sessionId } = request.params
-
-        const session = await db
-          .selectFrom("session")
-          .select("id")
-          .where("id", "=", sessionId)
-          .executeTakeFirst()
-
+        const session = await closeSessionRecord(db, {
+          sessionId: request.params.id,
+          source: {
+            surface: "ui",
+            channelType: "rest",
+            channelId: "rest:api",
+            chatId: "rest:api",
+          },
+        })
         if (!session) {
           return reply.status(404).send({ error: "not_found", message: "Session not found" })
         }
 
-        // Clear all messages and mark session as ended
-        await db.deleteFrom("session_message").where("session_id", "=", sessionId).execute()
-
-        await db
-          .updateTable("session")
-          .set({ status: "ended" })
-          .where("id", "=", sessionId)
-          .execute()
-
-        return reply.status(200).send({ id: sessionId, status: "ended", action: "cleared" })
+        return reply.status(200).send({ id: session.id, status: "closed", action: "closed" })
       },
     )
   }

--- a/packages/dashboard/fixtures/api-responses/session-delete.json
+++ b/packages/dashboard/fixtures/api-responses/session-delete.json
@@ -1,5 +1,5 @@
 {
   "id": "sess-001",
-  "status": "ended",
-  "action": "cleared"
+  "status": "closed",
+  "action": "closed"
 }

--- a/packages/dashboard/fixtures/api-responses/sessions-list.json
+++ b/packages/dashboard/fixtures/api-responses/sessions-list.json
@@ -6,6 +6,11 @@
       "user_account_id": "u1a2b3c4-d5e6-7890-abcd-ef1234567890",
       "channel_id": null,
       "status": "active",
+      "last_activity_at": "2025-11-01T10:05:00.000Z",
+      "last_resumed_at": "2025-11-01T10:05:00.000Z",
+      "idle_at": null,
+      "archived_at": null,
+      "closed_at": null,
       "created_at": "2025-11-01T10:00:00.000Z",
       "updated_at": "2025-11-01T10:05:00.000Z"
     },
@@ -14,7 +19,12 @@
       "agent_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
       "user_account_id": null,
       "channel_id": "ch-tg-001",
-      "status": "ended",
+      "status": "closed",
+      "last_activity_at": "2025-10-20T09:30:00.000Z",
+      "last_resumed_at": "2025-10-20T08:00:00.000Z",
+      "idle_at": null,
+      "archived_at": null,
+      "closed_at": "2025-10-20T09:30:00.000Z",
       "created_at": "2025-10-20T08:00:00.000Z",
       "updated_at": "2025-10-20T09:30:00.000Z"
     }

--- a/packages/dashboard/src/__tests__/chat.test.ts
+++ b/packages/dashboard/src/__tests__/chat.test.ts
@@ -47,6 +47,11 @@ describe("Chat & Session API Client", () => {
             user_account_id: "user-1",
             channel_id: "rest:api",
             status: "active",
+            last_activity_at: "2026-03-01T01:00:00Z",
+            last_resumed_at: "2026-03-01T01:00:00Z",
+            idle_at: null,
+            archived_at: null,
+            closed_at: null,
             created_at: "2026-03-01T00:00:00Z",
             updated_at: "2026-03-01T01:00:00Z",
           },
@@ -307,12 +312,12 @@ describe("Chat & Session API Client", () => {
 
   describe("deleteSession", () => {
     it("deletes a session", async () => {
-      mockFetchResponse({ id: "sess-1", status: "ended", action: "cleared" })
+      mockFetchResponse({ id: "sess-1", status: "closed", action: "closed" })
 
       const result = await deleteSession("sess-1")
 
       expect(result.id).toBe("sess-1")
-      expect(result.status).toBe("ended")
+      expect(result.status).toBe("closed")
 
       const [url, opts] = vi.mocked(fetch).mock.calls[0]!
       expect(url).toBe(`${API_BASE}/sessions/sess-1`)
@@ -344,6 +349,11 @@ describe("Chat schemas", () => {
         user_account_id: "user-1",
         channel_id: "rest:api",
         status: "active",
+        last_activity_at: "2026-03-01T01:00:00Z",
+        last_resumed_at: "2026-03-01T01:00:00Z",
+        idle_at: null,
+        archived_at: null,
+        closed_at: null,
         created_at: "2026-03-01T00:00:00Z",
         updated_at: "2026-03-01T01:00:00Z",
       })
@@ -356,6 +366,7 @@ describe("Chat schemas", () => {
         id: "sess-1",
         agent_id: "agent-1",
         status: "active",
+        last_activity_at: "2026-03-01T01:00:00Z",
         created_at: "2026-03-01T00:00:00Z",
         updated_at: "2026-03-01T01:00:00Z",
       })
@@ -515,6 +526,7 @@ describe("Chat schemas", () => {
             id: "s1",
             agent_id: "a1",
             status: "active",
+            last_activity_at: "2026-03-01T00:00:00Z",
             created_at: "2026-03-01T00:00:00Z",
             updated_at: "2026-03-01T00:00:00Z",
           },
@@ -547,10 +559,10 @@ describe("Chat schemas", () => {
     it("parses delete response", () => {
       const result = SessionClearResponseSchema.parse({
         id: "sess-1",
-        status: "ended",
-        action: "cleared",
+        status: "closed",
+        action: "closed",
       })
-      expect(result.status).toBe("ended")
+      expect(result.status).toBe("closed")
     })
 
     it("rejects wrong status", () => {

--- a/packages/dashboard/src/__tests__/schema-contract.test.ts
+++ b/packages/dashboard/src/__tests__/schema-contract.test.ts
@@ -484,7 +484,7 @@ describe("API-Dashboard contract tests", () => {
     it("parses the fixture successfully", () => {
       const result = SessionClearResponseSchema.parse(sessionDeleteFixture)
       expect(result.id).toBe("sess-001")
-      expect(result.status).toBe("ended")
+      expect(result.status).toBe("closed")
     })
 
     it("does not silently drop fields", () => {

--- a/packages/dashboard/src/app/api/copilotkit/route.ts
+++ b/packages/dashboard/src/app/api/copilotkit/route.ts
@@ -58,13 +58,17 @@ class CortexChatAdapter implements CopilotServiceAdapter {
 
     // Send message to our control-plane backend
     const sendUrl = `${CONTROL_PLANE_URL}/agents/${this.agentId}/chat?wait=false`
+    const requestedSessionId = request.threadId ?? this.authHeaders["x-session-id"]
     const sendRes = await fetch(sendUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         ...this.authHeaders,
       },
-      body: JSON.stringify({ text: textContent }),
+      body: JSON.stringify({
+        text: textContent,
+        ...(requestedSessionId ? { session_id: requestedSessionId } : {}),
+      }),
     })
 
     if (!sendRes.ok) {

--- a/packages/dashboard/src/components/agents/chat-panel.tsx
+++ b/packages/dashboard/src/components/agents/chat-panel.tsx
@@ -8,7 +8,7 @@ import { useToast } from "@/components/layout/toast"
 import { useApiQuery } from "@/hooks/use-api"
 import type { ChatMessage } from "@/hooks/use-chat-api"
 import { useChatApi } from "@/hooks/use-chat-api"
-import { clearSession, listAgentSessions, type Session } from "@/lib/api-client"
+import { clearSession, listAgentSessions, resumeSession, type Session } from "@/lib/api-client"
 import type { ChatMessageStatus } from "@/lib/schemas/chat"
 
 // ---------------------------------------------------------------------------
@@ -47,10 +47,18 @@ export function ChatPanel({ agentId }: ChatPanelProps): React.JSX.Element {
     setActiveSessionId(null)
   }, [])
 
-  const handleSelectSession = useCallback((id: string) => {
-    setActiveSessionId(id)
-    setShowSessions(false)
-  }, [])
+  const handleSelectSession = useCallback(
+    (id: string) => {
+      void resumeSession(id)
+        .catch(() => undefined)
+        .finally(() => {
+          setActiveSessionId(id)
+          setShowSessions(false)
+          void refetchSessions()
+        })
+    },
+    [refetchSessions],
+  )
 
   const handleSessionCreated = useCallback(
     (sessionId: string) => {
@@ -68,10 +76,10 @@ export function ChatPanel({ agentId }: ChatPanelProps): React.JSX.Element {
         if (activeSessionId === sessionId) {
           setActiveSessionId(null)
         }
-        addToast("Session cleared", "success")
+        addToast("Session closed", "success")
         void refetchSessions()
       } catch (err) {
-        const msg = err instanceof Error ? err.message : "Failed to clear session"
+        const msg = err instanceof Error ? err.message : "Failed to close session"
         setClearError(msg)
         addToast(msg, "error")
       }
@@ -180,6 +188,16 @@ function formatSessionTime(iso: string): string {
   })
 }
 
+function describeSessionStatus(session: Session): string {
+  if (session.status === "closed" && session.closed_at) {
+    return `Closed: ${formatSessionTime(session.closed_at)}`
+  }
+  if (session.status === "idle" && session.idle_at) {
+    return `Idle since: ${formatSessionTime(session.idle_at)}`
+  }
+  return `Last active: ${formatSessionTime(session.last_activity_at)}`
+}
+
 function SessionList({
   sessions,
   activeSessionId,
@@ -232,11 +250,18 @@ function SessionList({
               <div className="flex min-w-0 items-center gap-2">
                 <span
                   className={`inline-block size-2 shrink-0 rounded-full ${
-                    session.status === "active" ? "bg-emerald-500" : "bg-slate-400"
+                    session.status === "active"
+                      ? "bg-emerald-500"
+                      : session.status === "idle"
+                        ? "bg-amber-500"
+                        : "bg-slate-400"
                   }`}
                 />
                 <span className="text-xs font-semibold text-slate-700 dark:text-slate-200">
                   Session {sessions.length - index}
+                </span>
+                <span className="rounded-md bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:bg-slate-800 dark:text-slate-300">
+                  {session.status}
                 </span>
                 {isCurrent && (
                   <span className="rounded-md bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
@@ -249,7 +274,7 @@ function SessionList({
               </span>
               <div className="mt-0.5 flex flex-wrap items-center gap-x-3 text-[10px] text-slate-400">
                 <span>Created: {formatSessionTime(session.created_at)}</span>
-                <span>Last active: {formatSessionTime(session.updated_at)}</span>
+                <span>{describeSessionStatus(session)}</span>
               </div>
             </button>
             {confirmClearId === session.id ? (
@@ -274,8 +299,8 @@ function SessionList({
               <button
                 onClick={() => setConfirmClearId(session.id)}
                 className="shrink-0 rounded p-1 text-slate-400 transition-colors hover:text-amber-500"
-                title="Clear session history"
-                aria-label="Clear session history"
+                title="Close session"
+                aria-label="Close session"
               >
                 <span className="material-symbols-outlined text-sm">restart_alt</span>
               </button>

--- a/packages/dashboard/src/components/agents/copilot-chat-panel.tsx
+++ b/packages/dashboard/src/components/agents/copilot-chat-panel.tsx
@@ -9,7 +9,13 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { QuarantineBanner } from "@/components/agents/quarantine-banner"
 import { useToast } from "@/components/layout/toast"
 import { useApiQuery } from "@/hooks/use-api"
-import { clearSession, getSessionMessages, listAgentSessions, type Session } from "@/lib/api-client"
+import {
+  clearSession,
+  getSessionMessages,
+  listAgentSessions,
+  resumeSession,
+  type Session,
+} from "@/lib/api-client"
 import { getSessionStorageItem } from "@/lib/browser-storage"
 
 // ---------------------------------------------------------------------------
@@ -47,10 +53,18 @@ export function CopilotChatPanel({ agentId }: CopilotChatPanelProps): React.JSX.
     setActiveSessionId(null)
   }, [])
 
-  const handleSelectSession = useCallback((id: string) => {
-    setActiveSessionId(id)
-    setShowSessions(false)
-  }, [])
+  const handleSelectSession = useCallback(
+    (id: string) => {
+      void resumeSession(id)
+        .catch(() => undefined)
+        .finally(() => {
+          setActiveSessionId(id)
+          setShowSessions(false)
+          void refetchSessions()
+        })
+    },
+    [refetchSessions],
+  )
 
   const handleClearSession = useCallback(
     async (sessionId: string) => {
@@ -60,10 +74,10 @@ export function CopilotChatPanel({ agentId }: CopilotChatPanelProps): React.JSX.
         if (activeSessionId === sessionId) {
           setActiveSessionId(null)
         }
-        addToast("Session cleared", "success")
+        addToast("Session closed", "success")
         void refetchSessions()
       } catch (err) {
-        const msg = err instanceof Error ? err.message : "Failed to clear session"
+        const msg = err instanceof Error ? err.message : "Failed to close session"
         setClearError(msg)
         addToast(msg, "error")
       }

--- a/packages/dashboard/src/lib/api-client.ts
+++ b/packages/dashboard/src/lib/api-client.ts
@@ -1131,6 +1131,8 @@ import {
   MessageListResponseSchema,
   SessionClearResponseSchema,
   SessionListResponseSchema,
+  SessionResumeResponseSchema,
+  SessionSchema,
 } from "./schemas/chat"
 
 export type { ChatResponse, Session, SessionMessage } from "./schemas/chat"
@@ -1167,6 +1169,21 @@ export async function getSessionMessages(
   })
 }
 
+export async function getSession(sessionId: string): Promise<import("./schemas/chat").Session> {
+  return apiFetch(`/sessions/${sessionId}`, {
+    schema: SessionSchema,
+  })
+}
+
+export async function resumeSession(
+  sessionId: string,
+): Promise<{ session: import("./schemas/chat").Session; action: "resumed" }> {
+  return apiFetch(`/sessions/${sessionId}/resume`, {
+    method: "POST",
+    schema: SessionResumeResponseSchema,
+  })
+}
+
 export async function sendChatMessage(
   agentId: string,
   body: { text: string; session_id?: string },
@@ -1186,7 +1203,7 @@ export async function sendChatMessage(
 
 export async function clearSession(
   sessionId: string,
-): Promise<{ id: string; status: "ended"; action: "cleared" }> {
+): Promise<{ id: string; status: "closed"; action: "closed" }> {
   return apiFetch(`/sessions/${sessionId}`, {
     method: "DELETE",
     schema: SessionClearResponseSchema,

--- a/packages/dashboard/src/lib/schemas/chat.ts
+++ b/packages/dashboard/src/lib/schemas/chat.ts
@@ -11,6 +11,11 @@ export const SessionSchema = z.object({
   channel_id: z.string().nullable().optional(),
   status: z.string(),
   metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+  last_activity_at: z.string(),
+  last_resumed_at: z.string().nullable().optional(),
+  idle_at: z.string().nullable().optional(),
+  archived_at: z.string().nullable().optional(),
+  closed_at: z.string().nullable().optional(),
   created_at: z.string(),
   updated_at: z.string(),
 })
@@ -87,9 +92,14 @@ export type ChatResponse = z.infer<typeof ChatResponseSchema>
 
 export const SessionClearResponseSchema = z.object({
   id: z.string(),
-  status: z.literal("ended"),
-  action: z.literal("cleared"),
+  status: z.literal("closed"),
+  action: z.literal("closed"),
 })
 
 // Backward-compatible alias (deprecated name)
 export const SessionDeleteResponseSchema = SessionClearResponseSchema
+
+export const SessionResumeResponseSchema = z.object({
+  session: SessionSchema,
+  action: z.literal("resumed"),
+})


### PR DESCRIPTION
## Summary
- add a first-class session lifecycle record with persisted activity/resume/idle/close metadata
- unify REST chat and inbound channel dispatch on shared session resolution so related jobs reuse the same session
- expose session fetch/resume contracts and update dashboard/Copilot chat flows to reuse and surface session identity

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build

Closes #771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session resume capability—users can now resume paused sessions from the session list.
  * Added individual session details retrieval.
  * Enhanced session lifecycle tracking with timestamps for activity and state transitions.

* **Improvements**
  * Redesigned session status display with clearer state indicators (Active, Idle, Closed).
  * Updated session action terminology for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->